### PR TITLE
fix: eliminate document-load flicker — content at first paint

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -11,7 +11,7 @@
 # All client messages are broadcast to every subscriber (sender filters its own
 # via cid); update/sync-reply are additionally merged into persistent storage.
 class SyncChannel < ApplicationCable::Channel
-  SEED_CLAIM_TIMEOUT = 30.seconds
+  SEED_CLAIM_TIMEOUT = Document::SEED_CLAIM_TIMEOUT
 
   def subscribed
     @document = Document.find_by(slug: params[:slug])
@@ -59,17 +59,9 @@ class SyncChannel < ApplicationCable::Channel
   private
 
   # Exactly one client seeds an empty document from its markdown template.
-  # The atomic UPDATE claims it; a stale claim (seeder crashed before its first
-  # update persisted) is reclaimable after SEED_CLAIM_TIMEOUT.
+  # The atomic claim lives on Document (shared with the HTTP grant path in
+  # documents#show); this channel path remains as the stale-claim fallback.
   def claim_seed?
-    return false if @document.yjs_state.present? || @document.seed_markdown.blank?
-
-    Document
-      .where(id: @document.id)
-      .where(
-        "seed_state = 'pending' OR (seed_state = 'claimed' AND seed_claimed_at < ?)",
-        SEED_CLAIM_TIMEOUT.ago
-      )
-      .update_all(seed_state: "claimed", seed_claimed_at: Time.current) == 1
+    @document.try_claim_seed
   end
 end

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -11,8 +11,6 @@
 # All client messages are broadcast to every subscriber (sender filters its own
 # via cid); update/sync-reply are additionally merged into persistent storage.
 class SyncChannel < ApplicationCable::Channel
-  SEED_CLAIM_TIMEOUT = Document::SEED_CLAIM_TIMEOUT
-
   def subscribed
     @document = Document.find_by(slug: params[:slug])
     return reject unless @document

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -33,9 +33,16 @@ class DocumentsController < InertiaController
     remember_recent(document)
     @agent_guide = AgentGuide.text(document, request.base_url)
 
+    # Claim the seed at page-render time so a fresh document paints its
+    # template from props instead of waiting for the WebSocket round-trip.
+    # Only the HTML editor path may claim — agent/JSON fetches above never
+    # reach here, so a programmatic read can't burn the claim.
+    seed_granted = document.try_claim_seed
+
     render inertia: "documents/show", props: {
       document: document.slice(:id, :slug, :title).merge(
         seed_markdown: document.seed_markdown,
+        seed_granted: seed_granted,
         has_state: document.yjs_state.present?,
         yjs_state_b64: (Base64.strict_encode64(document.yjs_state) if document.yjs_state.present?)
       ),

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -36,8 +36,11 @@ class DocumentsController < InertiaController
     # Claim the seed at page-render time so a fresh document paints its
     # template from props instead of waiting for the WebSocket round-trip.
     # Only the HTML editor path may claim — agent/JSON fetches above never
-    # reach here, so a programmatic read can't burn the claim.
-    seed_granted = document.try_claim_seed
+    # reach here, so a programmatic read can't burn the claim. Partial
+    # reloads and prefetch-shaped requests are also excluded: only an
+    # initial render mounts an editor that will actually apply the grant,
+    # and a burned grant blocks the channel fallback for SEED_CLAIM_TIMEOUT.
+    seed_granted = initial_render? && !prefetch_request? && document.try_claim_seed
 
     render inertia: "documents/show", props: {
       document: document.slice(:id, :slug, :title).merge(
@@ -140,5 +143,20 @@ class DocumentsController < InertiaController
   def agent_user_agent?
     ua = request.user_agent.to_s
     ua.blank? || !ua.include?("Mozilla")
+  end
+
+  # Inertia partial reloads (presence polls, ownership events, …) re-run
+  # this action but never remount the editor — they must not touch the
+  # seed claim.
+  def initial_render?
+    request.headers["X-Inertia-Partial-Component"].blank?
+  end
+
+  # Link prefetchers fetch pages no editor will mount in. Sec-Purpose is
+  # the standard header; Purpose is the legacy spelling still sent by
+  # some browsers and proxies.
+  def prefetch_request?
+    request.headers["Sec-Purpose"].to_s.include?("prefetch") ||
+      request.headers["Purpose"].to_s == "prefetch"
   end
 end

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -127,6 +127,11 @@ export class CableProvider {
           update: toBase64(Y.encodeStateAsUpdate(this.doc, serverVector)),
         })
         if (data.seed && data.seed_markdown) {
+          // No one listens to 'seed' by design: the editor reads
+          // provider.seedMarkdown directly inside its bind step, which runs
+          // on the 'synced' emit below — this assignment is ordered before
+          // it on purpose. Handling the seed in a 'seed' listener instead
+          // would double-apply the template.
           this.seedMarkdown = data.seed_markdown
           this.emit('seed')
         }

--- a/app/frontend/editor/highlighter.ts
+++ b/app/frontend/editor/highlighter.ts
@@ -36,7 +36,10 @@ export function loadShikiParser(): Promise<Parser> {
  * re-renders decorations when it resolves. Once ready, it highlights
  * synchronously. If shiki fails to load, code blocks stay plain text.
  */
+let loadedPromise: Promise<void> | null = null
+
 export function lazyShikiParser(): Parser {
-  const loaded = loadShikiParser().then(() => undefined)
+  loadedPromise ??= loadShikiParser().then(() => undefined)
+  const loaded = loadedPromise
   return (options) => (readyParser ? readyParser(options) : loaded)
 }

--- a/app/frontend/editor/highlighter.ts
+++ b/app/frontend/editor/highlighter.ts
@@ -7,6 +7,7 @@ const LANGS = [
 ]
 
 let parserPromise: Promise<Parser> | null = null
+let readyParser: Parser | null = null
 
 /** Singleton shiki-backed parser for code block highlighting. */
 export function loadShikiParser(): Promise<Parser> {
@@ -21,8 +22,21 @@ export function loadShikiParser(): Promise<Parser> {
           return []
         }
       }
+      readyParser = safe
       return safe
     },
   )
   return parserPromise
+}
+
+/**
+ * Non-blocking parser so the editor never waits on shiki to paint.
+ * While the highlighter loads, it returns the in-flight promise —
+ * prosemirror-highlight's documented lazy protocol — and the plugin
+ * re-renders decorations when it resolves. Once ready, it highlights
+ * synchronously. If shiki fails to load, code blocks stay plain text.
+ */
+export function lazyShikiParser(): Parser {
+  const loaded = loadShikiParser().then(() => undefined)
+  return (options) => (readyParser ? readyParser(options) : loaded)
 }

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -97,7 +97,10 @@ function acquireSession(
     // Hydrate from the server-rendered state the moment the doc exists, so
     // the editor binds an already-populated doc and content is in its first
     // paint; Yjs converges idempotently when the provider's sync lands.
-    if (initialStateB64) {
+    // The clients-empty guard is redundant for a just-created Y.Doc but
+    // keeps the hydration idempotent if this block ever runs on a doc
+    // that already carries state.
+    if (initialStateB64 && ydoc.store.clients.size === 0) {
       try {
         Y.applyUpdate(
           ydoc,
@@ -119,6 +122,30 @@ function acquireSession(
   }
   session.refs += 1
   return session
+}
+
+// History restores replay stale props: a back-navigation remounts the page
+// with the original seed_granted: true long after the template was applied
+// and synced. Re-applying onto a fresh local doc would duplicate the
+// template when the server state merges in, so grant consumption is made
+// durable per tab. sessionStorage is per-tab, which matches the grant's
+// scope — other tabs get fresh props (seed_granted: false once claimed).
+const seedAppliedKey = (slug: string) => `pruf:seed-applied:${slug}`
+
+function seedAlreadyApplied(slug: string): boolean {
+  try {
+    return sessionStorage.getItem(seedAppliedKey(slug)) === '1'
+  } catch {
+    return false
+  }
+}
+
+function markSeedApplied(slug: string): void {
+  try {
+    sessionStorage.setItem(seedAppliedKey(slug), '1')
+  } catch {
+    // best effort — worst case is the pre-fix behavior on history restore
+  }
 }
 
 function releaseSession(slug: string): void {
@@ -263,7 +290,8 @@ function CollabEditor({
     // someone else holds the claim — waits for the sync handshake.
     if (provider.synced || ydoc.store.clients.size > 0) {
       start()
-    } else if (seedGranted && seedMarkdown) {
+    } else if (seedGranted && seedMarkdown && !seedAlreadyApplied(slug)) {
+      markSeedApplied(slug)
       provider.seedMarkdown = seedMarkdown
       start()
     } else {

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import * as Y from 'yjs'
 import { Editor, editorViewCtx, rootCtx } from '@milkdown/kit/core'
 import { commonmark } from '@milkdown/kit/preset/commonmark'
@@ -19,11 +19,10 @@ import './table_block.css'
 import { getMarkdown } from '@milkdown/kit/utils'
 import { collab, collabServiceCtx } from '@milkdown/plugin-collab'
 import { highlight, highlightPluginConfig } from '@milkdown/plugin-highlight'
-import type { Parser } from '@milkdown/plugin-highlight/shiki'
 import { Milkdown, MilkdownProvider, useEditor } from '@milkdown/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { CableProvider } from './cable_provider'
-import { loadShikiParser } from './highlighter'
+import { lazyShikiParser, loadShikiParser } from './highlighter'
 import { imageUploader } from './upload'
 import type { UserIdentity } from './identity'
 import { provenance, provenanceIdentityCtx, collectSpans, type ProvenanceSpan } from './provenance'
@@ -61,8 +60,12 @@ interface EditorProps {
 
 const SNAPSHOT_DEBOUNCE_MS = 900
 
-// Start loading shiki at import time so the parser is warm by mount.
-const shikiParserPromise = loadShikiParser()
+// Start loading shiki at import time so it's warm as early as possible. The
+// editor never waits on it: lazyShikiParser highlights synchronously once
+// ready and upgrades already-painted code blocks in place via the plugin's
+// lazy-parser protocol. Content paint is gated on nothing.
+void loadShikiParser()
+const shikiParser = lazyShikiParser()
 
 interface CollabSession {
   ydoc: Y.Doc
@@ -77,10 +80,28 @@ interface CollabSession {
 // the claim times out. Real teardown happens after a short grace period.
 const sessions = new Map<string, CollabSession>()
 
-function acquireSession(slug: string, identity: UserIdentity): CollabSession {
+function acquireSession(
+  slug: string,
+  identity: UserIdentity,
+  initialStateB64?: string | null,
+): CollabSession {
   let session = sessions.get(slug)
   if (!session) {
     const ydoc = new Y.Doc()
+    // Hydrate from the server-rendered state the moment the doc exists, so
+    // the editor binds an already-populated doc and content is in its first
+    // paint; Yjs converges idempotently when the provider's sync lands.
+    if (initialStateB64) {
+      try {
+        Y.applyUpdate(
+          ydoc,
+          Uint8Array.from(atob(initialStateB64), (c) => c.charCodeAt(0)),
+          'server-hydrate',
+        )
+      } catch {
+        // corrupt/stale prop — fall back to the wait-for-synced path
+      }
+    }
     const provider = new CableProvider(ydoc, slug)
     provider.awareness.setLocalStateField('user', identity)
     session = { ydoc, provider, refs: 0, destroyTimer: null }
@@ -106,29 +127,15 @@ function releaseSession(slug: string): void {
   }, 1000)
 }
 
-function EditorInner(props: EditorProps) {
-  const [parser, setParser] = useState<Parser | null>(null)
-
-  useEffect(() => {
-    // Wrap in an updater: passing the parser function directly would make
-    // React call it as a state updater.
-    void shikiParserPromise.then((p) => setParser(() => p))
-  }, [])
-
-  if (!parser) return <div className="doc-editor-loading" aria-hidden />
-  return <CollabEditor {...props} parser={parser} />
-}
-
 function CollabEditor({
   slug,
   identity,
-  parser,
   initialStateB64,
   onReady,
   onStatus,
   onSpans,
   onSelection,
-}: EditorProps & { parser: Parser }) {
+}: EditorProps) {
   const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection })
   callbacksRef.current = { onReady, onStatus, onSpans, onSelection }
 
@@ -140,7 +147,7 @@ function CollabEditor({
           ctx.set(provenanceIdentityCtx.key, { name: identity.name })
           ctx.update(highlightPluginConfig.key, (prev) => ({
             ...prev,
-            parser,
+            parser: shikiParser,
             languageExtractor: (node) => (node.attrs.language as string) ?? '',
           }))
           ctx.update(uploadConfig.key, (prev) => ({
@@ -194,22 +201,8 @@ function CollabEditor({
     const editor = get()
     if (!editor) return
 
-    const { ydoc, provider } = acquireSession(slug, identity)
+    const { ydoc, provider } = acquireSession(slug, identity, initialStateB64)
     callbacksRef.current.onStatus?.('connecting')
-
-    // Hydrate from the server-rendered state so the first paint is already
-    // populated; Yjs converges idempotently when the provider's sync lands.
-    if (initialStateB64 && ydoc.store.clients.size === 0) {
-      try {
-        Y.applyUpdate(
-          ydoc,
-          Uint8Array.from(atob(initialStateB64), (c) => c.charCodeAt(0)),
-          'server-hydrate',
-        )
-      } catch {
-        // corrupt/stale prop — fall back to the wait-for-synced path
-      }
-    }
 
     let snapshotTimer: ReturnType<typeof setTimeout> | null = null
     const pushSnapshot = () => {
@@ -279,7 +272,7 @@ function CollabEditor({
 export function DocumentEditor(props: EditorProps) {
   return (
     <MilkdownProvider>
-      <EditorInner {...props} />
+      <CollabEditor {...props} />
     </MilkdownProvider>
   )
 }

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -52,6 +52,12 @@ interface EditorProps {
   /** Server-rendered Yjs state (base64) — hydrates the doc before the
    *  provider syncs, so the first paint is already populated. */
   initialStateB64?: string | null
+  /** Seed template for a never-edited document. Applied at bind time when
+   *  the page response granted this client the seed claim. */
+  seedMarkdown?: string | null
+  /** True when documents#show atomically claimed the seed for this page
+   *  load — the props-first path that skips the WebSocket round-trip. */
+  seedGranted?: boolean
   onReady?: (handle: EditorHandle) => void
   onStatus?: (status: ConnectionStatus) => void
   onSpans?: (spans: ProvenanceSpan[]) => void
@@ -131,6 +137,8 @@ function CollabEditor({
   slug,
   identity,
   initialStateB64,
+  seedMarkdown,
+  seedGranted,
   onReady,
   onStatus,
   onSpans,
@@ -247,10 +255,20 @@ function CollabEditor({
       callbacksRef.current.onStatus?.('live')
     }
 
-    // A hydrated doc binds immediately — no visible empty-editor frame. The
-    // first-ever load (no state yet) keeps waiting for the seed-claim sync.
-    if (provider.synced || ydoc.store.clients.size > 0) start()
-    else provider.on('synced', start)
+    // A hydrated doc binds immediately — no visible empty-editor frame. A
+    // fresh doc whose seed claim arrived with the page response also binds
+    // immediately, applying the template from props (the one-shot consume in
+    // start() plus applyTemplate's remote-empty guard keep this race-safe
+    // against a channel-granted seeder). Only a fresh doc with no grant —
+    // someone else holds the claim — waits for the sync handshake.
+    if (provider.synced || ydoc.store.clients.size > 0) {
+      start()
+    } else if (seedGranted && seedMarkdown) {
+      provider.seedMarkdown = seedMarkdown
+      start()
+    } else {
+      provider.on('synced', start)
+    }
 
     return () => {
       cancelled = true

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -430,13 +430,14 @@ a:focus-visible {
   padding: 3rem 2rem 6rem;
 }
 
-.doc-editor-loading {
-  min-height: 50vh;
-}
-
 /* ----------------------------- Editor typography ------------------------- */
+/* The height reservation lives on the persistent editor mount (not a
+   transient placeholder) so the layout below the editor never shifts while
+   Milkdown finishes binding — any residual pre-content frames are blank
+   within a stable layout, never a pop. */
 .milkdown {
   outline: none;
+  min-height: 50vh;
 }
 
 .milkdown .ProseMirror {

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -66,6 +66,7 @@ export interface DocumentProps {
     slug: string
     title: string
     seed_markdown: string | null
+    seed_granted: boolean
     has_state: boolean
     yjs_state_b64: string | null
   }
@@ -543,6 +544,8 @@ export default function DocumentShow({
                 slug={doc.slug}
                 identity={identity}
                 initialStateB64={doc.yjs_state_b64}
+                seedMarkdown={doc.seed_markdown}
+                seedGranted={doc.seed_granted}
                 onReady={setHandle}
                 onStatus={setStatus}
                 onSpans={setSpans}

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -104,6 +104,10 @@ class Document < ApplicationRecord
   # stale-claim reclaim when an HTTP-granted seeder never applied).
   def try_claim_seed
     return false if yjs_state.present? || seed_markdown.blank?
+    # Read-side short-circuit: a fresh claim can't be won, so don't issue
+    # a write per page load of a just-claimed doc. The conditional UPDATE
+    # below remains the single source of truth under concurrency.
+    return false if seed_state == "claimed" && seed_claimed_at&.after?(SEED_CLAIM_TIMEOUT.ago)
 
     self.class
       .where(id: id)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,10 @@
 class Document < ApplicationRecord
   DEFAULT_SEED = "# Untitled\n\nStart writing — everything you type is attributed to you.\n"
 
+  # A stale seed claim (seeder crashed or never connected before its first
+  # update persisted) is reclaimable after this window.
+  SEED_CLAIM_TIMEOUT = 30.seconds
+
   # Docs that must never be claimed: claiming's only power is delete, and
   # deleting the demo would take it away from everyone.
   UNCLAIMABLE_SLUGS = %w[demo].freeze
@@ -90,6 +94,24 @@ class Document < ApplicationRecord
     DocumentMetaChannel.broadcast_event(self, :activities) if activity
     DocumentMetaChannel.broadcast_event(self, :ownership)
     self
+  end
+
+  # Exactly one client seeds an empty document from its markdown template.
+  # The atomic UPDATE claims it; the affected-row count picks exactly one
+  # winner under concurrency. Shared by both grant paths — the HTTP page
+  # render (documents#show, so a fresh doc seeds from props without waiting
+  # for the WebSocket) and the SyncChannel subscribe handshake (fallback for
+  # stale-claim reclaim when an HTTP-granted seeder never applied).
+  def try_claim_seed
+    return false if yjs_state.present? || seed_markdown.blank?
+
+    self.class
+      .where(id: id)
+      .where(
+        "seed_state = 'pending' OR (seed_state = 'claimed' AND seed_claimed_at < ?)",
+        SEED_CLAIM_TIMEOUT.ago
+      )
+      .update_all(seed_state: "claimed", seed_claimed_at: Time.current) == 1
   end
 
   def ownership_props(viewer_token)

--- a/docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md
+++ b/docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Eliminate document-load flicker — content at first paint"
 type: fix
-status: active
+status: completed
 date: 2026-06-05
 ---
 

--- a/docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md
+++ b/docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md
@@ -1,0 +1,255 @@
+---
+title: "fix: Eliminate document-load flicker — content at first paint"
+type: fix
+status: active
+date: 2026-06-05
+---
+
+# fix: Eliminate document-load flicker — content at first paint
+
+## Summary
+
+Loading a document shows a short flicker: a blank 50vh placeholder paints first, then the editor and content pop in. The user requirement is **zero visible flicker** — everything needed for first paint must arrive via Inertia props (which it already does) and actually *render* at first paint, with progressive upgrades (syntax highlighting, live collab) layering in afterward without visual disruption.
+
+Research confirms the Inertia layer is already props-first: `documents#show` ships the full document including the base64 Yjs state inline, with no deferred props and no client-side fetches gating first paint. The flicker lives entirely in the client editor bring-up chain in `app/frontend/editor/milkdown_editor.tsx`:
+
+1. **Shiki gate (primary).** `EditorInner` returns an empty `.doc-editor-loading` div (min-height 50vh) until the shiki highlighter — 15 grammars + theme + regex engine — finishes loading. The entire document is invisible until then. Blank page → content pop = the flicker.
+2. **Milkdown async creation.** `useEditor` builds the editor asynchronously; `<Milkdown />` renders an empty root for a few frames after shiki resolves, before the Yjs doc binds.
+3. **New-document seed path.** A never-edited doc has no Yjs state; its seed content appears only after the ActionCable subscription round-trip grants the seed claim — the worst-case blank window, even though `seed_markdown` is already in props.
+
+The fix inverts the dependency: the editor mounts and paints content immediately from props-hydrated state; syntax highlighting upgrades in place when shiki arrives; new docs seed from props via an HTTP-time claim instead of waiting on the WebSocket.
+
+---
+
+## Problem Frame
+
+**Observed:** Visible flicker on every document load — blank space where the document should be, then content appears.
+
+**Root cause:** Client-side render gates, not data availability. All data is in the initial Inertia response; the page component (`app/frontend/pages/documents/show.tsx`) renders header/rails synchronously from props — but the editor area withholds content behind async initialization (shiki, Milkdown creation, and for new docs, the WebSocket seed handshake).
+
+**Goal:** Document content visible at the editor's first paint with no blank placeholder, no content pop, and no layout shift. Progressive enhancement (highlighting, live cursors) must layer in without visual disruption.
+
+**Out of scope:** SSR (the app has none; first paint is client-rendered and that stays), dev-mode-only CSS injection flash from Vite (does not affect production), and the cosmetic `connecting → live` status dot transition.
+
+---
+
+## Requirements
+
+- **R1** — No blank placeholder or content pop when loading an existing document: document text is present the moment the editor area first paints.
+- **R2** — All data needed for first paint arrives via Inertia props (preserve the existing props-first contract; no new client-side fetches, no mount-time `router.reload`).
+- **R3** — Brand-new documents (no Yjs state yet) render their seed content without waiting for the ActionCable round-trip.
+- **R4** — Syntax highlighting still works; it may upgrade progressively (plain code block → highlighted) but must not cause layout shift or block content paint.
+- **R5** — No collab regressions: Yjs convergence, single-seeder guarantee, StrictMode-safe session reuse, snapshot push, and reconnect behavior all preserved.
+
+---
+
+## Key Technical Decisions
+
+1. **Decouple shiki from editor mount (hot-swap parser), rather than pre-rendering static HTML.** The editor module is statically imported (already in the main chunk) and Milkdown creation is pure CPU work — the only slow async dependency is shiki's grammar/engine loading. Mounting the editor immediately with a passthrough parser and swapping in the shiki parser when it resolves removes the dominant flicker source with no second rendering pipeline. A server- or client-rendered static markdown preview was considered and rejected: it requires a second markdown renderer whose output must pixel-match ProseMirror's, otherwise the editor-swap itself becomes a new flicker (see Alternatives).
+2. **Hydrate the Y.Doc at session creation, not in the post-mount effect.** `yjs_state_b64` is already in props; applying it when `acquireSession` creates the Y.Doc (instead of inside the `loading`-gated effect) means the doc is populated before the editor ever binds, so bind paints content in the same frame.
+3. **Move the seed claim to the HTTP response for page loads.** `SyncChannel#claim_seed?` already implements atomic first-claim-wins with stale-claim timeout reclaim. Extract that into the `Document` model and let `documents#show` attempt the claim when the doc has no state, passing `seed_granted` + the seed markdown via props. The client applies the template at bind time (local doc empty, remote doc empty — the existing double-guard holds) and then connects. The channel-side claim path remains for resilience (stale-claim reclaim when an HTTP-granted seeder never applies). This is the genuinely props-first answer to R3 and reuses the existing claim state machine rather than inventing a parallel one.
+4. **Defense in depth on layout stability.** Even with gates removed, a 1–2 frame empty-editor window can exist on slow devices. Keep the editor container dimensionally stable (reserve min-height on the mount container, not on a separate placeholder div) so any residual frames are blank-within-stable-layout rather than layout shift + pop.
+
+---
+
+## High-Level Technical Design
+
+Current vs. target load sequence for an existing document:
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (first paint)
+    participant S as Shiki loader
+    participant M as Milkdown
+    participant C as ActionCable
+
+    rect rgb(255, 235, 235)
+    note over B: CURRENT — content gated behind shiki
+    B->>B: render header/rails from props
+    B->>B: render EMPTY 50vh placeholder
+    S-->>B: parser resolves (hundreds of ms cold)
+    B->>M: create editor (async)
+    M-->>B: bind hydrated Y.Doc → content POPS in
+    end
+
+    rect rgb(235, 255, 235)
+    note over B: TARGET — content at first editor paint
+    B->>B: render header/rails from props
+    B->>B: hydrate Y.Doc from props (sync, at session create)
+    B->>M: create editor with passthrough parser
+    M-->>B: bind → content paints (plain code blocks)
+    S-->>B: parser resolves later
+    B->>M: hot-swap highlight config → code blocks colorize in place
+    B->>C: connect collab (background, never gates paint)
+    end
+```
+
+New-document seed flow (target):
+
+```mermaid
+sequenceDiagram
+    participant S as documents#show (HTTP)
+    participant P as Page (props)
+    participant E as Editor
+    participant CH as SyncChannel
+
+    S->>S: no yjs_state → attempt atomic seed claim
+    S->>P: props { seed_granted: true, seed_markdown }
+    P->>E: bind time: applyTemplate(seed) — local+remote empty, guard holds
+    E->>CH: connect() → seeded content syncs out
+    note over CH: channel claim path kept as fallback<br/>(stale-claim timeout reclaim unchanged)
+```
+
+Diagrams are directional; prose and per-unit approach notes are authoritative.
+
+---
+
+## Implementation Units
+
+### U1. Mount the editor immediately; hot-swap the shiki parser
+
+**Goal:** Remove the `!parser` gate so the document paints without waiting for shiki; highlighting upgrades in place when ready.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** none
+
+**Files:**
+- `app/frontend/editor/milkdown_editor.tsx` (modify — remove `EditorInner` gate, add parser hot-swap effect)
+- `app/frontend/editor/highlighter.ts` (modify — export a synchronous passthrough parser alongside the async loader)
+- `app/frontend/entrypoints/application.css` (modify — retire `.doc-editor-loading` or repurpose per U4)
+
+**Approach:**
+- `EditorInner` no longer returns the empty placeholder. `CollabEditor` is created with a synchronous passthrough parser (`() => []` — code blocks render as plain text with their existing block styling; no decorations).
+- When the module-level `shikiParserPromise` resolves, update the live editor's `highlightPluginConfig` via `editor.action((ctx) => ctx.update(highlightPluginConfig.key, …))` and trigger a re-decoration pass so visible code blocks colorize.
+- **Deferred to implementation:** the exact mechanism to force the highlight plugin to recompute decorations after a config swap (the plugin recomputes on doc changes; a no-op transaction dispatch or the plugin's own refresh hook are candidates). If hot-swap proves infeasible in `@milkdown/plugin-highlight` 7.x, fallback: inspect the props-supplied markdown (`seed_markdown` / hydrated doc) for fenced code blocks (markdown ``` delimiters; inline code does not count) and only await shiki when the document actually contains them — documents without fenced code (the common case) never wait. **The fallback is a last resort and a known R1 carve-out for fence-bearing documents — if used, record it explicitly in the PR so the residual flicker for that subset is tracked, not silently accepted.** Hot-swap is the target.
+- Highlighting is color-only (decorations), so the upgrade causes no layout shift (R4).
+
+**Patterns to follow:** existing `ctx.update(...PluginConfig.key, ...)` calls in the same file's `Editor.make().config` block; the module-level warm-load pattern (`shikiParserPromise`) stays.
+
+**Test scenarios:**
+- Loading a document with no fenced code blocks paints text without any shiki wait (verify via type check + browser verification; no JS unit framework exists).
+- Loading a document containing fenced code blocks shows the code as plain text first, then colorized — same block dimensions before/after (no layout shift).
+- Shiki load failure (network error) leaves the editor fully functional with plain code blocks — the passthrough parser never throws.
+- Test expectation: frontend behavior verified via `npm run check` (tsc) and the browser-test pass — repo has no JS unit-test framework; minitest cannot reach this layer.
+
+**Verification:** Cold-load a document with code blocks (disable cache): document text visible at editor first paint; code blocks colorize afterward without movement.
+
+---
+
+### U2. Hydrate the Y.Doc at session creation
+
+**Goal:** The Y.Doc is populated from `yjs_state_b64` before the editor binds, so bind renders content immediately instead of after an effect-time hydration.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** none (lands cleanly with or before U1)
+
+**Files:**
+- `app/frontend/editor/milkdown_editor.tsx` (modify — move the `Y.applyUpdate` hydration from the post-`loading` effect into `acquireSession`)
+
+**Approach:**
+- `acquireSession(slug, identity, initialStateB64)` applies the base64 state right after `new Y.Doc()`, guarded by `ydoc.store.clients.size === 0` exactly as today (idempotent across StrictMode remounts and session reuse — a reused session already has clients and skips).
+- Keep the existing `try/catch` for corrupt/stale props falling back to the wait-for-synced path.
+- The bind-time branch (`provider.synced || ydoc.store.clients.size > 0`) is unchanged and now always takes the immediate path for existing documents.
+
+**Patterns to follow:** the session map's StrictMode-safety comments and structure (`sessions`, `acquireSession`, `releaseSession`) — preserve the ref-counting and grace-period teardown untouched.
+
+**Test scenarios:**
+- Existing document (has Yjs state): bind happens synchronously on first effect run — no empty-editor frame between editor creation and content.
+- StrictMode double-mount: hydration applies exactly once (second mount sees `clients.size > 0`).
+- Corrupt `yjs_state_b64` prop: editor still loads via the synced fallback path, no crash.
+- Test expectation: verified via `npm run check` + browser pass (no JS unit framework).
+
+**Verification:** With network throttled, an existing document's text appears in the same paint as the editor surface — no empty-editor flash.
+
+---
+
+### U3. Props-first seed for brand-new documents
+
+**Goal:** A fresh document renders its seed content at bind time from props, instead of blank-until-WebSocket-handshake.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U2 (bind-time flow is the integration point)
+
+**Files:**
+- `app/models/document.rb` (modify — extract atomic seed claim into a model method, e.g. claim-seed with stale-reclaim semantics)
+- `app/channels/sync_channel.rb` (modify — `claim_seed?` delegates to the model method; behavior unchanged)
+- `app/controllers/documents_controller.rb` (modify — `show` attempts the claim when `yjs_state` is blank and HTML is being served; adds `seed_granted` to the document prop)
+- `app/frontend/pages/documents/show.tsx` (modify — pass seed grant through to the editor)
+- `app/frontend/editor/milkdown_editor.tsx` (modify — apply template at bind time when granted via props; skip waiting for `synced`)
+- `app/frontend/editor/cable_provider.ts` (modify only if needed — the channel may still grant a seed on sync; the client must not double-apply)
+- `test/integration/document_seed_claim_test.rb` (create)
+- `test/channels/sync_channel_test.rb` (modify — cover delegation)
+
+**Approach:**
+- The atomic `update_all` claim logic (first-claim-wins, stale `seed_claimed_at` reclaim) currently lives **only** in `SyncChannel#claim_seed?` — the `Document` model has no seed methods today. This unit creates a new model method (e.g. `Document#try_claim_seed`) carrying that logic verbatim, so HTTP and channel paths share one state machine.
+- `documents#show`: when the doc has no state and has seed markdown, attempt the claim; on grant, include `seed_granted: true` in props — a **new** prop introduced by this unit (seed markdown is already shipped as `seed_markdown`).
+- Client: when `seed_granted` arrives via props, the bind gate in `milkdown_editor.tsx` changes — instead of `provider.on('synced', start)` for empty docs, a props-granted client calls `start()` immediately and applies the template there, then `connect()`s. This is what removes the ActionCable round-trip from the paint path (R3). The existing `applyTemplate` remote-empty double-guard stays as the race backstop. Consume one-shot exactly like the current `provider.seedMarkdown = null` pattern so remounts never re-apply.
+- The channel-side grant path stays: if an HTTP-granted client never connects (closed tab), the stale-claim timeout lets the next subscriber reclaim — identical to today's crashed-seeder recovery. Client must tolerate receiving a channel seed grant it already satisfied via props (the one-shot consume + remote-empty guard cover this; verify in implementation).
+- JSON/txt/agent requests in `show` must NOT claim the seed — only the HTML editor render path does (an agent fetching state should never burn the claim).
+
+**Test scenarios:**
+- `GET show` (HTML) on a stateless doc with seed markdown: claim transitions to `claimed`, props include the grant. Second concurrent-style request: no grant (already claimed, not stale).
+- Covers seed atomicity: two claim attempts, exactly one wins (model-level test mirroring the existing channel guarantee).
+- Stale claim (`seed_claimed_at` older than timeout): a later `show` request reclaims and gets the grant.
+- Doc with existing `yjs_state`: `show` never attempts a claim; no `seed_granted` in props.
+- JSON and agent-UA requests on a stateless doc: no claim attempted.
+- Channel path regression: `SyncChannel` still grants the seed to a subscriber when the doc is unclaimed (delegation works).
+- Integration: granted page load → editor applies template → connect → seeded content persists (snapshot/state lands server-side).
+
+**Verification:** Create a new document, load it on a throttled connection: seed content visible at editor first paint, before the WebSocket connects. Existing channel tests stay green.
+
+---
+
+### U4. Stable editor container — no layout shift in residual frames
+
+**Goal:** Any remaining sub-perceptual empty frames occur inside a dimensionally stable layout — nothing below the editor jumps when content binds.
+
+**Requirements:** R1
+
+**Dependencies:** U1 (placeholder div is removed there)
+
+**Files:**
+- `app/frontend/entrypoints/application.css` (modify — move the min-height reservation onto the persistent editor container / `.milkdown` mount, remove the now-dead `.doc-editor-loading` rule)
+- `app/frontend/pages/documents/show.tsx` (modify if the container needs a class hook)
+
+**Approach:** Reserve the same `min-height: 50vh` on the always-present editor mount container instead of a transient placeholder div, so the DOM never swaps a sized element for an unsized one. Audit that header, margin-suggestion rail, and comments rail don't reflow when the editor binds.
+
+**Test scenarios:**
+- Test expectation: none — pure CSS/layout change with no behavioral logic; covered by the browser-pass layout-shift check in Verification.
+
+**Verification:** Record a load with DevTools performance/layout-shift overlay: CLS contribution from the editor area is zero; footer/rails don't move when content binds.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the document show page's first-paint path (editor bring-up, seed claim plumbing), and the minimal CSS to keep layout stable.
+
+**Not in scope (true non-goals):**
+- SSR — out of the product's current architecture; first paint remains client-rendered.
+- The `connecting → live` status dot transition — cosmetic, not layout shift.
+- Presence polling / ActionCable subscription timing — none of it gates first paint today.
+
+### Deferred to Follow-Up Work
+- Dev-only flash of unstyled editor from Vite's JS-injected CSS (`prosemirror.css`, `tables.css`, `table_block.css` static imports) — does not affect production builds; fix separately if dev DX warrants.
+- Lazy-loading shiki grammars per-language (load only grammars the document uses) — a payload optimization, orthogonal once the gate is removed.
+- Capturing this fix as the repo's first `docs/solutions/` learning (no knowledge base exists yet).
+
+---
+
+## Risks & Dependencies
+
+- **Highlight config hot-swap is unverified in `@milkdown/plugin-highlight` 7.x** (the one execution-time unknown). Mitigated by the U1 fallback: gate on shiki only when the document actually contains code fences — which still satisfies R1 for the common no-code case and keeps R4 intact for code-bearing docs.
+- **Seed protocol change (U3) touches the single-seeder guarantee.** Mitigated by reusing the exact atomic claim + stale-reclaim state machine (extracted, not reimplemented), keeping the `applyTemplate` remote-empty double-guard, and full minitest coverage of both claim paths. The dogfood-report learning applies: no new mount-time reloads, and non-GET redirects keep `status: :see_other`.
+- **StrictMode regressions** if session/hydration ordering changes (U2). The session-reuse map and its guards are preserved verbatim; hydration moves but keeps its idempotency guard.
+
+---
+
+## Sources & Research
+
+- Repo research: full document-show flow traced through `app/controllers/documents_controller.rb`, `app/frontend/pages/documents/show.tsx`, `app/frontend/editor/milkdown_editor.tsx`, `app/frontend/editor/highlighter.ts`, `app/frontend/editor/cable_provider.ts`, `app/channels/sync_channel.rb`. Confirmed: no deferred Inertia props, no client-side initial-data fetches; flicker is editor bring-up.
+- Institutional context: `docs/plans/2026-06-05-001-feat-proof-clone-collaborative-editor-plan.md` (origin architecture — props-first by design, theme-cookie "server knows everything at first paint" precedent), `docs/REVIEW-NOTES.md` ("no useEffect+fetch for page data" is documented policy), `docs/dogfood-reports/2026-06-05-feat-proof-clone-dogfood.md` (batched-reload learning — add no mount-time reloads).
+- External research: skipped — fix area is fully local with strong existing patterns; the single library-behavior unknown (highlight config hot-swap) is deferred to implementation with a designed fallback.

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -36,6 +36,17 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert_nil transmissions.last["seed"]
   end
 
+  test "an HTTP page-render claim blocks the channel grant while fresh" do
+    doc = Document.create!(title: "PreClaimed", seed_markdown: "# Template")
+    assert doc.try_claim_seed, "HTTP path should win the fresh claim"
+
+    subscribe slug: doc.slug
+
+    assert subscription.confirmed?
+    assert_nil transmissions.last["seed"],
+               "channel must not re-grant a seed freshly claimed by documents#show"
+  end
+
   test "documents with existing state never seed" do
     doc = Document.create!(title: "Existing", seed_markdown: "# Template")
     YjsPersistence.merge(doc, build_update_b64("already here"))
@@ -80,7 +91,7 @@ class SyncChannelTest < ActionCable::Channel::TestCase
 
     # The claim is consumed but reclaimable after timeout because the no-op
     # merge did not flip seed_state to "seeded".
-    travel SyncChannel::SEED_CLAIM_TIMEOUT + 1.second do
+    travel Document::SEED_CLAIM_TIMEOUT + 1.second do
       unsubscribe
       subscribe slug: doc.slug
       assert_equal true, transmissions.last["seed"], "doc must remain seedable after a no-op merge"

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -37,7 +37,27 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
       assert_inertia_props do |props|
         props[:document][:seed_granted] == true
       end
+      assert_equal "claimed", @document.reload.seed_state
     end
+  end
+
+  test "Inertia partial reloads never touch the seed claim" do
+    get document_page_path(@document.slug), headers: browser.merge(
+      "X-Inertia" => "true",
+      "X-Inertia-Partial-Component" => "documents/show",
+      "X-Inertia-Partial-Data" => "presences"
+    )
+
+    assert_equal "pending", @document.reload.seed_state,
+                 "a partial reload must not burn or refresh the claim"
+  end
+
+  test "prefetch-shaped requests never claim the seed" do
+    get document_page_path(@document.slug), headers: browser.merge("Sec-Purpose" => "prefetch")
+    assert_equal "pending", @document.reload.seed_state
+
+    get document_page_path(@document.slug), headers: browser.merge("Purpose" => "prefetch")
+    assert_equal "pending", @document.reload.seed_state
   end
 
   test "documents with existing state never grant the seed" do
@@ -75,10 +95,15 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
     assert_equal "pending", @document.reload.seed_state
   end
 
-  test "exactly one of two concurrent claims wins at the model level" do
-    results = [ @document.try_claim_seed, Document.find(@document.id).try_claim_seed ]
+  # Exercises the conditional-UPDATE guard with two independent record
+  # instances loaded before either claim runs. In-process calls can't
+  # reproduce a true DB-level race — the WHERE clause's affected-row count
+  # is the atomicity authority under real concurrency.
+  test "exactly one of two competing claims wins at the model level" do
+    first = Document.find(@document.id)
+    second = Document.find(@document.id)
 
-    assert_equal [ true, false ], results
+    assert_equal [ true, false ], [ first.try_claim_seed, second.try_claim_seed ]
   end
 
   test "an HTML grant blocks the channel grant while fresh" do

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+# The HTTP-side seed grant: documents#show atomically claims the seed for a
+# fresh document so the editor applies its template from props instead of
+# waiting for the SyncChannel round-trip. The channel path keeps the same
+# claim (delegated to Document#try_claim_seed) as the stale-claim fallback.
+class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(title: "Fresh", seed_markdown: "# Template")
+  end
+
+  test "first HTML page load of a stateless doc gets the seed grant" do
+    get document_page_path(@document.slug), headers: browser
+
+    assert_response :ok
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == true &&
+        props[:document][:seed_markdown] == "# Template"
+    end
+    assert_equal "claimed", @document.reload.seed_state
+  end
+
+  test "second page load while the claim is fresh gets no grant" do
+    get document_page_path(@document.slug), headers: browser
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == false
+    end
+  end
+
+  test "a stale claim is reclaimable by a later page load" do
+    get document_page_path(@document.slug), headers: browser
+
+    travel Document::SEED_CLAIM_TIMEOUT + 1.second do
+      get document_page_path(@document.slug), headers: browser
+      assert_inertia_props do |props|
+        props[:document][:seed_granted] == true
+      end
+    end
+  end
+
+  test "documents with existing state never grant the seed" do
+    @document.update!(yjs_state: "x")
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == false
+    end
+    assert_equal "pending", @document.reload.seed_state
+  end
+
+  test "documents without seed markdown never grant the seed" do
+    doc = Document.create!(title: "Blank", seed_markdown: nil)
+
+    get document_page_path(doc.slug), headers: browser
+
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == false
+    end
+  end
+
+  test "agent and JSON fetches never burn the claim" do
+    get "/d/#{@document.slug}", headers: { "User-Agent" => "curl/8.6.0" }
+    assert_response :ok
+    assert_equal "pending", @document.reload.seed_state
+
+    get "/d/#{@document.slug}", headers: browser.merge("Accept" => "application/json")
+    assert_response :ok
+    assert_equal "pending", @document.reload.seed_state
+
+    get "/d/#{@document.slug}?format=txt", headers: browser
+    assert_response :ok
+    assert_equal "pending", @document.reload.seed_state
+  end
+
+  test "exactly one of two concurrent claims wins at the model level" do
+    results = [ @document.try_claim_seed, Document.find(@document.id).try_claim_seed ]
+
+    assert_equal [ true, false ], results
+  end
+
+  test "an HTML grant blocks the channel grant while fresh" do
+    get document_page_path(@document.slug), headers: browser
+
+    assert_not Document.find(@document.id).try_claim_seed,
+               "channel path must not re-grant a freshly claimed seed"
+  end
+
+  private
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+end


### PR DESCRIPTION
## Why

Loading a document showed a short flicker: a blank 50vh placeholder painted first, then the editor and content popped in. The requirement: **zero visible flicker** — everything needed for first paint arrives via Inertia props and actually renders at first paint, with progressive upgrades layering in afterward.

Research confirmed the Inertia layer was already props-first; the flicker lived entirely in the client editor bring-up chain.

## What changed

- **No shiki gate.** The editor no longer waits for the shiki highlighter (15 grammars + engine) to mount. The highlight plugin gets a lazy parser that returns the in-flight load promise — prosemirror-highlight's documented lazy protocol — so code blocks paint plain and colorize in place when shiki resolves.
- **Early Y.Doc hydration.** `yjs_state_b64` is applied at session creation instead of in the post-mount effect, so bind renders content in the editor's first paint.
- **Props-first seed for fresh docs.** `documents#show` atomically claims the seed (logic extracted to `Document#try_claim_seed`, shared with the `SyncChannel` fallback) and ships `seed_granted`; the editor applies the template at bind time instead of waiting for the WebSocket round-trip. Agent/JSON/txt paths, Inertia partial reloads, and prefetch-shaped requests never touch the claim.
- **Stable layout.** The 50vh reservation moved from the removed placeholder div onto the persistent `.milkdown` mount — residual pre-content frames are blank-within-stable-layout, never a pop.
- **Review hardening.** Per-tab sessionStorage guard stops history restores from re-applying the seed; read-side short-circuit avoids a DB write per page load of a freshly claimed doc.

## Verification

- `bin/rails test`: 138 runs, 0 failures (8 new seed-claim integration tests + channel-level delegation test)
- Browser pass (agent-browser, dev server): new doc paints seed from props instantly; reload paints content + highlighted code at first paint; `seed_state` transitions to `seeded` server-side via sync-reply; shiki colorizes in place with no layout shift
- `npm run check`: no new type errors (one pre-existing error in `inertia.tsx` untouched)

Plan: `docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md`

## Residual Review Findings

- **P1 (correctness + adversarial, not applied — needs design):** `app/frontend/editor/milkdown_editor.tsx` — if an HTTP-granted seeder's WebSocket takes >30s to sync while another client reclaims the stale seed and seeds independently, both templates merge and duplicate. `applyTemplate`'s remote-empty guard only sees the local pre-sync doc. Mitigations in place: prefetch/partial-reload exclusions shrink the burned-grant population; the window requires a >30s WS stall plus a concurrent visitor on a brand-new doc. Proper fix: reconcile at first sync (prefer server state when non-empty and this client seeded pre-sync).
- **P2 (advisory, library-level):** prosemirror-highlight's refresh dispatch can fire on a destroyed EditorView if the user navigates away mid-shiki-load (sub-200ms window, cold cache). No crash observed; fix belongs upstream or in a thin dispatch guard.
- **P2 (pre-existing, adjacent):** a corrupt persisted server-side Yjs blob still bricks subscribers (documented in `docs/residual-review-findings/feat-proof-clone.md`); the seed path neither worsens nor fixes it — `try_claim_seed` sees a corrupt-but-present `yjs_state` as "has state" and won't re-seed.
- **P3 (advisory):** `onStatus('live')` fires from `start()` before any WS connection on the seed-granted and hydrated paths (hydrated-path behavior is pre-existing); driving 'live' from the provider's `synced` event would be more truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
