### PR TITLE
fix(feedback): riffrec records only its own tab

### DIFF
--- a/app/frontend/components/feedback_button.tsx
+++ b/app/frontend/components/feedback_button.tsx
@@ -13,7 +13,7 @@ export function FeedbackButton() {
       consentDescription="Records this tab’s screen, your voice, clicks, and console/network signals into a zip that downloads to your machine. Nothing is uploaded."
       consentLabel="I understand what's being recorded"
       onSessionComplete={(result) =>
-        console.info('riffrec session saved:', result.filesPresent.join(', '))
+        console.info('riffrec session saved:', result?.filesPresent.join(', ') ?? '(no files)')
       }
     />
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "riffrec": "^2.0.0",
+        "riffrec": "git+https://github.com/kieranklaassen/riffrec.git#9d3e2b5c62694049bcefec9370eaa9b30f41a60e",
         "shiki": "^4.2.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
@@ -4346,8 +4346,8 @@
     },
     "node_modules/riffrec": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/riffrec/-/riffrec-2.0.0.tgz",
-      "integrity": "sha512-Q6ntpWUukQsZn5h4QWyuJ3x7LdDCDT/0AGIWzkVTaMzX4q6N5YjjTs6ix1fJY9lUbs6prSbKFKvW9Tqd95BrvQ==",
+      "resolved": "git+ssh://git@github.com/kieranklaassen/riffrec.git#9d3e2b5c62694049bcefec9370eaa9b30f41a60e",
+      "integrity": "sha512-+uJ6+DZcpYq91eIwrIaeWQo4sjD36Tfx+bnuOOdfIELZ3IDFJHIXXkaRTQbqZ4NMvyc0Qst6gCXhgjRXiSHYvg==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "riffrec": "^2.0.0",
+    "riffrec": "git+https://github.com/kieranklaassen/riffrec.git#9d3e2b5c62694049bcefec9370eaa9b30f41a60e",
     "shiki": "^4.2.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
Riffrec from npm let the picker offer full screens and other windows. This pins `riffrec` to the same fork commit cora uses, whose `getDisplayMedia` defaults lock capture to the app's own tab:

- `displaySurface: "browser"` + `preferCurrentTab: true` — current tab preselected
- `monitorTypeSurfaces: "exclude"` — full-screen capture not offered
- `surfaceSwitching: "exclude"`, `systemAudio: "exclude"`

Also null-guards `onSessionComplete` per the pinned types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)