### PR TITLE
feat: set your display name — session-stored, random names become guest mode

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@ class CommentsController < InertiaController
     document = Document.find_by!(slug: params[:slug])
     Comment.post!(
       document:,
-      author_name: params[:author_name].presence || "Anonymous",
+      author_name: preferred_name(params[:author_name].presence || "Anonymous"),
       author_kind: "human",
       body: params[:body],
       anchor_text: params[:anchor_text].presence
@@ -22,7 +22,7 @@ class CommentsController < InertiaController
     document = comment.document
     Activity.log!(
       document:,
-      actor_name: params[:by].presence || "Someone",
+      actor_name: preferred_name(params[:by].presence || "Someone"),
       actor_kind: "human",
       action: "resolved_comment",
       detail: comment.body.truncate(80)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@ class CommentsController < InertiaController
     document = Document.find_by!(slug: params[:slug])
     Comment.post!(
       document:,
-      author_name: preferred_name(params[:author_name].presence || "Anonymous"),
+      author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
       author_kind: "human",
       body: params[:body],
       anchor_text: params[:anchor_text].presence
@@ -22,7 +22,7 @@ class CommentsController < InertiaController
     document = comment.document
     Activity.log!(
       document:,
-      actor_name: preferred_name(params[:by].presence || "Someone"),
+      actor_name: preferred_name(params[:by], fallback: "Someone"),
       actor_kind: "human",
       action: "resolved_comment",
       detail: comment.body.truncate(80)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -57,7 +57,7 @@ class DocumentsController < InertiaController
       title: params[:title].presence || "Untitled",
       seed_markdown: params[:markdown].presence || Document::DEFAULT_SEED,
       owner_token: owner_token,
-      owner_name: Document.normalize_owner_name(preferred_name(params[:name])),
+      owner_name: Document.normalize_owner_name(preferred_name(params[:name], fallback: nil)),
       claimed_at: Time.current
     )
     remember_recent(document)
@@ -68,7 +68,7 @@ class DocumentsController < InertiaController
   # prefetchers and unfurlers can't claim. First claim wins atomically.
   def claim
     document = Document.find_by!(slug: params[:slug])
-    document.claim!(token: owner_token, name: preferred_name(params[:name]))
+    document.claim!(token: owner_token, name: preferred_name(params[:name], fallback: nil))
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue Document::UnclaimableError
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other,

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -57,7 +57,7 @@ class DocumentsController < InertiaController
       title: params[:title].presence || "Untitled",
       seed_markdown: params[:markdown].presence || Document::DEFAULT_SEED,
       owner_token: owner_token,
-      owner_name: Document.normalize_owner_name(params[:name]),
+      owner_name: Document.normalize_owner_name(preferred_name(params[:name])),
       claimed_at: Time.current
     )
     remember_recent(document)
@@ -68,7 +68,7 @@ class DocumentsController < InertiaController
   # prefetchers and unfurlers can't claim. First claim wins atomically.
   def claim
     document = Document.find_by!(slug: params[:slug])
-    document.claim!(token: owner_token, name: params[:name])
+    document.claim!(token: owner_token, name: preferred_name(params[:name]))
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue Document::UnclaimableError
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other,

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -1,0 +1,16 @@
+class IdentitiesController < InertiaController
+  # Set (or clear) the viewer's display name. Stored in the session — the
+  # browser-stack CSRF protection means a drive-by POST can't rename you.
+  # Blank means "go back to guest": delete the key entirely, never store a
+  # fallback like "Anonymous" (that would break the return-to-guest flow).
+  def update
+    name = Document.normalize_display_name(params[:name])
+    if name
+      session[:display_name] = name
+    else
+      session.delete(:display_name)
+    end
+
+    redirect_back fallback_location: root_path, status: :see_other
+  end
+end

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -4,7 +4,9 @@ class IdentitiesController < InertiaController
   # Blank means "go back to guest": delete the key entirely, never store a
   # fallback like "Anonymous" (that would break the return-to-guest flow).
   def update
-    name = Document.normalize_display_name(params[:name])
+    # Non-string params (name[x]=1) must clear, not stringify into garbage.
+    raw = params[:name].is_a?(String) ? params[:name] : nil
+    name = Document.normalize_display_name(raw)
     if name
       session[:display_name] = name
     else

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -27,8 +27,10 @@ class InertiaController < ApplicationController
 
   # Session name wins over client-posted names on every attribution write —
   # a stale tab can't sign your old guest name once you've introduced
-  # yourself. Guests keep the client-posted fallback.
-  def preferred_name(fallback)
-    session[:display_name].presence || fallback
+  # yourself. Guests keep the client-posted value, then the fallback.
+  # Non-string params (name[x]=1 produces ActionController::Parameters) are
+  # treated as absent rather than stringified into garbage attribution.
+  def preferred_name(raw, fallback:)
+    session[:display_name].presence || (raw.presence if raw.is_a?(String)) || fallback
   end
 end

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -19,5 +19,16 @@ class InertiaController < ApplicationController
 
   # Share data with all Inertia responses
   # see https://inertia-rails.dev/guide/shared-data
-  #   inertia_share user: -> { Current.user&.as_json(only: [:id, :name, :email]) }
+  # The viewer's chosen display name lives in the session; no name set means
+  # guest mode (the client falls back to its random localStorage identity).
+  inertia_share viewer: -> { { name: session[:display_name], guest: session[:display_name].blank? } }
+
+  private
+
+  # Session name wins over client-posted names on every attribution write —
+  # a stale tab can't sign your old guest name once you've introduced
+  # yourself. Guests keep the client-posted fallback.
+  def preferred_name(fallback)
+    session[:display_name].presence || fallback
+  end
 end

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -2,7 +2,7 @@ class SuggestionsController < InertiaController
   before_action :set_suggestion
 
   def accept
-    @suggestion.accept!(by: params[:by].presence || "human")
+    @suggestion.accept!(by: preferred_name(params[:by].presence || "human"))
     log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
@@ -11,7 +11,7 @@ class SuggestionsController < InertiaController
   end
 
   def reject
-    @suggestion.reject!(by: params[:by].presence || "human")
+    @suggestion.reject!(by: preferred_name(params[:by].presence || "human"))
     log_and_broadcast("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
@@ -29,7 +29,7 @@ class SuggestionsController < InertiaController
     document = @suggestion.document
     Activity.log!(
       document:,
-      actor_name: params[:by].presence || "Someone",
+      actor_name: preferred_name(params[:by].presence || "Someone"),
       actor_kind: "human",
       action:,
       detail:

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -2,7 +2,7 @@ class SuggestionsController < InertiaController
   before_action :set_suggestion
 
   def accept
-    @suggestion.accept!(by: preferred_name(params[:by].presence || "human"))
+    @suggestion.accept!(by: preferred_name(params[:by], fallback: "human"))
     log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
@@ -11,7 +11,7 @@ class SuggestionsController < InertiaController
   end
 
   def reject
-    @suggestion.reject!(by: preferred_name(params[:by].presence || "human"))
+    @suggestion.reject!(by: preferred_name(params[:by], fallback: "human"))
     log_and_broadcast("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
@@ -29,7 +29,7 @@ class SuggestionsController < InertiaController
     document = @suggestion.document
     Activity.log!(
       document:,
-      actor_name: preferred_name(params[:by].presence || "Someone"),
+      actor_name: preferred_name(params[:by], fallback: "Someone"),
       actor_kind: "human",
       action:,
       detail:

--- a/app/frontend/components/identity_chip.tsx
+++ b/app/frontend/components/identity_chip.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { router } from '@inertiajs/react'
+import type { UserIdentity } from '../editor/identity'
+
+interface Props {
+  identity: UserIdentity
+  guest: boolean
+  /** Fired after the server confirms the session write — the caller applies
+   *  the live side effects (awareness label, provenance identity). `null`
+   *  means cleared back to guest. */
+  onRenamed: (name: string | null) => void
+}
+
+/**
+ * Who you are, in the header. Chrome-toggle register, no modal — the
+ * OwnershipChip inline-expand pattern with an input instead of buttons:
+ *   display  → avatar dot + name (guests: "‹name› · guest")
+ *   editing  → inline input, Enter saves, Esc cancels, empty clears to guest
+ *   saving   → input locked while the POST is in flight
+ *   error    → input stays open with an inline retry message
+ *
+ * The live identity (cursor label, provenance) only flips in onSuccess —
+ * a failed save must never leave this tab signing a name the session
+ * doesn't hold.
+ */
+export function IdentityChip({ identity, guest, onRenamed }: Props) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const inFlight = useRef(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!editing) return
+    inputRef.current?.focus()
+    inputRef.current?.select()
+    // Mobile: the soft keyboard must not occlude the input.
+    inputRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [editing])
+
+  const close = () => {
+    setEditing(false)
+    setSaving(false)
+    setFailed(false)
+    triggerRef.current?.focus()
+  }
+
+  const save = () => {
+    if (inFlight.current) return
+    inFlight.current = true
+    setSaving(true)
+    setFailed(false)
+    const name = draft.trim()
+    router.post(
+      '/identity',
+      { name },
+      {
+        only: ['viewer'],
+        preserveScroll: true,
+        async: true,
+        onSuccess: () => {
+          onRenamed(name.length > 0 ? name : null)
+          close()
+        },
+        onError: () => {
+          setSaving(false)
+          setFailed(true)
+        },
+        onFinish: () => {
+          inFlight.current = false
+        },
+      },
+    )
+  }
+
+  if (editing) {
+    return (
+      <span className="identity-edit">
+        <input
+          ref={inputRef}
+          className="identity-input"
+          type="text"
+          placeholder="Your name"
+          maxLength={80}
+          value={draft}
+          disabled={saving}
+          aria-label="Your display name — leave empty to stay a guest"
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              save()
+            } else if (event.key === 'Escape') {
+              event.preventDefault()
+              close()
+            }
+          }}
+        />
+        {failed && <span className="identity-error">Couldn’t save — try again</span>}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      ref={triggerRef}
+      className="chrome-toggle identity-chip"
+      title={guest ? 'You’re a guest — click to set your name' : `Signed as ${identity.name} — click to change`}
+      aria-label={
+        guest
+          ? `Set your display name — currently ${identity.name} (guest)`
+          : `Change your display name — currently ${identity.name}`
+      }
+      onClick={() => {
+        setDraft(guest ? '' : identity.name)
+        setEditing(true)
+      }}
+    >
+      <span className="identity-dot" style={{ background: identity.color }} aria-hidden />
+      <span className="identity-name">{identity.name}</span>
+      {guest && <span className="identity-guest">· guest</span>}
+    </button>
+  )
+}

--- a/app/frontend/components/identity_chip.tsx
+++ b/app/frontend/components/identity_chip.tsx
@@ -53,6 +53,7 @@ export function IdentityChip({ identity, guest, onRenamed }: Props) {
     setSaving(true)
     setFailed(false)
     const name = draft.trim()
+    let succeeded = false
     router.post(
       '/identity',
       { name },
@@ -61,15 +62,19 @@ export function IdentityChip({ identity, guest, onRenamed }: Props) {
         preserveScroll: true,
         async: true,
         onSuccess: () => {
+          succeeded = true
           onRenamed(name.length > 0 ? name : null)
           close()
         },
-        onError: () => {
-          setSaving(false)
-          setFailed(true)
-        },
+        // Inertia's onError only covers validation errors; CSRF/network/5xx
+        // failures land only in onFinish — recover there or the disabled
+        // input (which can't receive Escape) locks forever.
         onFinish: () => {
           inFlight.current = false
+          if (!succeeded) {
+            setSaving(false)
+            setFailed(true)
+          }
         },
       },
     )

--- a/app/frontend/editor/identity.ts
+++ b/app/frontend/editor/identity.ts
@@ -23,13 +23,27 @@ const STORAGE_KEY = 'proof:identity'
 
 const pick = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
 
-/** Stable per-browser identity so reloads keep the same name and color. */
-export function userIdentity(): UserIdentity {
+/**
+ * Stable per-browser identity so reloads keep the same name and color.
+ *
+ * `serverName` is the session-stored chosen display name (the `viewer`
+ * shared prop). When present it wins over the stored random name — but the
+ * color always comes from the stored guest identity, and the localStorage
+ * record is never overwritten by a chosen name, so clearing the session
+ * name falls back to the same guest identity as before.
+ */
+export function userIdentity(serverName?: string | null): UserIdentity {
   // Render-path callers (useForm initializers) must survive non-browser
   // environments where localStorage doesn't exist.
   if (typeof window === 'undefined') {
-    return { name: 'Anonymous', color: COLORS[0] }
+    return { name: serverName ?? 'Anonymous', color: COLORS[0] }
   }
+  const guest = guestIdentity()
+  return serverName ? { ...guest, name: serverName } : guest
+}
+
+/** The random localStorage identity — what you are with no chosen name. */
+function guestIdentity(): UserIdentity {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored) return JSON.parse(stored) as UserIdentity

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1292,6 +1292,74 @@ a:focus-visible {
   color: var(--ink);
 }
 
+/* ------------------------------ Identity chip ------------------------------ */
+.identity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+}
+
+.identity-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  flex: none;
+}
+
+.identity-name {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.identity-guest {
+  color: var(--ink-faint);
+  font-weight: 450;
+  flex: none;
+}
+
+.identity-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.identity-input {
+  border: 1px solid var(--line);
+  background: var(--surface-raised);
+  color: var(--ink);
+  font-size: 0.74rem;
+  border-radius: 7px;
+  padding: 0.28rem 0.6rem;
+  width: 10rem;
+}
+
+.identity-input:focus {
+  outline: none;
+  border-color: var(--ink-faint);
+}
+
+.identity-error {
+  font-size: 0.72rem;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+@media (max-width: 64rem) {
+  .identity-name {
+    max-width: 5.5rem;
+  }
+  .identity-input {
+    width: 7.5rem;
+  }
+}
+
+.landing-wordmark-link {
+  color: inherit;
+  text-decoration: none;
+}
+
 /* ------------------------------ Ownership chip ----------------------------- */
 .ownership-owner {
   font-size: 0.74rem;

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -167,6 +167,11 @@ a:focus-visible {
   letter-spacing: -0.02em;
 }
 
+.landing-wordmark-link {
+  color: inherit;
+  text-decoration: none;
+}
+
 .landing-tagline {
   margin-top: 0.75rem;
   color: var(--ink-soft);
@@ -1353,11 +1358,6 @@ a:focus-visible {
   .identity-input {
     width: 7.5rem;
   }
-}
-
-.landing-wordmark-link {
-  color: inherit;
-  text-decoration: none;
 }
 
 /* ------------------------------ Ownership chip ----------------------------- */

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -11,13 +11,15 @@ interface DocLink {
 interface Props {
   yours: DocLink[]
   recent: DocLink[]
+  viewer: { name: string | null; guest: boolean }
 }
 
-export default function DocumentsIndex({ yours, recent }: Props) {
-  // Lazy initializer: reads the localStorage identity at first render so the
-  // creator's display name rides along and the new doc is owned from birth.
-  // Staying on useForm keeps the `processing` double-submit guard.
-  const { post, processing } = useForm(() => ({ name: userIdentity().name }))
+export default function DocumentsIndex({ yours, recent, viewer }: Props) {
+  // Lazy initializer: the chosen session name wins; guests post their
+  // random localStorage name as the fallback (the server prefers the
+  // session name on create anyway). Staying on useForm keeps the
+  // `processing` double-submit guard.
+  const { post, processing } = useForm(() => ({ name: userIdentity(viewer.name).name }))
   const [copied, setCopied] = useState(false)
 
   const origin = typeof window === 'undefined' ? '' : window.location.origin
@@ -40,7 +42,11 @@ export default function DocumentsIndex({ yours, recent }: Props) {
       <div className="landing">
         <div className="landing-corner"><FeedbackButton /></div>
         <main className="landing-main">
-          <h1 className="landing-wordmark">Pruf</h1>
+          <h1 className="landing-wordmark">
+            <Link href="/" className="landing-wordmark-link">
+              Pruf
+            </Link>
+          </h1>
           <p className="landing-tagline">
             A collaborative editor that remembers who wrote what — humans and AI,
             side by side, every word attributed.

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -118,7 +118,7 @@ export default function DocumentShow({
   // sync-on-prop-change effect, which a future reload batch listing
   // `viewer` would silently clobber mid-rename.
   const [identity, setIdentity] = useState<UserIdentity>(() => userIdentity(viewer.name))
-  const [isGuest, setIsGuest] = useState(viewer.guest)
+  const [guest, setGuest] = useState(viewer.guest)
   const [status, setStatus] = useState<ConnectionStatus>('connecting')
   const [handle, setHandle] = useState<EditorHandle | null>(null)
   const [spans, setSpans] = useState<ProvenanceSpan[]>([])
@@ -204,21 +204,24 @@ export default function DocumentShow({
   }, [handle])
 
   // Rename applies here AFTER the server confirms the session write (the
-  // chip's POST onSuccess) — awareness and the provenance identity ctx are
-  // live side effects Inertia's optimistic rollback can't touch, so they
-  // only flip once the name is durably stored.
-  const handleRenamed = useCallback(
-    (name: string | null) => {
-      const next = userIdentity(name)
-      setIdentity(next)
-      setIsGuest(name === null)
-      if (handle) {
-        handle.provider.awareness.setLocalStateField('user', next)
-        handle.editor.action((ctx) => ctx.set(provenanceIdentityCtx.key, { name: next.name }))
-      }
-    },
-    [handle],
-  )
+  // chip's POST onSuccess). The handler only moves React state — the live
+  // side effects ride the effect below, so a rename that completes while
+  // the editor is still connecting (handle null) heals the moment the
+  // handle arrives, and an in-flight POST can never act through a stale
+  // null-handle closure.
+  const handleRenamed = useCallback((name: string | null) => {
+    setIdentity(userIdentity(name))
+    setGuest(name === null)
+  }, [])
+
+  // Identity state is the source of truth for the live editor surfaces:
+  // re-applied whenever the handle arrives or the identity changes.
+  // Idempotent — re-writing the same awareness state is a no-op for peers.
+  useEffect(() => {
+    if (!handle) return
+    handle.provider.awareness.setLocalStateField('user', identity)
+    handle.editor.action((ctx) => ctx.set(provenanceIdentityCtx.key, { name: identity.name }))
+  }, [handle, identity])
 
   // Agent pseudo-cursors track the presences prop.
   useEffect(() => {
@@ -509,7 +512,7 @@ export default function DocumentShow({
             />
           </div>
           <div className="doc-header-right">
-            <IdentityChip identity={identity} guest={isGuest} onRenamed={handleRenamed} />
+            <IdentityChip identity={identity} guest={guest} onRenamed={handleRenamed} />
             <ProvenanceSummaryChip spans={spans} />
             <PresenceBar humans={peers} agents={presences} compact={isMobile} />
             <button

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -8,6 +8,7 @@ import {
   type EditorHandle,
 } from '../../editor/milkdown_editor'
 import { userIdentity, type UserIdentity } from '../../editor/identity'
+import { provenanceIdentityCtx } from '../../editor/provenance'
 import {
   aiSpanAt,
   applyReviewState,
@@ -32,6 +33,7 @@ import { SelectionToolbar } from '../../components/selection_toolbar'
 import { PresenceBar, type AgentPresencePayload } from '../../components/presence_bar'
 import { ActivityPanel } from '../../components/activity_panel'
 import { FeedbackButton } from '../../components/feedback_button'
+import { IdentityChip } from '../../components/identity_chip'
 import { OwnershipChip, type OwnershipPayload } from '../../components/ownership_chip'
 import { SharePopover } from '../../components/share_popover'
 import {
@@ -53,6 +55,11 @@ export interface ActivityPayload {
   created_at: string
 }
 
+export interface ViewerPayload {
+  name: string | null
+  guest: boolean
+}
+
 export interface DocumentProps {
   document: {
     id: number
@@ -62,6 +69,7 @@ export interface DocumentProps {
     has_state: boolean
     yjs_state_b64: string | null
   }
+  viewer: ViewerPayload
   ownership: OwnershipPayload
   suggestions: SuggestionPayload[]
   comments: CommentPayload[]
@@ -99,13 +107,18 @@ const writeStoredFlag = (key: string, value: boolean): void => {
 
 export default function DocumentShow({
   document: doc,
+  viewer,
   ownership,
   suggestions,
   comments,
   activities,
   presences,
 }: DocumentProps) {
-  const identity = useMemo(userIdentity, [])
+  // Initializer-only state plus an explicit rename handler — NOT a
+  // sync-on-prop-change effect, which a future reload batch listing
+  // `viewer` would silently clobber mid-rename.
+  const [identity, setIdentity] = useState<UserIdentity>(() => userIdentity(viewer.name))
+  const [isGuest, setIsGuest] = useState(viewer.guest)
   const [status, setStatus] = useState<ConnectionStatus>('connecting')
   const [handle, setHandle] = useState<EditorHandle | null>(null)
   const [spans, setSpans] = useState<ProvenanceSpan[]>([])
@@ -170,15 +183,18 @@ export default function DocumentShow({
     prevSuggestionCount.current = suggestions.length
   }, [suggestions.length])
 
-  // Human presence from Yjs awareness.
+  // Human presence from Yjs awareness. Self is filtered out — the
+  // IdentityChip represents you; a duplicate avatar next to it is noise.
   useEffect(() => {
     if (!handle) return
     const { awareness } = handle.provider
+    const selfId = handle.provider.doc.clientID
     const update = () => {
-      const states = Array.from(awareness.getStates().values())
+      const states = Array.from(awareness.getStates().entries())
       setPeers(
         states
-          .map((state) => (state as { user?: UserIdentity }).user)
+          .filter(([clientId]) => clientId !== selfId)
+          .map(([, state]) => (state as { user?: UserIdentity }).user)
           .filter((user): user is UserIdentity => Boolean(user)),
       )
     }
@@ -186,6 +202,23 @@ export default function DocumentShow({
     awareness.on('change', update)
     return () => awareness.off('change', update)
   }, [handle])
+
+  // Rename applies here AFTER the server confirms the session write (the
+  // chip's POST onSuccess) — awareness and the provenance identity ctx are
+  // live side effects Inertia's optimistic rollback can't touch, so they
+  // only flip once the name is durably stored.
+  const handleRenamed = useCallback(
+    (name: string | null) => {
+      const next = userIdentity(name)
+      setIdentity(next)
+      setIsGuest(name === null)
+      if (handle) {
+        handle.provider.awareness.setLocalStateField('user', next)
+        handle.editor.action((ctx) => ctx.set(provenanceIdentityCtx.key, { name: next.name }))
+      }
+    },
+    [handle],
+  )
 
   // Agent pseudo-cursors track the presences prop.
   useEffect(() => {
@@ -476,6 +509,7 @@ export default function DocumentShow({
             />
           </div>
           <div className="doc-header-right">
+            <IdentityChip identity={identity} guest={isGuest} onRenamed={handleRenamed} />
             <ProvenanceSummaryChip spans={spans} />
             <PresenceBar humans={peers} agents={presences} compact={isMobile} />
             <button

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,10 +42,17 @@ class Document < ApplicationRecord
     token.present? && owner_token == token
   end
 
-  # One normalization rule for owner display names, shared by claim! and the
-  # auto-claim path in documents#create.
+  # One normalization rule for display names: strip, cap, nil for blank.
+  # nil matters — the identity endpoint clears the session on blank rather
+  # than storing a fallback.
+  def self.normalize_display_name(raw)
+    raw.to_s.strip.first(255).presence
+  end
+
+  # Owner names additionally fall back to "Anonymous" (ownership rows always
+  # carry a name).
   def self.normalize_owner_name(raw)
-    raw.to_s.strip.first(255).presence || "Anonymous"
+    normalize_display_name(raw) || "Anonymous"
   end
 
   # Atomic first-claim-wins, mirroring the seed-claim pattern: the conditional

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  :name # chosen display names are PII
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resources :documents, only: :create
 
+  post "identity", to: "identities#update", as: :identity
+
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
   delete "d/:slug", to: "documents#destroy", as: :destroy_document

--- a/docs/plans/2026-06-05-004-feat-display-name-guest-mode-plan.md
+++ b/docs/plans/2026-06-05-004-feat-display-name-guest-mode-plan.md
@@ -1,0 +1,100 @@
+---
+title: "feat: Set your display name — session-stored, random names become guest mode"
+type: feat
+status: active
+date: 2026-06-05
+---
+
+# feat: Set Your Display Name — Session-Stored, Random Names Become Guest Mode
+
+## Summary
+
+Everyone is currently a random "Quiet Falcon" forever. This plan adds a way to say who you are: an identity chip in the editor header shows your current name, click it to type your real one. The name stores in the Rails session and wins over the random localStorage identity everywhere new attribution happens — presence cursors, comments, suggestion resolutions, doc ownership. No name set = **guest mode**: the random name, visibly marked as guest. Clearing your name returns you to the same guest identity.
+
+## Problem Frame
+
+Identity today is a random adjective+animal minted client-side (`app/frontend/editor/identity.ts`, localStorage `proof:identity`) and used for everything: Yjs awareness labels, provenance mark authors, comment/suggestion attribution, and — since the ownership feature — claim/create owner names. There is no way to be "Kieran" instead of "Velvet Stoat". The user asked for the name to live in the session, making the random identity an explicit guest tier.
+
+## Assumptions
+
+Headless-mode inferred bets (pipeline run):
+
+- **The Rails session is the store for chosen names** (`session[:display_name]`), per the user's "store to session". The random guest identity (name + color) stays in localStorage; **color always comes from localStorage** — choosing a name doesn't change your cursor color.
+- **Setting the name is a CSRF-protected browser POST** (mirrors the claim endpoint's trust posture — drive-by requests can't rename you). Submitting an empty/whitespace name clears the session name → back to guest.
+- **Rename applies live in-session** for presence (awareness label) and future attribution (provenance identity, comments, suggestions); text already attributed keeps its historical author name — renames are not retroactive.
+- **Server prefers the session name** when stamping names on every browser-stack attribution write — create/claim ownership AND comments/suggestion resolutions — falling back to the client-posted name for guests. Other tabs pick up a rename on their next page load — no cross-tab live sync.
+- **Names are self-asserted and unverified** — anyone with the share link can set any display name, including one resembling another participant. Accepted: it matches the share-link trust model (same boundary as ownership). No rate limiting on the rename endpoint either (CSRF-protected, session-scoped, no DB write).
+- **Rider (user-requested in session):** the Pruf wordmark on the landing page becomes a link to `/`, so clicking the logo always goes home.
+
+## Requirements
+
+- R1. A user can set their display name from the editor header; new attribution everywhere uses it (presence label, comments, suggestion accept/reject, claim/create ownership).
+- R2. The name persists in the Rails session — returning in the same browser keeps it without re-entering.
+- R3. With no name set, the user is a guest: the existing random identity, visibly marked (e.g., "· guest") with an affordance inviting them to set a name.
+- R4. Clearing the name (empty submit) returns to guest mode with the same random identity as before.
+- R5. Names are normalized (strip, 255 cap — the `Document.normalize_owner_name` rule) and rendered only as text, never HTML.
+- R6. Renaming mid-session updates the live presence label without a reload; GET requests never change the stored name.
+- R7. The landing wordmark links to home.
+
+## Key Technical Decisions
+
+1. **`session[:display_name]` + `POST /identity`.** A tiny browser-stack endpoint (CSRF-protected like claim — KTD 2 of the ownership plan) writes the normalized name to the session; blank clears it. No model, no migration — the session cookie is the persistence the user asked for.
+2. **`viewer` shared Inertia prop.** `inertia_share viewer: -> { ... }` in `app/controllers/inertia_controller.rb` (the file already documents this exact hook) exposes `{ name, guest }` to every page — index and show both need it, and shared data avoids per-action wiring. Reload after rename scopes to `only: ['viewer']`.
+3. **Client precedence: server name > localStorage random.** `userIdentity()` gains an optional server-name argument: when present, it overrides the stored random name but keeps the stored color. The localStorage record itself is never overwritten by a chosen name — clearing the session name falls back to the unchanged guest identity (R4 for free).
+4. **Live rename is imperative, not editor-recreating — and confirmed feasible.** The provenance writer reads `provenanceIdentityCtx` freshly inside every `appendTransaction`, and `EditorHandle` already exposes `editor` and `provider`; so `handle.editor.action(ctx => ctx.set(provenanceIdentityCtx.key, { name }))` + `handle.provider.awareness.setLocalStateField('user', ...)` covers both live surfaces with no editor teardown (the session effect keys on `[loading, slug]`; identity changes cannot recreate it). **Rename applies on POST success, not optimistically**: awareness and provenance are live Yjs/ctx side effects Inertia's optimistic rollback can't touch — applying them in `onSuccess` (one round-trip of label lag) avoids the failed-write divergence where this tab signs the new name while the session (and therefore create/claim stamping) keeps the old one. On error: input stays open with an inline retry message.
+5. **Server stamps the session name on every browser attribution write.** Not just `documents#create`/`#claim` — also `comments#create` (`author_name`), `comments#resolve` (`by`), and `suggestions#accept`/`#reject` (`by`): `session[:display_name].presence || params[...]`. Otherwise a stale tab resolves comments as "Quiet Falcon" while the same session claims docs as "Kieran" — split identity in one activity feed. Clients keep posting their name as the guest fallback.
+
+## Implementation Units
+
+### U1. Session identity endpoint + viewer prop + server-side name preference
+
+**Goal:** The session stores a chosen display name; every Inertia page knows the viewer's name/guest state; ownership stamping prefers it.
+**Requirements:** R2, R4 (server half), R5, R6 (GET-never-mutates).
+**Dependencies:** none.
+**Files:** `config/routes.rb`, `app/controllers/identities_controller.rb` (new), `app/controllers/inertia_controller.rb`, `app/controllers/documents_controller.rb`, `app/controllers/comments_controller.rb`, `app/controllers/suggestions_controller.rb`, `app/models/document.rb`, `config/initializers/filter_parameter_logging.rb`, `test/integration/identity_flow_test.rb` (new).
+**Approach:** `post "identity" => "identities#update"`. `IdentitiesController < InertiaController` must **not** reuse `Document.normalize_owner_name` (its "Anonymous" fallback would store "Anonymous" instead of clearing — breaking guest-mode return). Add `Document.normalize_display_name(raw)` → strip, 255 cap, `nil` for blank (and re-express `normalize_owner_name` as `normalize_display_name(raw) || "Anonymous"`); blank → `session.delete(:display_name)`, else store; redirect back 303 (mirrors claim). `inertia_share viewer: -> { { name: session[:display_name], guest: session[:display_name].blank? } }` in `InertiaController` (KTD 2). Session-name preference (`session[:display_name].presence || params[...]`) lands in `documents#create`/`#claim` AND `comments#create`/`#resolve` AND `suggestions#accept`/`#reject` (KTD 5). Add `:name` to `config/initializers/filter_parameter_logging.rb` — chosen names are PII and shouldn't land in production logs.
+**Patterns to follow:** claim endpoint shape in `app/controllers/documents_controller.rb` (browser-stack POST, redirect_back 303); `inertia_share` comment in `inertia_controller.rb`.
+**Test scenarios:** POST identity with a name → subsequent GET serves `viewer.name` set and `guest: false`; name persists across requests in the same session; POST with blank/whitespace → viewer back to guest (and the session key is actually gone — not "Anonymous"); name longer than 255 truncated; HTML in the name arrives intact in the prop as a plain JSON string (no server-side interpretation) — and is capped; GET never sets or changes the name; with session name set, `documents#create` stamps it as `owner_name` regardless of `params[:name]`; claim stamps session name over params; a comment created and a comment resolved by a named user carry the session name over params; suggestion accept/reject resolved_by and activity actor use the session name; guest (no session name) keeps every params fallback path; claim activity detail uses the same resolved name.
+**Verification:** integration tests green; curl POST without CSRF token is rejected (covered by stack, same as claim).
+
+### U2. Client identity precedence + live rename plumbing
+
+**Goal:** The chosen name flows into every client-side attribution surface; renames apply live without recreating the editor.
+**Requirements:** R1, R3 (precedence half), R6.
+**Dependencies:** U1.
+**Files:** `app/frontend/editor/identity.ts`, `app/frontend/pages/documents/show.tsx`, `app/frontend/editor/milkdown_editor.tsx`, `app/frontend/pages/documents/index.tsx`.
+**Approach:** `userIdentity(serverName?)` — server name overrides stored random name, color always from the stored guest identity (KTD 3). `show.tsx`: identity becomes **initializer-only state** (`useState(() => userIdentity(viewer.name))`) plus the explicit rename handler — not a sync-on-prop-change effect, which a future reload batch listing `viewer` would silently clobber mid-rename. The rename handler runs in the POST's `onSuccess` (KTD 4): set state, `handle.provider.awareness.setLocalStateField('user', ...)`, `handle.editor.action(ctx => ctx.set(provenanceIdentityCtx.key, { name }))`. Existing `identity.name` consumers (suggestion accept/reject `by`, comment `author_name`, OwnershipChip `claimerName`) read the updated state automatically. Filter self out of the PresenceBar peers (`show.tsx` awareness loop, by `doc.clientID`) — the IdentityChip now represents you, and a duplicate self-avatar next to it is noise. **Audit step:** confirm `@milkdown/kit/plugin/cursor` builds remote cursor labels with `textContent`-safe APIs (not innerHTML) before relying on R5 for awareness-sourced names; if it uses innerHTML, sanitize the name before `setLocalStateField`. `index.tsx`: `useForm` initializer prefers `viewer.name` (guests keep posting the random name as fallback — the server prefers session anyway per U1).
+**Patterns to follow:** existing identity prop threading in `show.tsx`/`milkdown_editor.tsx`; `acquireSession` awareness wiring.
+**Test scenarios:** Test expectation: none in Ruby — client behavior; covered by U1's server tests plus browser verification: rename mid-session → cursor label in a second window updates within a beat; a comment posted after rename carries the new name; text typed after rename attributes to the new name; reload keeps the name; own avatar no longer duplicated between chip and presence bar.
+**Verification:** two-window browser pass per scenarios above.
+
+### U3. Identity chip UI + guest affordance + wordmark link
+
+**Goal:** A visible, editable identity in the editor header; guests are invited to introduce themselves; the logo goes home.
+**Requirements:** R1 (affordance), R3, R4 (UX half), R7.
+**Dependencies:** U1, U2.
+**Files:** `app/frontend/components/identity_chip.tsx` (new), `app/frontend/pages/documents/show.tsx`, `app/frontend/pages/documents/index.tsx`, `app/frontend/entrypoints/application.css`.
+**Approach:** `IdentityChip` in the `doc-header-right` cluster (next to `PresenceBar`), chrome-toggle visual register, no modal — `OwnershipChip`'s inline-expand pattern with four states: *display* (avatar dot in your color + name, `max-width` ~12rem with ellipsis + full name in `title`, `cursor: pointer`, `aria-label="Set your display name — currently ‹name›"`), *guest display* (same + "· guest" suffix kept visible outside the truncation), *editing* (inline text input pre-filled with the current name — empty with placeholder "Your name" for guests — `maxLength` 80, Enter saves, Esc cancels, focus returns to the chip trigger on either), *saving/error* (input locked while the POST is in flight; on error the input stays open with an inline "Couldn't save — try again"). Save = `router.post('/identity', { name }, { only: ['viewer'], preserveScroll: true, async: true })` with the in-flight ref guard; the live identity side effects fire in `onSuccess` per KTD 4/U2; empty submit clears to guest. At ≤64rem the chip stays in the header in compact form (dot + tighter truncation); on focus, scroll the input into view so the soft keyboard doesn't occlude it. Landing page (`index.tsx`): wrap the wordmark in a `Link` to `/` (R7); optionally show the same chip on the landing under the actions — only if it drops in cleanly, otherwise editor-only.
+**Patterns to follow:** `OwnershipChip` (inline expand, scoped POST, in-flight ref guard, error recovery); `chrome-toggle` CSS register.
+**Test scenarios:** Test expectation: none in Ruby — presentational; browser verification: guest chip shows random name + guest marker; setting a name flips the chip and presence label; empty submit returns to the same random name; double-Enter doesn't double-POST (in-flight guard); a failed POST keeps the input open with the retry message and does NOT change the live cursor label; wordmark click navigates to `/`.
+**Verification:** browser pass per scenarios; suite stays green.
+
+## Scope Boundaries
+
+**In scope:** everything above.
+
+### Deferred to Follow-Up Work
+
+- Cross-tab live name sync (other tabs update on next load only).
+- Retroactive re-attribution of existing provenance marks/comments after rename.
+- Showing the identity chip on the landing page if it doesn't drop in cleanly (editor-only is acceptable for v1).
+- Agent-visible "humans present" names beyond what awareness already carries — no agent API changes in this plan.
+- Account-grade identity (cross-device) — same boundary as the ownership plan.
+
+## Risks & Dependencies
+
+- **Editor stability on rename** — verified structurally safe: `useEditor` runs with `[]` deps and the collab session effect keys on `[loading, slug]`, so identity changes cannot tear down the CRDT session; renames apply imperatively via the existing handle (KTD 4). The two-window browser pass remains the guard against regressions here.
+- **Two name stores could drift** (session name vs localStorage guest) — mitigated by precedence being one line (KTD 3) and by never writing chosen names into localStorage.
+- **`viewer` shared prop on partial reloads** — verified: inertia_rails merges shared data into props before partial-reload filtering, so `only: ['viewer']` re-evaluates and delivers it. U1's tests assert it anyway.
+- **Session cookie budget** — `display_name` (≤255 chars) joins `recent_slugs` and friends in the 4KB CookieStore cookie; comfortably under budget, but an overflow would drop the whole session silently. The 255 cap is the guard.
+- **Awareness names bypass server normalization** — a modified client can put anything in the awareness stream regardless of U1; the U2 cursor-plugin audit (textContent vs innerHTML) is what actually protects peers, not the session normalization.

--- a/docs/plans/2026-06-05-004-feat-display-name-guest-mode-plan.md
+++ b/docs/plans/2026-06-05-004-feat-display-name-guest-mode-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Set your display name — session-stored, random names become guest mode"
 type: feat
-status: active
+status: completed
 date: 2026-06-05
 ---
 

--- a/test/integration/identity_flow_test.rb
+++ b/test/integration/identity_flow_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+class IdentityFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(title: "Doc")
+  end
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+
+  def viewer_props
+    props = nil
+    assert_inertia_props do |p|
+      props = p
+      true
+    end
+    props[:viewer]
+  end
+
+  test "setting a name serves viewer.name on subsequent pages" do
+    post identity_path, params: { name: "Kieran" }
+    assert_response :see_other
+
+    get root_path
+    assert_equal({ name: "Kieran", guest: false }, viewer_props.symbolize_keys.transform_values { |v| v })
+  end
+
+  test "name persists across requests in the same session" do
+    post identity_path, params: { name: "Kieran" }
+
+    get root_path
+    assert_equal "Kieran", viewer_props[:name]
+    get document_page_path(@document.slug), headers: browser
+    assert_equal "Kieran", viewer_props[:name]
+  end
+
+  test "no name set means guest mode" do
+    get root_path
+    viewer = viewer_props
+    assert_nil viewer[:name]
+    assert viewer[:guest]
+  end
+
+  test "blank name clears back to guest — session key gone, not Anonymous" do
+    post identity_path, params: { name: "Kieran" }
+    post identity_path, params: { name: "   " }
+
+    get root_path
+    viewer = viewer_props
+    assert_nil viewer[:name]
+    assert viewer[:guest]
+    refute_equal "Anonymous", viewer[:name]
+  end
+
+  test "names are stripped and capped at 255" do
+    post identity_path, params: { name: "  Kieran  " }
+    get root_path
+    assert_equal "Kieran", viewer_props[:name]
+
+    post identity_path, params: { name: "x" * 400 }
+    get root_path
+    assert_equal 255, viewer_props[:name].length
+  end
+
+  test "HTML in the name arrives as an inert JSON string" do
+    post identity_path, params: { name: "<script>alert(1)</script>" }
+    get root_path
+    assert_equal "<script>alert(1)</script>", viewer_props[:name]
+  end
+
+  test "GET requests never set or change the name" do
+    get root_path
+    get document_page_path(@document.slug), headers: browser
+    get root_path
+    assert viewer_props[:guest]
+  end
+
+  # --- session name wins on every attribution write ---
+
+  test "create stamps the session name over the posted name" do
+    post identity_path, params: { name: "Kieran" }
+
+    post documents_path, params: { name: "Stale Guest" }
+    assert_equal "Kieran", Document.order(:created_at).last.owner_name
+  end
+
+  test "claim stamps the session name over the posted name" do
+    post identity_path, params: { name: "Kieran" }
+
+    post claim_document_path(@document.slug), params: { name: "Stale Guest" }
+    @document.reload
+    assert_equal "Kieran", @document.owner_name
+    assert_includes @document.activities.last.detail, "Kieran"
+  end
+
+  test "comments carry the session name over the posted author_name" do
+    post identity_path, params: { name: "Kieran" }
+
+    post document_comments_path(@document.slug), params: { body: "hi", author_name: "Stale Guest" }
+    assert_equal "Kieran", @document.comments.last.author_name
+  end
+
+  test "comment resolution logs the session name" do
+    comment = @document.comments.create!(author_name: "Someone", body: "note")
+    post identity_path, params: { name: "Kieran" }
+
+    patch resolve_comment_path(comment), params: { by: "Stale Guest" }
+    assert_equal "Kieran", @document.activities.last.actor_name
+  end
+
+  test "suggestion accept and reject resolve with the session name" do
+    post identity_path, params: { name: "Kieran" }
+
+    accepted = @document.suggestions.create!(author_name: "Gemini", author_kind: "ai", body: "a")
+    patch accept_suggestion_path(accepted), params: { by: "Stale Guest" }
+    assert_equal "Kieran", accepted.reload.resolved_by
+    assert_equal "Kieran", @document.activities.last.actor_name
+
+    rejected = @document.suggestions.create!(author_name: "Gemini", author_kind: "ai", body: "b")
+    patch reject_suggestion_path(rejected), params: { by: "Stale Guest" }
+    assert_equal "Kieran", rejected.reload.resolved_by
+  end
+
+  test "guests keep the client-posted fallback everywhere" do
+    post documents_path, params: { name: "Quiet Falcon" }
+    assert_equal "Quiet Falcon", Document.order(:created_at).last.owner_name
+
+    post document_comments_path(@document.slug), params: { body: "hi", author_name: "Quiet Falcon" }
+    assert_equal "Quiet Falcon", @document.comments.last.author_name
+
+    suggestion = @document.suggestions.create!(author_name: "Gemini", author_kind: "ai", body: "a")
+    patch accept_suggestion_path(suggestion), params: { by: "Quiet Falcon" }
+    assert_equal "Quiet Falcon", suggestion.reload.resolved_by
+  end
+end

--- a/test/integration/identity_flow_test.rb
+++ b/test/integration/identity_flow_test.rb
@@ -23,7 +23,48 @@ class IdentityFlowTest < ActionDispatch::IntegrationTest
     assert_response :see_other
 
     get root_path
-    assert_equal({ name: "Kieran", guest: false }, viewer_props.symbolize_keys.transform_values { |v| v })
+    viewer = viewer_props
+    assert_equal "Kieran", viewer[:name]
+    assert_equal false, viewer[:guest]
+  end
+
+  test "viewer is delivered on a partial reload" do
+    post identity_path, params: { name: "Kieran" }
+    get root_path # establish the page + version
+
+    get root_path, headers: {
+      "X-Inertia" => "true",
+      "X-Inertia-Version" => InertiaController.safe_vite_digest.to_s,
+      "X-Inertia-Partial-Component" => "documents/index",
+      "X-Inertia-Partial-Data" => "viewer"
+    }
+    assert_response :success
+    props = response.parsed_body.fetch("props")
+    assert_equal "Kieran", props.dig("viewer", "name")
+  end
+
+  test "forged identity POST without CSRF token is rejected when protection is active" do
+    original = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    begin
+      get root_path # mint cookies, discard the token
+
+      post identity_path, params: { name: "Forger" }
+
+      assert_response :unprocessable_entity
+      get root_path
+      assert viewer_props[:guest]
+    ensure
+      ActionController::Base.allow_forgery_protection = original
+    end
+  end
+
+  test "non-string name params clear rather than stringify" do
+    post identity_path, params: { name: "Kieran" }
+    post identity_path, params: { name: { x: "1" } }
+
+    get root_path
+    assert viewer_props[:guest]
   end
 
   test "name persists across requests in the same session" do


### PR DESCRIPTION
## Say who you are — display names with guest mode 👤

Everyone was a random "Quiet Falcon" forever. Now:

- **Identity chip** in the editor header — shows who you are; click, type your name, Enter. Stored in the Rails session (`POST /identity`, CSRF-protected; blank clears).
- **Guest mode** — no name set = your existing random localStorage identity, marked "· guest" with an invitation to introduce yourself. Clearing your name returns you to the *same* random identity (color never changes).
- **Live rename** — cursor label and future provenance attribution flip in-session via an effect keyed on `[handle, identity]` (heals renames that complete while the editor is still connecting; no editor teardown).
- **Session name wins server-side** on every attribution write — create/claim ownership, comments, comment resolutions, suggestion accept/reject — so a stale tab can never sign your old guest name once you've introduced yourself.
- **Rider:** the Pruf wordmark links home.

Plan: `docs/plans/2026-06-05-004-feat-display-name-guest-mode-plan.md` (R1–R7, U1–U3 shipped).

### Review & verification

- 6-reviewer pass: rename-before-editor-ready healed (triple-corroborated finding), chip failure recovery (Inertia onError only covers validation errors), non-string `name[x]=1` param guard, vacuous test assertion fixed, partial-reload + CSRF tests added, `preferred_name(raw, fallback:)` unified across 5 call sites.
- y-prosemirror cursor-label XSS audit performed: `createTextNode(user.name)` — text-safe.
- 127 Minitest runs green; tsc, Vite build, rubocop clean.
- Headless browser pass: guest chip → rename → claim stamps session name → reload persists → clear returns to same guest → wordmark link. 10/10.

### Accepted posture (documented in plan)

Names are self-asserted (impersonation accepted under the share-link trust model); no rate limiting on rename; cross-tab updates on next load only; renames not retroactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
