### PR TITLE
feat: claim visibility, header cleanup, and Edit/Suggest/Comment modes

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,8 +11,11 @@ class DocumentsController < InertiaController
     docs = Document.where(slug: slugs).index_by(&:slug)
     render inertia: "documents/index", props: {
       yours: yours.map { |d| d.slice(:title, :slug) },
+      # Recent rows carry ownership state so claimable docs can offer an
+      # inline claim affordance. Render-time staleness is fine: the claim
+      # POST is race-tolerant and the scoped reload reconciles the lists.
       recent: slugs.filter_map { |slug| docs[slug] unless your_slugs.include?(slug) }
-                   .map { |d| d.slice(:title, :slug) }
+                   .map { |d| d.slice(:title, :slug).merge(d.ownership_props(owner_token)) }
     }
   end
 

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -32,8 +32,8 @@ class SuggestionsController < InertiaController
     log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
-    redirect_back fallback_location: document_page_path(@suggestion.document.slug),
-                  inertia: { errors: { suggestion: "is no longer pending" }, status: :see_other }
+    redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other,
+                  inertia: { errors: { suggestion: "is no longer pending" } }
   end
 
   def reject
@@ -41,14 +41,19 @@ class SuggestionsController < InertiaController
     log_and_broadcast("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
-    redirect_back fallback_location: document_page_path(@suggestion.document.slug),
-                  inertia: { errors: { suggestion: "is no longer pending" }, status: :see_other }
+    redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other,
+                  inertia: { errors: { suggestion: "is no longer pending" } }
   end
 
   private
 
   def set_suggestion
     @suggestion = Suggestion.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    # The suggestion (or its doc) was deleted while the card was on screen —
+    # redirect back cleanly instead of a 404 modal over the editor.
+    redirect_back fallback_location: root_path, status: :see_other,
+                  inertia: { errors: { suggestion: "is no longer available" } }
   end
 
   def log_and_broadcast(action, detail)

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -1,5 +1,31 @@
 class SuggestionsController < InertiaController
-  before_action :set_suggestion
+  before_action :set_suggestion, only: [ :accept, :reject ]
+
+  # Browser-facing suggest-a-change (Suggest mode). Mirrors comments#create:
+  # the session display name wins over the posted one, the author kind is
+  # forced server-side — a browser can never mint agent/ai-attributed
+  # suggestions — and everything flows through propose! so activity logging
+  # and the live broadcast stay uniform with the agent path.
+  def create
+    document = Document.find_by!(slug: params[:slug])
+    Suggestion.propose!(
+      document:,
+      author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
+      author_kind: "human",
+      body: params[:body].to_s,
+      intent: (params[:intent].presence if params[:intent].is_a?(String)),
+      anchor_text: (params[:anchor_text].presence if params[:anchor_text].is_a?(String)),
+      replaces: (params[:replaces].presence if params[:replaces].is_a?(String))
+    )
+
+    redirect_back fallback_location: document_page_path(document.slug), status: :see_other
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_back fallback_location: document_page_path(params[:slug]), status: :see_other,
+                  inertia: { errors: { suggestion: e.record.errors.full_messages.to_sentence } }
+  rescue ActiveRecord::RecordNotFound
+    # The doc was deleted while the composer was open — go home cleanly.
+    redirect_to root_path, status: :see_other
+  end
 
   def accept
     @suggestion.accept!(by: preferred_name(params[:by], fallback: "human"))

--- a/app/frontend/components/claim_banner.tsx
+++ b/app/frontend/components/claim_banner.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { useClaim } from '../lib/use_claim'
+import type { OwnershipPayload } from './ownership_chip'
+
+interface Props {
+  slug: string
+  ownership: OwnershipPayload
+  claimerName: string
+}
+
+const dismissKey = (slug: string) => `pruf:claim-banner:${slug}`
+
+const readDismissed = (slug: string): boolean => {
+  try {
+    return localStorage.getItem(dismissKey(slug)) === '1'
+  } catch {
+    return false
+  }
+}
+
+const writeDismissed = (slug: string): void => {
+  try {
+    localStorage.setItem(dismissKey(slug), '1')
+  } catch {
+    // private mode — the dismissal just won't persist
+  }
+}
+
+/**
+ * Prominent claim CTA for unclaimed claimable docs — the primary claim
+ * surface (the header menu keeps a fallback item). The per-slug dismiss
+ * flag gates ONLY this banner element: ownership transitions still ride
+ * the `:ownership` broadcast and the header re-renders to "Owned by ‹name›"
+ * regardless of the stored flag, so a dismissed visitor is never offered
+ * a doomed claim.
+ */
+export function ClaimBanner({ slug, ownership, claimerName }: Props) {
+  const [dismissed, setDismissed] = useState(() => readDismissed(slug))
+  const { claim, claiming, claimFailed } = useClaim(slug, claimerName, {
+    only: ['ownership', 'activities'],
+    optimistic: (props: { ownership?: OwnershipPayload }) => ({
+      ownership: { ...(props.ownership ?? ownership), claimed: true, yours: true },
+    }),
+  })
+
+  // claimable goes false the moment anyone claims (broadcast → scoped
+  // reload) — the banner unmounts for every viewer without local wiring.
+  if (!ownership.claimable || dismissed) return null
+
+  return (
+    <div className="claim-banner" role="region" aria-label="Claim this document">
+      <span className="claim-banner-text">
+        This doc belongs to no one yet — claim it to your account to manage it.
+      </span>
+      <span className="claim-banner-actions">
+        <button className="btn btn-primary claim-banner-claim" disabled={claiming} onClick={claim}>
+          {claimFailed ? 'Try again' : claiming ? 'Claiming…' : 'Claim this doc'}
+        </button>
+        <button
+          className="claim-banner-dismiss"
+          aria-label="Dismiss"
+          title="Dismiss — you can still claim from the header menu"
+          onClick={() => {
+            writeDismissed(slug)
+            setDismissed(true)
+          }}
+        >
+          ×
+        </button>
+      </span>
+    </div>
+  )
+}

--- a/app/frontend/components/claim_banner.tsx
+++ b/app/frontend/components/claim_banner.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useClaim } from '../lib/use_claim'
+import { getStoredFlag, setStoredFlag } from '../lib/local_storage'
 import type { OwnershipPayload } from './ownership_chip'
 
 interface Props {
@@ -10,22 +11,6 @@ interface Props {
 
 const dismissKey = (slug: string) => `pruf:claim-banner:${slug}`
 
-const readDismissed = (slug: string): boolean => {
-  try {
-    return localStorage.getItem(dismissKey(slug)) === '1'
-  } catch {
-    return false
-  }
-}
-
-const writeDismissed = (slug: string): void => {
-  try {
-    localStorage.setItem(dismissKey(slug), '1')
-  } catch {
-    // private mode — the dismissal just won't persist
-  }
-}
-
 /**
  * Prominent claim CTA for unclaimed claimable docs — the primary claim
  * surface (the header menu keeps a fallback item). The per-slug dismiss
@@ -35,7 +20,7 @@ const writeDismissed = (slug: string): void => {
  * a doomed claim.
  */
 export function ClaimBanner({ slug, ownership, claimerName }: Props) {
-  const [dismissed, setDismissed] = useState(() => readDismissed(slug))
+  const [dismissed, setDismissed] = useState(() => getStoredFlag(dismissKey(slug), false))
   const { claim, claiming, claimFailed } = useClaim(slug, claimerName, {
     only: ['ownership', 'activities'],
     optimistic: (props: { ownership?: OwnershipPayload }) => ({
@@ -61,7 +46,7 @@ export function ClaimBanner({ slug, ownership, claimerName }: Props) {
           aria-label="Dismiss"
           title="Dismiss — you can still claim from the header menu"
           onClick={() => {
-            writeDismissed(slug)
+            setStoredFlag(dismissKey(slug), true)
             setDismissed(true)
           }}
         >

--- a/app/frontend/components/header_menu.tsx
+++ b/app/frontend/components/header_menu.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useMediaQuery } from '../lib/use_media_query'
+import { OwnershipChip, type OwnershipPayload } from './ownership_chip'
+import { FeedbackButton } from './feedback_button'
+
+interface Props {
+  panelOpen: boolean
+  onTogglePanel: () => void
+  focusMode: boolean
+  onToggleFocus: () => void
+  slug: string
+  ownership: OwnershipPayload
+  claimerName: string
+}
+
+/**
+ * The header's `⋯` overflow menu — content layer over the same popover
+ * mechanics as SharePopover (anchored absolute panel, outside-mousedown +
+ * Escape to close). Holds the secondary chrome (Panel/Focus toggles,
+ * Feedback) and the ownership section: "Yours" + delete confirm, "Owned by
+ * ‹name›", or the fallback Claim item (the banner is the primary claim CTA).
+ */
+export function HeaderMenu({
+  panelOpen,
+  onTogglePanel,
+  focusMode,
+  onToggleFocus,
+  slug,
+  ownership,
+  claimerName,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  // Same constraint as SharePopover: the sticky header's backdrop-filter is
+  // the containing block for fixed descendants — the mobile sheet must
+  // portal to body.
+  const isMobile = useMediaQuery('(max-width: 48rem)')
+
+  useEffect(() => {
+    if (!open) return
+    const close = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (rootRef.current?.contains(target) || popoverRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    document.addEventListener('keydown', esc)
+    return () => {
+      document.removeEventListener('mousedown', close)
+      document.removeEventListener('keydown', esc)
+    }
+  }, [open])
+
+  const ownershipLabel = ownership.yours
+    ? 'Your document'
+    : ownership.claimed
+      ? 'Ownership'
+      : ownership.claimable
+        ? 'Claim'
+        : null
+
+  return (
+    <div className="share-root header-menu-root" ref={rootRef}>
+      <button
+        className="chrome-toggle header-menu-trigger"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="More options"
+        title="More options"
+        onClick={() => setOpen((v) => !v)}
+      >
+        ⋯
+      </button>
+      {open &&
+        (() => {
+          const popover = (
+            <div
+              className="share-popover header-menu-popover"
+              ref={popoverRef}
+              role="dialog"
+              aria-label="Document options"
+              onClick={(event) => event.stopPropagation()}
+            >
+          <div className="share-section">
+            <div className="share-section-title">View</div>
+            <div className="header-menu-row">
+              <button
+                className="chrome-toggle"
+                aria-pressed={panelOpen}
+                title="Hide/show panel — ⌘\"
+                onClick={onTogglePanel}
+              >
+                Panel
+              </button>
+              <button
+                className="chrome-toggle"
+                aria-pressed={focusMode}
+                title="Suggestion focus — ⌘."
+                onClick={onToggleFocus}
+              >
+                Focus
+              </button>
+            </div>
+          </div>
+          {ownershipLabel && (
+            <div className="share-section">
+              <div className="share-section-title">{ownershipLabel}</div>
+              <div className="header-menu-row">
+                <OwnershipChip slug={slug} ownership={ownership} claimerName={claimerName} />
+              </div>
+            </div>
+          )}
+          <div className="share-section">
+            <div className="share-section-title">Feedback</div>
+            <div className="header-menu-row">
+              <FeedbackButton />
+            </div>
+          </div>
+            </div>
+          )
+          return isMobile
+            ? createPortal(
+                <div className="share-backdrop" onClick={() => setOpen(false)}>
+                  {popover}
+                </div>,
+                document.body,
+              )
+            : popover
+        })()}
+    </div>
+  )
+}

--- a/app/frontend/components/header_menu.tsx
+++ b/app/frontend/components/header_menu.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useMediaQuery } from '../lib/use_media_query'
+import { useDismissable } from '../lib/use_dismissable'
 import { OwnershipChip, type OwnershipPayload } from './ownership_chip'
 import { FeedbackButton } from './feedback_button'
 
@@ -37,24 +38,7 @@ export function HeaderMenu({
   // the containing block for fixed descendants — the mobile sheet must
   // portal to body.
   const isMobile = useMediaQuery('(max-width: 48rem)')
-
-  useEffect(() => {
-    if (!open) return
-    const close = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (rootRef.current?.contains(target) || popoverRef.current?.contains(target)) return
-      setOpen(false)
-    }
-    const esc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', close)
-    document.addEventListener('keydown', esc)
-    return () => {
-      document.removeEventListener('mousedown', close)
-      document.removeEventListener('keydown', esc)
-    }
-  }, [open])
+  useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
 
   const ownershipLabel = ownership.yours
     ? 'Your document'

--- a/app/frontend/components/margin_suggestions.tsx
+++ b/app/frontend/components/margin_suggestions.tsx
@@ -254,6 +254,9 @@ export function MarginSuggestions({
               <del className="margin-old">{truncate(suggestion.replaces, 120)}</del>
             )}
             <p className="margin-new">{truncate(suggestion.body, 280)}</p>
+            {/* Optimistic placeholders (negative id) have no server row yet —
+                hide actions until the real id arrives from the reload. */}
+            {suggestion.id > 0 && (
             <div className="suggestion-actions">
               <button
                 className="btn-accept"
@@ -276,6 +279,7 @@ export function MarginSuggestions({
                 Reject
               </button>
             </div>
+            )}
           </div>
         )
       })}

--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
+import { useDismissable } from '../lib/use_dismissable'
 
 export type EditorMode = 'edit' | 'suggest' | 'comment'
 
@@ -29,23 +30,7 @@ interface Props {
 export function ModeControl({ mode, onChange, locked = false }: Props) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const close = (e: MouseEvent) => {
-      if (rootRef.current?.contains(e.target as Node)) return
-      setOpen(false)
-    }
-    const esc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', close)
-    document.addEventListener('keydown', esc)
-    return () => {
-      document.removeEventListener('mousedown', close)
-      document.removeEventListener('keydown', esc)
-    }
-  }, [open])
+  useDismissable(open, () => setOpen(false), [rootRef])
 
   return (
     <div className="share-root mode-control" ref={rootRef}>

--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react'
+
+export type EditorMode = 'edit' | 'suggest' | 'comment'
+
+export const MODE_LABELS: Record<EditorMode, string> = {
+  edit: 'Edit',
+  suggest: 'Suggest',
+  comment: 'Comment',
+}
+
+const MODE_HINTS: Record<EditorMode, string> = {
+  edit: 'Type directly into the document',
+  suggest: 'Propose changes for review — nothing edits the doc directly',
+  comment: 'Read-only — select text to comment',
+}
+
+interface Props {
+  mode: EditorMode
+  onChange: (mode: EditorMode) => void
+  /** Demo doc: control renders but stays locked to Edit. */
+  locked?: boolean
+}
+
+/**
+ * Google-Docs-style mode switcher: a compact header dropdown showing the
+ * current mode, opening to the three modes with hints. Per-visitor UI state
+ * only — switching never affects other collaborators.
+ */
+export function ModeControl({ mode, onChange, locked = false }: Props) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const close = (e: MouseEvent) => {
+      if (rootRef.current?.contains(e.target as Node)) return
+      setOpen(false)
+    }
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    document.addEventListener('keydown', esc)
+    return () => {
+      document.removeEventListener('mousedown', close)
+      document.removeEventListener('keydown', esc)
+    }
+  }, [open])
+
+  return (
+    <div className="share-root mode-control" ref={rootRef}>
+      <button
+        className="chrome-toggle mode-control-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Mode: ${MODE_LABELS[mode]}`}
+        title={locked ? 'Mode switching is disabled on the demo doc' : MODE_HINTS[mode]}
+        disabled={locked}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {MODE_LABELS[mode]}
+        <span className="mode-control-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div className="share-popover mode-control-popover" role="listbox" aria-label="Editor mode">
+          {(Object.keys(MODE_LABELS) as EditorMode[]).map((value) => (
+            <button
+              key={value}
+              role="option"
+              aria-selected={mode === value}
+              className={`mode-control-option ${mode === value ? 'is-active' : ''}`}
+              onClick={() => {
+                onChange(value)
+                setOpen(false)
+              }}
+            >
+              <span className="mode-control-option-label">{MODE_LABELS[value]}</span>
+              <span className="mode-control-option-hint">{MODE_HINTS[value]}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/frontend/components/ownership_chip.tsx
+++ b/app/frontend/components/ownership_chip.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { router } from '@inertiajs/react'
+import { useClaim } from '../lib/use_claim'
 
 export interface OwnershipPayload {
   claimed: boolean
@@ -28,21 +29,22 @@ interface Props {
  * as if it were current would mislead.
  */
 export function OwnershipChip({ slug, ownership, claimerName }: Props) {
-  const [claimFailed, setClaimFailed] = useState(false)
   const [confirming, setConfirming] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  // Refs guard double-fires synchronously — state updates only take effect
+  // Ref guards double-fires synchronously — state updates only take effect
   // after the next render commit, leaving a same-frame window for a second
   // click (Enter bounce, mobile double-tap) to dispatch a duplicate request.
-  const claimInFlight = useRef(false)
   const deleteInFlight = useRef(false)
 
-  // A failed claim offers "Try again" for a beat, then settles back.
-  useEffect(() => {
-    if (!claimFailed) return
-    const timer = setTimeout(() => setClaimFailed(false), 3000)
-    return () => clearTimeout(timer)
-  }, [claimFailed])
+  // Shared claim primitive — same hook as the index rows and claim banner.
+  const { claim, claimFailed } = useClaim(slug, claimerName, {
+    // Scoped like acceptSuggestion — the redirect-back must never re-ship
+    // the document prop's embedded Yjs state.
+    only: ['ownership', 'activities'],
+    optimistic: (props: { ownership?: OwnershipPayload }) => ({
+      ownership: { ...(props.ownership ?? ownership), claimed: true, yours: true },
+    }),
+  })
 
   if (ownership.yours) {
     if (confirming) {
@@ -99,34 +101,6 @@ export function OwnershipChip({ slug, ownership, claimerName }: Props) {
   }
 
   if (!ownership.claimable) return null
-
-  const claim = () => {
-    if (claimInFlight.current) return
-    claimInFlight.current = true
-    setClaimFailed(false)
-    router
-      .optimistic((props: { ownership?: OwnershipPayload }) => ({
-        ownership: { ...(props.ownership ?? ownership), claimed: true, yours: true },
-      }))
-      .post(
-        `/d/${slug}/claim`,
-        { name: claimerName },
-        {
-          preserveScroll: true,
-          // Scoped like acceptSuggestion — the redirect-back must never
-          // re-ship the document prop's embedded Yjs state.
-          only: ['ownership', 'activities'],
-          async: true,
-          // A lost race arrives as an error + refreshed ownership prop; the
-          // chip re-renders to "Owned by ‹winner›" on its own. "Try again"
-          // only matters when the doc is still unclaimed (network blip).
-          onError: () => setClaimFailed(true),
-          onFinish: () => {
-            claimInFlight.current = false
-          },
-        },
-      )
-  }
 
   return (
     <button

--- a/app/frontend/components/selection_toolbar.tsx
+++ b/app/frontend/components/selection_toolbar.tsx
@@ -3,6 +3,8 @@ import { Fragment } from 'react'
 interface Action {
   label: string
   onClick: () => void
+  disabled?: boolean
+  title?: string
 }
 
 interface Props {
@@ -26,7 +28,9 @@ export function SelectionToolbar({ position, actions }: Props) {
       {actions.map((action, i) => (
         <Fragment key={action.label}>
           {i > 0 && <span className="selection-toolbar-sep" />}
-          <button onClick={action.onClick}>{action.label}</button>
+          <button onClick={action.onClick} disabled={action.disabled} title={action.title}>
+            {action.label}
+          </button>
         </Fragment>
       ))}
     </div>

--- a/app/frontend/components/selection_toolbar.tsx
+++ b/app/frontend/components/selection_toolbar.tsx
@@ -1,11 +1,20 @@
+import { Fragment } from 'react'
+
+interface Action {
+  label: string
+  onClick: () => void
+}
+
 interface Props {
   position: { x: number; y: number }
-  onComment: () => void
-  onAskAi: () => void
+  /** Mode-gated action list (Edit: Comment · Ask AI; Suggest: Suggest a
+   *  change; Comment: Comment). Renders nothing when empty. */
+  actions: Action[]
 }
 
 /** Floating actions over a non-empty text selection. */
-export function SelectionToolbar({ position, onComment, onAskAi }: Props) {
+export function SelectionToolbar({ position, actions }: Props) {
+  if (actions.length === 0) return null
   return (
     <div
       className="selection-toolbar"
@@ -14,9 +23,12 @@ export function SelectionToolbar({ position, onComment, onAskAi }: Props) {
       role="toolbar"
       aria-label="Selection actions"
     >
-      <button onClick={onComment}>Comment</button>
-      <span className="selection-toolbar-sep" />
-      <button onClick={onAskAi}>Ask AI</button>
+      {actions.map((action, i) => (
+        <Fragment key={action.label}>
+          {i > 0 && <span className="selection-toolbar-sep" />}
+          <button onClick={action.onClick}>{action.label}</button>
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/app/frontend/components/share_popover.tsx
+++ b/app/frontend/components/share_popover.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useMediaQuery } from '../lib/use_media_query'
+import { useDismissable } from '../lib/use_dismissable'
 import { ThemePicker } from './theme_picker'
 
 /** Share is two audiences, one URL: humans get the editor, agents fetching the
@@ -30,23 +31,7 @@ export function SharePopover({ agentsActive }: { agentsActive: number }) {
     })
   }, [])
 
-  useEffect(() => {
-    if (!open) return
-    const close = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (rootRef.current?.contains(target) || popoverRef.current?.contains(target)) return
-      setOpen(false)
-    }
-    const esc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', close)
-    document.addEventListener('keydown', esc)
-    return () => {
-      document.removeEventListener('mousedown', close)
-      document.removeEventListener('keydown', esc)
-    }
-  }, [open])
+  useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
 
   const popover = (
     <div

--- a/app/frontend/components/suggest_composer.tsx
+++ b/app/frontend/components/suggest_composer.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { truncate } from '../lib/truncate'
+
+interface Props {
+  /** The selected text the suggestion proposes to replace. */
+  target: string
+  position: { x: number; y: number }
+  onSubmit: (replacement: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Suggest-mode composer: quoted original + replacement textarea, floating at
+ * the selection (a fixed bottom sheet on small screens via CSS — same shape
+ * the comment composer takes when it routes into the mobile sheet).
+ *
+ * A dedicated component rather than a parameterized comment composer: the
+ * comment form is one body field embedded in the comments rail; this one is
+ * an original→replacement pair posting replaces/anchor_text to a different
+ * endpoint — parameterizing would entangle two unrelated forms.
+ *
+ * Empty replacement disables submit (no server round-trip); validation
+ * errors (size caps) surface via the Inertia error shape and redirect_back,
+ * mirroring comments.
+ */
+export function SuggestComposer({ target, position, onSubmit, onCancel }: Props) {
+  const [body, setBody] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    const trimmed = body.trim()
+    if (!trimmed) return
+    onSubmit(trimmed)
+  }
+
+  return (
+    <form
+      className="suggest-composer"
+      style={{ left: position.x, top: position.y }}
+      role="dialog"
+      aria-label="Suggest a change"
+      onSubmit={submit}
+    >
+      <del className="suggest-composer-old">{truncate(target, 120)}</del>
+      <textarea
+        ref={textareaRef}
+        className="comment-input"
+        rows={3}
+        placeholder="Suggest replacement text…"
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) submit(event)
+          if (event.key === 'Escape') onCancel()
+        }}
+      />
+      <div className="comment-composer-actions">
+        <button type="submit" className="btn-accept" disabled={!body.trim()}>
+          Suggest
+        </button>
+        <button type="button" className="btn-reject" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/app/frontend/components/suggest_composer.tsx
+++ b/app/frontend/components/suggest_composer.tsx
@@ -5,6 +5,10 @@ interface Props {
   /** The selected text the suggestion proposes to replace. */
   target: string
   position: { x: number; y: number }
+  /** Server validation/network error — rendered inline; the composer stays
+   *  open so the typed replacement is never destroyed. */
+  error?: string | null
+  submitting?: boolean
   onSubmit: (replacement: string) => void
   onCancel: () => void
 }
@@ -23,7 +27,14 @@ interface Props {
  * errors (size caps) surface via the Inertia error shape and redirect_back,
  * mirroring comments.
  */
-export function SuggestComposer({ target, position, onSubmit, onCancel }: Props) {
+export function SuggestComposer({
+  target,
+  position,
+  error = null,
+  submitting = false,
+  onSubmit,
+  onCancel,
+}: Props) {
   const [body, setBody] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -34,7 +45,7 @@ export function SuggestComposer({ target, position, onSubmit, onCancel }: Props)
   const submit = (event: FormEvent) => {
     event.preventDefault()
     const trimmed = body.trim()
-    if (!trimmed) return
+    if (!trimmed || submitting) return
     onSubmit(trimmed)
   }
 
@@ -59,9 +70,10 @@ export function SuggestComposer({ target, position, onSubmit, onCancel }: Props)
           if (event.key === 'Escape') onCancel()
         }}
       />
+      {error && <p className="suggest-composer-error">{error}</p>}
       <div className="comment-composer-actions">
-        <button type="submit" className="btn-accept" disabled={!body.trim()}>
-          Suggest
+        <button type="submit" className="btn-accept" disabled={!body.trim() || submitting}>
+          {submitting ? 'Suggesting…' : 'Suggest'}
         </button>
         <button type="button" className="btn-reject" onClick={onCancel}>
           Cancel

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import * as Y from 'yjs'
-import { Editor, editorViewCtx, rootCtx } from '@milkdown/kit/core'
+import { Editor, editorViewCtx, editorViewOptionsCtx, rootCtx } from '@milkdown/kit/core'
 import { commonmark } from '@milkdown/kit/preset/commonmark'
 import { gfm } from '@milkdown/kit/preset/gfm'
 import { listener, listenerCtx } from '@milkdown/kit/plugin/listener'
@@ -58,6 +58,12 @@ interface EditorProps {
   /** True when documents#show atomically claimed the seed for this page
    *  load — the props-first path that skips the WebSocket round-trip. */
   seedGranted?: boolean
+  /** Read-only gate for Suggest/Comment modes. Implemented EXCLUSIVELY as
+   *  ProseMirror `editable: () => false` — provider connection, Yjs sync,
+   *  agent edits, programmatic dispatch, and seed application stay
+   *  mode-independent (a restored read-only mode must never burn the seed
+   *  claim). Defaults to editable. */
+  editable?: boolean
   onReady?: (handle: EditorHandle) => void
   onStatus?: (status: ConnectionStatus) => void
   onSpans?: (spans: ProvenanceSpan[]) => void
@@ -166,6 +172,7 @@ function CollabEditor({
   initialStateB64,
   seedMarkdown,
   seedGranted,
+  editable = true,
   onReady,
   onStatus,
   onSpans,
@@ -173,6 +180,10 @@ function CollabEditor({
 }: EditorProps) {
   const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection })
   callbacksRef.current = { onReady, onStatus, onSpans, onSelection }
+  // Ref so the editable() closure always reads the live value; the effect
+  // below nudges ProseMirror to re-read it when the mode changes.
+  const editableRef = useRef(editable)
+  editableRef.current = editable
 
   const { get, loading } = useEditor(
     (root) =>
@@ -180,6 +191,12 @@ function CollabEditor({
         .config((ctx) => {
           ctx.set(rootCtx, root)
           ctx.set(provenanceIdentityCtx.key, { name: identity.name })
+          // Read-only modes gate USER input only — ProseMirror still accepts
+          // programmatic transactions (Yjs sync, seeding, suggestion accept).
+          ctx.update(editorViewOptionsCtx, (prev) => ({
+            ...prev,
+            editable: () => editableRef.current,
+          }))
           ctx.update(highlightPluginConfig.key, (prev) => ({
             ...prev,
             parser: shikiParser,
@@ -311,6 +328,24 @@ function CollabEditor({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, slug])
+
+  // ProseMirror caches editable at each state update; an empty transaction
+  // makes it re-read the prop when the mode flips. Safe pre-bind: the action
+  // no-ops until the view exists.
+  useEffect(() => {
+    if (loading) return
+    const editor = get()
+    if (!editor) return
+    try {
+      editor.action((ctx) => {
+        const view = ctx.get(editorViewCtx)
+        view.dispatch(view.state.tr)
+      })
+    } catch {
+      // view not mounted yet — the initial editable value applies at bind
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editable, loading])
 
   return <Milkdown />
 }

--- a/app/frontend/editor/suggestions.ts
+++ b/app/frontend/editor/suggestions.ts
@@ -66,8 +66,12 @@ export function findTextRange(
 
 /**
  * Merge an accepted suggestion into the live document. The inserted text
- * carries AI provenance (kind: ai, author, state: pending) so accepted
- * machine prose stays visibly machine prose until a human reviews it.
+ * carries provenance matching its author kind: machine authors (ai/agent)
+ * get `kind: ai, state: pending` so accepted machine prose stays visibly
+ * machine prose until a human reviews it; human authors get the same marks
+ * the provenance writer applies to typed text (`kind: human, state:
+ * verbatim`) — human prose must never inflate the AI percentages or enter
+ * the AI review-state machinery (which keys on kind === 'ai').
  *
  * - `replaces` present and found → the matched range is replaced
  * - `anchor_text` present and found → content inserted after that block
@@ -115,14 +119,15 @@ export function applySuggestion(
       insertSize = parsed.content.size
     }
 
+    const human = suggestion.author_kind === 'human'
     tr = tr.addMark(
       insertFrom,
       insertFrom + insertSize,
-      markType.create({
-        kind: 'ai',
-        author: suggestion.author_name,
-        state: 'pending',
-      }),
+      markType.create(
+        human
+          ? { kind: 'human', author: suggestion.author_name, state: 'verbatim' }
+          : { kind: 'ai', author: suggestion.author_name, state: 'pending' },
+      ),
     )
     tr.setMeta(SKIP_PROVENANCE, true)
     tr.setSelection(TextSelection.near(tr.doc.resolve(insertFrom + insertSize)))

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1538,6 +1538,48 @@ a:focus-visible {
   color: var(--ink-faint);
 }
 
+/* Suggest-mode composer — floating at the selection on desktop, a fixed
+   bottom sheet on small screens (same shape as the mobile comment sheet). */
+.suggest-composer {
+  position: fixed;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 20rem;
+  max-width: calc(100vw - 1.5rem);
+  background: var(--surface-raised);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgb(0 0 0 / 0.14);
+  padding: 0.65rem;
+  animation: popover-in 140ms ease;
+}
+
+.suggest-composer-old {
+  font-size: 0.76rem;
+  color: var(--ink-faint);
+  text-decoration: line-through;
+  line-height: 1.4;
+}
+
+@media (max-width: 48rem) {
+  .suggest-composer {
+    left: 0 !important;
+    right: 0;
+    top: auto !important;
+    bottom: 0;
+    width: auto;
+    max-width: none;
+    border-radius: 14px 14px 0 0;
+  }
+}
+
+.selection-toolbar button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* Header chrome toggles (panel / focus). */
 .chrome-toggle {
   border: 1px solid var(--line);

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -351,6 +351,53 @@ a:focus-visible {
   flex-direction: column;
 }
 
+/* ------------------------------ Claim banner ------------------------------ */
+/* In normal flow below the sticky header (not sticky itself) so the popover
+   anchor math — which only accounts for the 52px header band — is untouched. */
+.claim-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.55rem 1rem;
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--line);
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+
+.claim-banner-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.claim-banner-claim {
+  font-size: 0.8rem;
+  padding: 0.32rem 0.75rem;
+}
+
+.claim-banner-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-faint);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.claim-banner-dismiss:hover {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+}
+
 .doc-header {
   position: sticky;
   top: 0;

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1556,6 +1556,12 @@ a:focus-visible {
   animation: popover-in 140ms ease;
 }
 
+.suggest-composer-error {
+  font-size: 0.74rem;
+  color: #b3261e;
+  line-height: 1.4;
+}
+
 .suggest-composer-old {
   font-size: 0.76rem;
   color: var(--ink-faint);

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1481,6 +1481,63 @@ a:focus-visible {
   flex-wrap: wrap;
 }
 
+/* Mode switcher (Edit / Suggest / Comment). */
+.mode-control-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.mode-control-trigger:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.mode-control-caret {
+  font-size: 0.6rem;
+}
+
+.mode-control-popover {
+  width: 16rem;
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.mode-control-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+  border-radius: 7px;
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mode-control-option:hover {
+  background: var(--accent-soft);
+}
+
+.mode-control-option.is-active {
+  background: var(--accent-soft);
+}
+
+.mode-control-option-label {
+  font-size: 0.8rem;
+  font-weight: 550;
+  color: var(--ink);
+}
+
+.mode-control-option-hint {
+  font-size: 0.7rem;
+  color: var(--ink-faint);
+}
+
 /* Header chrome toggles (panel / focus). */
 .chrome-toggle {
   border: 1px solid var(--line);

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1437,21 +1437,48 @@ a:focus-visible {
   margin-left: -7px;
 }
 
+/* Share is the header's primary action — inked like btn-primary, sized for
+   the chrome row. Everything secondary lives in the ⋯ menu. */
 .share-button {
-  border: 1px solid var(--line);
-  background: var(--surface-raised);
-  color: var(--ink);
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--surface);
   font-size: 0.74rem;
   font-weight: 550;
   border-radius: 7px;
-  padding: 0.28rem 0.7rem;
+  padding: 0.28rem 0.8rem;
   cursor: pointer;
   transition: border-color 120ms ease, background 120ms ease;
   min-width: 4rem;
 }
 
 .share-button:hover {
-  border-color: var(--ink-faint);
+  background: #000;
+  border-color: #000;
+}
+
+/* Header right side groups: people cluster · mode · Share · ⋯ menu. */
+.doc-header-people {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.header-menu-trigger {
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0.28rem 0.5rem;
+}
+
+.header-menu-popover {
+  width: 13.5rem;
+}
+
+.header-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
 }
 
 /* Header chrome toggles (panel / focus). */

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -227,6 +227,48 @@ a:focus-visible {
   line-height: 1.5;
 }
 
+/* Recent rows: title link + optional claim icon / owner label inline. */
+.recent-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.recent-row a {
+  flex: 1;
+  min-width: 0;
+}
+
+.recent-claim {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-faint);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.recent-claim:hover {
+  background: var(--accent-soft);
+  color: var(--ink);
+}
+
+.recent-claim:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.recent-owner {
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
 /* --------------------------- Agent create card ---------------------------- */
 .landing-agent {
   margin-top: 2.5rem;

--- a/app/frontend/lib/local_storage.ts
+++ b/app/frontend/lib/local_storage.ts
@@ -1,0 +1,37 @@
+/**
+ * localStorage with private-mode tolerance: reads fall back, writes are
+ * best-effort. One implementation for every stored UI flag/string (panel,
+ * focus, editor mode, banner dismissals).
+ */
+export function getStoredFlag(key: string, fallback: boolean): boolean {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw === null ? fallback : raw === '1'
+  } catch {
+    return fallback
+  }
+}
+
+export function setStoredFlag(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? '1' : '0')
+  } catch {
+    // private mode — the flag just won't persist
+  }
+}
+
+export function getStoredString(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function setStoredString(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // private mode — the value just won't persist
+  }
+}

--- a/app/frontend/lib/use_claim.ts
+++ b/app/frontend/lib/use_claim.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+import { router } from '@inertiajs/react'
+
+interface UseClaimOptions {
+  /** Inertia props to reload on settle — page-specific (e.g. ['ownership',
+   *  'activities'] on the doc page, ['yours', 'recent'] on the index). */
+  only: string[]
+  /** Optional optimistic-props updater applied before the POST. */
+  optimistic?: (props: Record<string, unknown>) => Record<string, unknown>
+}
+
+/**
+ * Shared claim primitive for every claim surface (index row, doc banner,
+ * header menu item). Owns the POST, the synchronous in-flight guard (refs
+ * because state commits a frame too late for Enter-bounce/double-tap), and
+ * the silent race handling: a lost race arrives as an Inertia error plus a
+ * refreshed ownership prop — the UI re-renders to the winner on its own, no
+ * error modal. `claimFailed` only matters for genuine network blips and
+ * settles back after a beat.
+ */
+export function useClaim(slug: string, claimerName: string, options: UseClaimOptions) {
+  const [claimFailed, setClaimFailed] = useState(false)
+  const [claiming, setClaiming] = useState(false)
+  const inFlight = useRef(false)
+
+  useEffect(() => {
+    if (!claimFailed) return
+    const timer = setTimeout(() => setClaimFailed(false), 3000)
+    return () => clearTimeout(timer)
+  }, [claimFailed])
+
+  const claim = () => {
+    if (inFlight.current) return
+    inFlight.current = true
+    setClaiming(true)
+    setClaimFailed(false)
+    const r = options.optimistic ? router.optimistic(options.optimistic) : router
+    r.post(
+      `/d/${slug}/claim`,
+      { name: claimerName },
+      {
+        preserveScroll: true,
+        only: options.only,
+        async: true,
+        onError: () => setClaimFailed(true),
+        onFinish: () => {
+          inFlight.current = false
+          setClaiming(false)
+        },
+      },
+    )
+  }
+
+  return { claim, claiming, claimFailed }
+}

--- a/app/frontend/lib/use_dismissable.ts
+++ b/app/frontend/lib/use_dismissable.ts
@@ -1,0 +1,30 @@
+import { useEffect, type RefObject } from 'react'
+
+/**
+ * Shared popover dismissal: outside mousedown or Escape closes. Pass every
+ * ref that counts as "inside" (trigger root, portaled popover).
+ */
+export function useDismissable(
+  open: boolean,
+  onClose: () => void,
+  refs: RefObject<HTMLElement | null>[],
+): void {
+  useEffect(() => {
+    if (!open) return
+    const close = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (refs.some((ref) => ref.current?.contains(target))) return
+      onClose()
+    }
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', close)
+    document.addEventListener('keydown', esc)
+    return () => {
+      document.removeEventListener('mousedown', close)
+      document.removeEventListener('keydown', esc)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+}

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -2,16 +2,54 @@ import { useCallback, useState } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { userIdentity } from '../../editor/identity'
+import { useClaim } from '../../lib/use_claim'
 
 interface DocLink {
   title: string
   slug: string
 }
 
+interface RecentDoc extends DocLink {
+  claimed: boolean
+  claimable: boolean
+  owner_name: string | null
+  yours: boolean
+}
+
 interface Props {
   yours: DocLink[]
-  recent: DocLink[]
+  recent: RecentDoc[]
   viewer: { name: string | null; guest: boolean }
+}
+
+/**
+ * Inline claim icon for a claimable Recent row. On win the scoped reload
+ * moves the row to "Your docs"; on a lost race the row re-renders with the
+ * winner's name — no error modal (the hook swallows the Inertia error).
+ */
+function RecentClaimButton({ slug, claimerName }: { slug: string; claimerName: string }) {
+  const { claim, claiming, claimFailed } = useClaim(slug, claimerName, {
+    only: ['yours', 'recent'],
+  })
+  return (
+    <button
+      className="recent-claim"
+      aria-label="Claim this document"
+      title={claimFailed ? 'Claim failed — try again' : 'Claim this document'}
+      disabled={claiming}
+      onClick={claim}
+    >
+      <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+        <path
+          d="M8 1.5l1.8 3.9 4.2.5-3.1 2.9.8 4.2L8 10.9 4.3 13l.8-4.2L2 5.9l4.2-.5L8 1.5z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </button>
+  )
 }
 
 export default function DocumentsIndex({ yours, recent, viewer }: Props) {
@@ -84,10 +122,19 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
             {recent.length > 0 ? (
               <ul>
                 {recent.map((doc) => (
-                  <li key={doc.slug}>
+                  <li key={doc.slug} className="recent-row">
                     <Link href={`/d/${doc.slug}`} prefetch>
                       {doc.title}
                     </Link>
+                    {doc.claimable && (
+                      <RecentClaimButton
+                        slug={doc.slug}
+                        claimerName={userIdentity(viewer.name).name}
+                      />
+                    )}
+                    {doc.claimed && !doc.yours && doc.owner_name && (
+                      <span className="recent-owner">Owned by {doc.owner_name}</span>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -3,18 +3,14 @@ import { Head, Link, useForm } from '@inertiajs/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { userIdentity } from '../../editor/identity'
 import { useClaim } from '../../lib/use_claim'
+import type { OwnershipPayload } from '../../components/ownership_chip'
 
 interface DocLink {
   title: string
   slug: string
 }
 
-interface RecentDoc extends DocLink {
-  claimed: boolean
-  claimable: boolean
-  owner_name: string | null
-  yours: boolean
-}
+interface RecentDoc extends DocLink, OwnershipPayload {}
 
 interface Props {
   yours: DocLink[]

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -37,6 +37,7 @@ import { type OwnershipPayload } from '../../components/ownership_chip'
 import { ClaimBanner } from '../../components/claim_banner'
 import { HeaderMenu } from '../../components/header_menu'
 import { ModeControl, type EditorMode } from '../../components/mode_control'
+import { SuggestComposer } from '../../components/suggest_composer'
 import { SharePopover } from '../../components/share_popover'
 import {
   MobileDock,
@@ -150,9 +151,17 @@ export default function DocumentShow({
   const [reviewTarget, setReviewTarget] = useState<ReviewTarget | null>(null)
   const [selectionTarget, setSelectionTarget] = useState<SelectionTarget | null>(null)
   const [composerAnchor, setComposerAnchor] = useState<string | null>(null)
+  // Suggest-mode composer: the selected text to replace, frozen with the
+  // toolbar position it was opened from (the selection itself collapses).
+  const [suggestTarget, setSuggestTarget] = useState<{
+    text: string
+    position: { x: number; y: number }
+  } | null>(null)
   const [aiPendingCount, setAiPendingCount] = useState(0)
   const aiPending = aiPendingCount > 0
-  const prevSuggestionCount = useRef(suggestions.length)
+  const prevSuggestionCount = useRef(
+    suggestions.filter((s) => s.author_kind !== 'human').length,
+  )
   const viewRef = useRef<EditorView | null>(null)
   const [panelOpen, setPanelOpen] = useState(() => readStoredFlag('pruf:panel', true))
   const [focusMode, setFocusMode] = useState(() => readStoredFlag('pruf:focus', false))
@@ -206,14 +215,17 @@ export default function DocumentShow({
     return () => window.removeEventListener('keydown', onKey)
   }, [])
 
-  // Only a suggestion ARRIVING clears the thinking state — accept/reject
-  // shrink the list and must not re-enable Ask AI while a request is live.
+  // Only a MACHINE suggestion ARRIVING clears the thinking state —
+  // accept/reject shrink the list and must not re-enable Ask AI while a
+  // request is live, and a human suggestion (yours or a collaborator's)
+  // landing mid-request must not release the button early.
+  const machineSuggestionCount = suggestions.filter((s) => s.author_kind !== 'human').length
   useEffect(() => {
-    if (suggestions.length > prevSuggestionCount.current) {
+    if (machineSuggestionCount > prevSuggestionCount.current) {
       setAiPendingCount((count) => Math.max(0, count - 1))
     }
-    prevSuggestionCount.current = suggestions.length
-  }, [suggestions.length])
+    prevSuggestionCount.current = machineSuggestionCount
+  }, [machineSuggestionCount])
 
   // Human presence from Yjs awareness. Self is filtered out — the
   // IdentityChip represents you; a duplicate avatar next to it is noise.
@@ -473,6 +485,38 @@ export default function DocumentShow({
     [doc.slug, handle, aiPendingCount],
   )
 
+  const submitSuggestion = useCallback(
+    (target: string, replacement: string) => {
+      setSuggestTarget(null)
+      const optimisticSuggestion: SuggestionPayload = {
+        id: -Date.now(),
+        author_name: identity.name,
+        author_kind: 'human',
+        intent: null,
+        body: replacement,
+        anchor_text: target,
+        replaces: target,
+        status: 'pending',
+        created_at: new Date().toISOString(),
+      }
+      router
+        .optimistic((props: Partial<DocumentProps>) => ({
+          suggestions: [...(props.suggestions ?? []), optimisticSuggestion],
+        }))
+        .post(
+          `/d/${doc.slug}/suggestions`,
+          {
+            body: replacement,
+            replaces: target,
+            anchor_text: target,
+            author_name: identity.name,
+          },
+          { preserveScroll: true, only: ['suggestions', 'activities'], async: true },
+        )
+    },
+    [doc.slug, identity.name],
+  )
+
   const submitComment = useCallback(
     (body: string, anchorText: string | null) => {
       setComposerAnchor(null)
@@ -619,7 +663,28 @@ export default function DocumentShow({
             position={liveSelectionPosition}
             actions={[
               // Per-mode capability matrix — Edit: Comment · Ask AI;
-              // Suggest: Suggest a change (wired in U6); Comment: Comment.
+              // Suggest: Suggest a change; Comment: Comment.
+              ...(mode === 'suggest'
+                ? [
+                    {
+                      label: 'Suggest a change',
+                      // textBetween joins blocks with '\n' — a newline means
+                      // the selection spans blocks, which the per-block
+                      // anchor matching in suggestions.ts can't replace.
+                      disabled: selectionTarget.text.includes('\n'),
+                      title: selectionTarget.text.includes('\n')
+                        ? 'Suggestions work on single paragraphs — narrow your selection'
+                        : undefined,
+                      onClick: () => {
+                        setSuggestTarget({
+                          text: selectionTarget.text,
+                          position: liveSelectionPosition,
+                        })
+                        setSelectionTarget(null)
+                      },
+                    },
+                  ]
+                : []),
               ...(mode !== 'suggest'
                 ? [
                     {
@@ -643,6 +708,14 @@ export default function DocumentShow({
                   ]
                 : []),
             ]}
+          />
+        )}
+        {suggestTarget && (
+          <SuggestComposer
+            target={suggestTarget.text}
+            position={suggestTarget.position}
+            onSubmit={(replacement) => submitSuggestion(suggestTarget.text, replacement)}
+            onCancel={() => setSuggestTarget(null)}
           />
         )}
         {reviewTarget && liveReview && (

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -32,10 +32,10 @@ import { CommentsPanel, type CommentPayload } from '../../components/comments_pa
 import { SelectionToolbar } from '../../components/selection_toolbar'
 import { PresenceBar, type AgentPresencePayload } from '../../components/presence_bar'
 import { ActivityPanel } from '../../components/activity_panel'
-import { FeedbackButton } from '../../components/feedback_button'
 import { IdentityChip } from '../../components/identity_chip'
-import { OwnershipChip, type OwnershipPayload } from '../../components/ownership_chip'
+import { type OwnershipPayload } from '../../components/ownership_chip'
 import { ClaimBanner } from '../../components/claim_banner'
+import { HeaderMenu } from '../../components/header_menu'
 import { SharePopover } from '../../components/share_popover'
 import {
   MobileDock,
@@ -514,28 +514,22 @@ export default function DocumentShow({
             />
           </div>
           <div className="doc-header-right">
-            <IdentityChip identity={identity} guest={guest} onRenamed={handleRenamed} />
-            <ProvenanceSummaryChip spans={spans} />
-            <PresenceBar humans={peers} agents={presences} compact={isMobile} />
-            <button
-              className="chrome-toggle"
-              aria-pressed={panelOpen}
-              title="Hide/show panel — ⌘\"
-              onClick={() => setPanelOpen((open) => !open)}
-            >
-              Panel
-            </button>
-            <button
-              className="chrome-toggle"
-              aria-pressed={focusMode}
-              title="Suggestion focus — ⌘."
-              onClick={() => setFocusMode((focus) => !focus)}
-            >
-              Focus
-            </button>
-            <OwnershipChip slug={doc.slug} ownership={ownership} claimerName={identity.name} />
-            <FeedbackButton />
+            {/* ≤4 groups: identity/presence · (mode control) · Share · ⋯ menu */}
+            <div className="doc-header-people">
+              <IdentityChip identity={identity} guest={guest} onRenamed={handleRenamed} />
+              <ProvenanceSummaryChip spans={spans} />
+              <PresenceBar humans={peers} agents={presences} compact={isMobile} />
+            </div>
             <SharePopover agentsActive={presences.length} />
+            <HeaderMenu
+              panelOpen={panelOpen}
+              onTogglePanel={() => setPanelOpen((open) => !open)}
+              focusMode={focusMode}
+              onToggleFocus={() => setFocusMode((focus) => !focus)}
+              slug={doc.slug}
+              ownership={ownership}
+              claimerName={identity.name}
+            />
           </div>
         </header>
         <ClaimBanner slug={doc.slug} ownership={ownership} claimerName={identity.name} />

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -48,6 +48,12 @@ import {
 import { useMetaChannel } from '../../lib/use_meta_channel'
 import { useMediaQuery } from '../../lib/use_media_query'
 import { postJSON } from '../../lib/csrf'
+import {
+  getStoredFlag,
+  getStoredString,
+  setStoredFlag,
+  setStoredString,
+} from '../../lib/local_storage'
 
 export interface ActivityPayload {
   id: number
@@ -92,42 +98,13 @@ interface SelectionTarget {
   text: string
 }
 
-const readStoredFlag = (key: string, fallback: boolean): boolean => {
-  try {
-    const raw = localStorage.getItem(key)
-    return raw === null ? fallback : raw === '1'
-  } catch {
-    return fallback
-  }
-}
-
-const writeStoredFlag = (key: string, value: boolean): void => {
-  try {
-    localStorage.setItem(key, value ? '1' : '0')
-  } catch {
-    // private mode — the toggle just won't persist
-  }
-}
-
 // Editor mode persists per doc (Google-Docs semantics: your mode, your
 // browser). Client-side only by design — never server state, never shared.
 const modeKey = (slug: string) => `pruf:mode:${slug}`
 
 const readStoredMode = (slug: string): EditorMode => {
-  try {
-    const raw = localStorage.getItem(modeKey(slug))
-    return raw === 'suggest' || raw === 'comment' ? raw : 'edit'
-  } catch {
-    return 'edit'
-  }
-}
-
-const writeStoredMode = (slug: string, mode: EditorMode): void => {
-  try {
-    localStorage.setItem(modeKey(slug), mode)
-  } catch {
-    // private mode — the mode just won't persist
-  }
+  const raw = getStoredString(modeKey(slug))
+  return raw === 'suggest' || raw === 'comment' ? raw : 'edit'
 }
 
 export default function DocumentShow({
@@ -163,8 +140,8 @@ export default function DocumentShow({
     suggestions.filter((s) => s.author_kind !== 'human').length,
   )
   const viewRef = useRef<EditorView | null>(null)
-  const [panelOpen, setPanelOpen] = useState(() => readStoredFlag('pruf:panel', true))
-  const [focusMode, setFocusMode] = useState(() => readStoredFlag('pruf:focus', false))
+  const [panelOpen, setPanelOpen] = useState(() => getStoredFlag('pruf:panel', true))
+  const [focusMode, setFocusMode] = useState(() => getStoredFlag('pruf:focus', false))
   // Demo doc always opens in Edit and stays locked there.
   const modeLocked = doc.slug === 'demo'
   const [mode, setMode] = useState<EditorMode>(() =>
@@ -191,10 +168,10 @@ export default function DocumentShow({
     if (isMobile && composerAnchor !== null) setActiveSheet('comments')
   }, [isMobile, composerAnchor])
 
-  useEffect(() => writeStoredFlag('pruf:panel', panelOpen), [panelOpen])
-  useEffect(() => writeStoredFlag('pruf:focus', focusMode), [focusMode])
+  useEffect(() => setStoredFlag('pruf:panel', panelOpen), [panelOpen])
+  useEffect(() => setStoredFlag('pruf:focus', focusMode), [focusMode])
   useEffect(() => {
-    if (!modeLocked) writeStoredMode(doc.slug, mode)
+    if (!modeLocked) setStoredString(modeKey(doc.slug), mode)
   }, [mode, modeLocked, doc.slug])
 
   // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
@@ -310,7 +287,11 @@ export default function DocumentShow({
     viewRef.current = view
     const { from, to, empty } = view.state.selection
 
-    if (!view.hasFocus()) {
+    // Only require focus when the view is editable: in Suggest/Comment mode
+    // the root is contenteditable=false, which browsers never focus, so
+    // hasFocus() is always false and the focus gate would make the selection
+    // toolbar unreachable in read-only modes.
+    if (view.editable && !view.hasFocus()) {
       setReviewTarget(null)
       setSelectionTarget(null)
       return
@@ -349,7 +330,7 @@ export default function DocumentShow({
   // While a popover is open, any scroll or resize schedules one rAF-throttled
   // reposition pass (coordsAtPos for a single anchor is cheap).
   const [popoverTick, setPopoverTick] = useState(0)
-  const popoverOpen = Boolean(reviewTarget) || Boolean(selectionTarget)
+  const popoverOpen = Boolean(reviewTarget) || Boolean(selectionTarget) || Boolean(suggestTarget)
   useEffect(() => {
     if (!popoverOpen) return
     let raf = 0
@@ -397,6 +378,20 @@ export default function DocumentShow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectionTarget, spans, popoverTick, anchorPosition])
 
+  // Composer tracks its anchor text live (scroll/resize/doc edits) instead
+  // of freezing at open-time viewport coords; falls back to the frozen
+  // position when the anchor text is currently unmatchable (edited away).
+  const liveSuggestPosition = useMemo(() => {
+    if (!suggestTarget) return null
+    const view = viewRef.current
+    if (!view) return suggestTarget.position
+    const range = findTextRange(view.state.doc, suggestTarget.text)
+    if (!range) return suggestTarget.position
+    return anchorPosition(view, range.from, 320) ?? suggestTarget.position
+    // spans (doc updates) + popoverTick (scroll/resize) drive repositioning.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [suggestTarget, spans, popoverTick, anchorPosition])
+
   const liveReview = useMemo(() => {
     if (!reviewTarget) return null
     const view = viewRef.current
@@ -421,6 +416,9 @@ export default function DocumentShow({
   const acceptSuggestion = useCallback(
     (suggestion: SuggestionPayload) => {
       if (!handle) return
+      // Optimistic placeholders (negative id) have no server row yet —
+      // a PATCH against them would 404.
+      if (suggestion.id < 0) return
       // The card clears optimistically, but the CRDT insert waits for the
       // server to confirm THIS client won the accept — otherwise two windows
       // accepting concurrently would each insert the text (the loser's PATCH
@@ -449,6 +447,7 @@ export default function DocumentShow({
 
   const rejectSuggestion = useCallback(
     (suggestion: SuggestionPayload) => {
+      if (suggestion.id < 0) return
       router
         .optimistic((props: Partial<DocumentProps>) => ({
           suggestions: (props.suggestions ?? []).filter((s) => s.id !== suggestion.id),
@@ -485,34 +484,39 @@ export default function DocumentShow({
     [doc.slug, handle, aiPendingCount],
   )
 
+  // The composer stays open until the server confirms — closing eagerly
+  // would destroy the typed replacement on a validation failure with no
+  // feedback. The margin card arrives via the suggestions broadcast/reload,
+  // so no optimistic placeholder is needed (a placeholder would also render
+  // accept/reject against a row that has no server id yet).
+  const [suggestError, setSuggestError] = useState<string | null>(null)
+  const [suggestSubmitting, setSuggestSubmitting] = useState(false)
   const submitSuggestion = useCallback(
     (target: string, replacement: string) => {
-      setSuggestTarget(null)
-      const optimisticSuggestion: SuggestionPayload = {
-        id: -Date.now(),
-        author_name: identity.name,
-        author_kind: 'human',
-        intent: null,
-        body: replacement,
-        anchor_text: target,
-        replaces: target,
-        status: 'pending',
-        created_at: new Date().toISOString(),
-      }
-      router
-        .optimistic((props: Partial<DocumentProps>) => ({
-          suggestions: [...(props.suggestions ?? []), optimisticSuggestion],
-        }))
-        .post(
-          `/d/${doc.slug}/suggestions`,
-          {
-            body: replacement,
-            replaces: target,
-            anchor_text: target,
-            author_name: identity.name,
-          },
-          { preserveScroll: true, only: ['suggestions', 'activities'], async: true },
-        )
+      setSuggestError(null)
+      setSuggestSubmitting(true)
+      router.post(
+        `/d/${doc.slug}/suggestions`,
+        {
+          body: replacement,
+          replaces: target,
+          anchor_text: target,
+          author_name: identity.name,
+        },
+        {
+          preserveScroll: true,
+          only: ['suggestions', 'activities'],
+          async: true,
+          onSuccess: () => setSuggestTarget(null),
+          onError: (errors) =>
+            setSuggestError(
+              typeof errors?.suggestion === 'string'
+                ? errors.suggestion
+                : 'Could not save the suggestion — please try again',
+            ),
+          onFinish: () => setSuggestSubmitting(false),
+        },
+      )
     },
     [doc.slug, identity.name],
   )
@@ -671,10 +675,16 @@ export default function DocumentShow({
                       // textBetween joins blocks with '\n' — a newline means
                       // the selection spans blocks, which the per-block
                       // anchor matching in suggestions.ts can't replace.
-                      disabled: selectionTarget.text.includes('\n'),
+                      // The byte guard mirrors the server's anchor cap so an
+                      // oversized selection fails here, not after typing.
+                      disabled:
+                        selectionTarget.text.includes('\n') ||
+                        new TextEncoder().encode(selectionTarget.text).length > 10 * 1024,
                       title: selectionTarget.text.includes('\n')
                         ? 'Suggestions work on single paragraphs — narrow your selection'
-                        : undefined,
+                        : new TextEncoder().encode(selectionTarget.text).length > 10 * 1024
+                          ? 'Selection is too long to suggest against — narrow your selection'
+                          : undefined,
                       onClick: () => {
                         setSuggestTarget({
                           text: selectionTarget.text,
@@ -713,9 +723,14 @@ export default function DocumentShow({
         {suggestTarget && (
           <SuggestComposer
             target={suggestTarget.text}
-            position={suggestTarget.position}
+            position={liveSuggestPosition ?? suggestTarget.position}
+            error={suggestError}
+            submitting={suggestSubmitting}
             onSubmit={(replacement) => submitSuggestion(suggestTarget.text, replacement)}
-            onCancel={() => setSuggestTarget(null)}
+            onCancel={() => {
+              setSuggestTarget(null)
+              setSuggestError(null)
+            }}
           />
         )}
         {reviewTarget && liveReview && (

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -35,6 +35,7 @@ import { ActivityPanel } from '../../components/activity_panel'
 import { FeedbackButton } from '../../components/feedback_button'
 import { IdentityChip } from '../../components/identity_chip'
 import { OwnershipChip, type OwnershipPayload } from '../../components/ownership_chip'
+import { ClaimBanner } from '../../components/claim_banner'
 import { SharePopover } from '../../components/share_popover'
 import {
   MobileDock,
@@ -537,6 +538,7 @@ export default function DocumentShow({
             <SharePopover agentsActive={presences.length} />
           </div>
         </header>
+        <ClaimBanner slug={doc.slug} ownership={ownership} claimerName={identity.name} />
         <main className="doc-body">
           <div className={`doc-canvas ${focusMode ? 'is-focus' : ''}`}>
             <article className="doc-main">

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -36,6 +36,7 @@ import { IdentityChip } from '../../components/identity_chip'
 import { type OwnershipPayload } from '../../components/ownership_chip'
 import { ClaimBanner } from '../../components/claim_banner'
 import { HeaderMenu } from '../../components/header_menu'
+import { ModeControl, type EditorMode } from '../../components/mode_control'
 import { SharePopover } from '../../components/share_popover'
 import {
   MobileDock,
@@ -107,6 +108,27 @@ const writeStoredFlag = (key: string, value: boolean): void => {
   }
 }
 
+// Editor mode persists per doc (Google-Docs semantics: your mode, your
+// browser). Client-side only by design — never server state, never shared.
+const modeKey = (slug: string) => `pruf:mode:${slug}`
+
+const readStoredMode = (slug: string): EditorMode => {
+  try {
+    const raw = localStorage.getItem(modeKey(slug))
+    return raw === 'suggest' || raw === 'comment' ? raw : 'edit'
+  } catch {
+    return 'edit'
+  }
+}
+
+const writeStoredMode = (slug: string, mode: EditorMode): void => {
+  try {
+    localStorage.setItem(modeKey(slug), mode)
+  } catch {
+    // private mode — the mode just won't persist
+  }
+}
+
 export default function DocumentShow({
   document: doc,
   viewer,
@@ -134,6 +156,11 @@ export default function DocumentShow({
   const viewRef = useRef<EditorView | null>(null)
   const [panelOpen, setPanelOpen] = useState(() => readStoredFlag('pruf:panel', true))
   const [focusMode, setFocusMode] = useState(() => readStoredFlag('pruf:focus', false))
+  // Demo doc always opens in Edit and stays locked there.
+  const modeLocked = doc.slug === 'demo'
+  const [mode, setMode] = useState<EditorMode>(() =>
+    modeLocked ? 'edit' : readStoredMode(doc.slug),
+  )
 
   // ≤64rem: rail and margin cards give way to anchor markers, a bottom dock,
   // and sheets — the full product, rearranged for one hand.
@@ -157,6 +184,9 @@ export default function DocumentShow({
 
   useEffect(() => writeStoredFlag('pruf:panel', panelOpen), [panelOpen])
   useEffect(() => writeStoredFlag('pruf:focus', focusMode), [focusMode])
+  useEffect(() => {
+    if (!modeLocked) writeStoredMode(doc.slug, mode)
+  }, [mode, modeLocked, doc.slug])
 
   // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
   useEffect(() => {
@@ -520,6 +550,7 @@ export default function DocumentShow({
               <ProvenanceSummaryChip spans={spans} />
               <PresenceBar humans={peers} agents={presences} compact={isMobile} />
             </div>
+            <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
             <SharePopover agentsActive={presences.length} />
             <HeaderMenu
               panelOpen={panelOpen}
@@ -542,6 +573,7 @@ export default function DocumentShow({
                 initialStateB64={doc.yjs_state_b64}
                 seedMarkdown={doc.seed_markdown}
                 seedGranted={doc.seed_granted}
+                editable={mode === 'edit'}
                 onReady={setHandle}
                 onStatus={setStatus}
                 onSpans={setSpans}
@@ -585,14 +617,32 @@ export default function DocumentShow({
         {selectionTarget && liveSelectionPosition && (
           <SelectionToolbar
             position={liveSelectionPosition}
-            onComment={() => {
-              setComposerAnchor(selectionTarget.text)
-              setSelectionTarget(null)
-            }}
-            onAskAi={() => {
-              askAi('', selectionTarget.text)
-              setSelectionTarget(null)
-            }}
+            actions={[
+              // Per-mode capability matrix — Edit: Comment · Ask AI;
+              // Suggest: Suggest a change (wired in U6); Comment: Comment.
+              ...(mode !== 'suggest'
+                ? [
+                    {
+                      label: 'Comment',
+                      onClick: () => {
+                        setComposerAnchor(selectionTarget.text)
+                        setSelectionTarget(null)
+                      },
+                    },
+                  ]
+                : []),
+              ...(mode === 'edit'
+                ? [
+                    {
+                      label: 'Ask AI',
+                      onClick: () => {
+                        askAi('', selectionTarget.text)
+                        setSelectionTarget(null)
+                      },
+                    },
+                  ]
+                : []),
+            ]}
           />
         )}
         {reviewTarget && liveReview && (

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -12,6 +12,7 @@ class Suggestion < ApplicationRecord
   # match a real span already in the document.
   MAX_BODY_BYTES = 64.kilobytes
   MAX_ANCHOR_BYTES = 10.kilobytes
+  MAX_INTENT_BYTES = 1.kilobyte
 
   belongs_to :document
 
@@ -61,6 +62,7 @@ class Suggestion < ApplicationRecord
     errors.add(:body, "is too long") if body.to_s.bytesize > MAX_BODY_BYTES
     errors.add(:replaces, "is too long") if replaces.to_s.bytesize > MAX_BODY_BYTES
     errors.add(:anchor_text, "is too long") if anchor_text.to_s.bytesize > MAX_ANCHOR_BYTES
+    errors.add(:intent, "is too long") if intent.to_s.bytesize > MAX_INTENT_BYTES
   end
 
   def transition!(new_status, by:)

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,9 +1,17 @@
 # A proposed edit awaiting human review. Suggestions live in the database —
 # not the Yjs doc — until a human accepts one, at which point the accepting
-# client inserts the text into the CRDT carrying AI provenance marks.
+# client inserts the text into the CRDT carrying provenance marks matching
+# the author kind (AI marks for ai/agent authors, human marks for human).
 class Suggestion < ApplicationRecord
   STATUSES = %w[pending accepted rejected].freeze
-  AUTHOR_KINDS = %w[ai agent].freeze
+  AUTHOR_KINDS = %w[ai agent human].freeze
+
+  # Suggestion text is parsed into every connected client's editor on accept,
+  # so the unauthenticated create surfaces must not relay megabyte payloads.
+  # Body/replaces share one generous cap; the anchor is tighter — it has to
+  # match a real span already in the document.
+  MAX_BODY_BYTES = 64.kilobytes
+  MAX_ANCHOR_BYTES = 10.kilobytes
 
   belongs_to :document
 
@@ -11,6 +19,7 @@ class Suggestion < ApplicationRecord
   validates :author_kind, inclusion: { in: AUTHOR_KINDS }
   validates :body, presence: true
   validates :status, inclusion: { in: STATUSES }
+  validate :payloads_within_caps
 
   scope :pending, -> { where(status: "pending") }
 
@@ -47,6 +56,12 @@ class Suggestion < ApplicationRecord
   end
 
   private
+
+  def payloads_within_caps
+    errors.add(:body, "is too long") if body.to_s.bytesize > MAX_BODY_BYTES
+    errors.add(:replaces, "is too long") if replaces.to_s.bytesize > MAX_BODY_BYTES
+    errors.add(:anchor_text, "is too long") if anchor_text.to_s.bytesize > MAX_ANCHOR_BYTES
+  end
 
   def transition!(new_status, by:)
     raise ActiveRecord::RecordInvalid.new(self), "already #{status}" unless status == "pending"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   delete "d/:slug", to: "documents#destroy", as: :destroy_document
   post "d/:slug/snapshot", to: "documents#snapshot", as: :document_snapshot
   post "d/:slug/ai_suggestions", to: "ai_suggestions#create", as: :document_ai_suggestions
+  post "d/:slug/suggestions", to: "suggestions#create", as: :document_suggestions
 
   patch "suggestions/:id/accept", to: "suggestions#accept", as: :accept_suggestion
   patch "suggestions/:id/reject", to: "suggestions#reject", as: :reject_suggestion

--- a/docs/brainstorms/riffrec-feedback/2026-06-05-1854/analysis.md
+++ b/docs/brainstorms/riffrec-feedback/2026-06-05-1854/analysis.md
@@ -1,0 +1,43 @@
+# Product Feedback Analysis
+
+## Source
+
+- Source: `/Users/kieranklaassen/pruf/riffrec-2026-06-05-1854-bc6c4e.zip`
+- Source kind: `riffrec_zip`
+- URL: `https://pruf.kieranklaassen.com/d/VCDx7RNVtk`
+- Started: `2026-06-06T01:53:00.531Z`
+- Duration: `71.18` seconds
+- Browser: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36`
+- Event counts: `{'click': 6, 'network_request': 1, 'navigation': 1}`
+
+## Transcript
+
+Okay, I wanna do some feedback if I see these recents. Maybe I wanna see an icon here to claim them as well. If I open it here, it has the claim button, but maybe make it a little bit more clear, like a banner, like claim this one to your account. Also, this menu here is a little bit messy. Can we just maybe do a menu or pull it a little bit together? Share is the most important thing, I think, and just clean it up a little bit. Yeah. Yeah, panel, focus, claim, yeah, focus and claim. It's a little bit weird. And also, I want this mode similar to Google Docs where you go edit mode, suggest mode, or comment mode. So, yeah. I can go into one of the three modes, like edit, suggest, or comments.
+
+## Selected Moments
+
+| ID | Time | Why selected | Screenshot | Event evidence |
+|---|---:|---|---|---|
+| M1 | 00:06.12 | click event | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m1-6.12s-click-event.png` | click div Stop & saveRecordingPrufA collaborative editor that remembers who wrote what — humans and AI, side by side, every word... |
+| M2 | 00:13.18 | click event | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m2-13.18s-click-event.png` | click a Ideation: Cora Page-Load Speedups |
+| M3 | 00:51.11 | late-session click near complaint transcript | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m3-51.11s-late-session-click-near-complaint-transcript.png` | click div |
+| M4 | 00:52.79 | late-session click near complaint transcript | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m4-52.79s-late-session-click-near-complaint-transcript.png` | click div date: 2026-06-05 topic: cora-page-load-speedups focus: find pages that load slow for humans and ways to speed them up (... |
+| M5 | 00:58.81 | late-session click near complaint transcript | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m5-58.81s-late-session-click-near-complaint-transcript.png` | click p Codebase Context: Rails 8 + Inertia React (julik fork) + esbuild, no SSR, Redis cache, Sprockets assets, Cloudflare on... |
+| M6 | 01:11.17 | late-session click near complaint transcript | `n/a` | click button Stop and save |
+
+## Candidate Findings
+
+### F1. User reported a control that felt weird or unclickable
+
+- **Severity:** P2
+- **Observed:** Transcript or notes contain a complaint cue. Review linked moments when available and use the text to identify the affected product behavior.
+- **Expected:** The affected product behavior should either work as presented or clearly explain why it is unavailable.
+- **Evidence:** M3, M4, M5, M6
+- **Confidence:** Medium until screenshots are reviewed
+
+## Human Review Checklist
+
+- Open each selected screenshot and name the exact visible control or state.
+- Tie transcript language to the closest click or visible UI state.
+- Promote only confirmed product problems into requirements.
+- Use repo-relative screenshot paths when moving evidence into a CE requirements document.

--- a/docs/brainstorms/riffrec-feedback/2026-06-05-1854/problem-analysis.md
+++ b/docs/brainstorms/riffrec-feedback/2026-06-05-1854/problem-analysis.md
@@ -1,0 +1,24 @@
+# Problem Analysis — Riffrec session 2026-06-05 18:54 (pruf.kieranklaassen.com)
+
+Session: 71s voice + screen recording on `https://pruf.kieranklaassen.com/d/VCDx7RNVtk`. Transcript confirmed against frames; all four findings below are verbal, explicit, and tied to visible UI. Frames live in `docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/` (local-only).
+
+## 1. Visual/UI Problems
+
+1. **Doc header right side is overcrowded** — 8 elements (identity chip, provenance chip, presence bar, Panel toggle, Focus toggle, ownership chip, feedback button, Share button) sit in one undifferentiated row at equal visual weight. Location: doc page header, `app/frontend/pages/documents/show.tsx` right header group. Frames: M3 (51.1s), M5 (58.8s). Transcript: *"this menu here is a little bit messy… just clean it up a little bit… panel, focus, claim, yeah… it's a little bit weird."*
+2. **Share is visually buried** despite being, per the user, *"the most important thing."* Same location/frames as above.
+
+## 2. Functional Problems
+
+1. **No claim affordance on home-page Recent rows.** The Recent list renders title-only links; ownership/claimability metadata is not shipped to the index page at all (`documents#index` props omit it). Frame: M1 (6.1s, home page). Transcript: *"if I see these recents, maybe I wanna see an icon here to claim them as well."* Classification: missing surface (High confidence).
+
+## 3. Requirements
+
+1. Recent docs on the home page need a per-row claim affordance for claimable docs.
+2. The doc-page claim CTA needs to be clearly visible — the user suggested a banner ("claim this one to your account") rather than the current small header chip.
+3. The doc header chrome needs consolidation: secondary controls (Panel, Focus, and similar) grouped into a single menu; Share promoted to the primary action.
+4. A Google Docs-style mode switcher: the user wants to switch between **Edit**, **Suggest**, and **Comment** modes. Transcript: *"I want this mode similar to Google Docs where you go edit mode, suggest mode, or comment mode."* No mode infrastructure exists today (suggestions are margin cards proposed by agents; comments are a side panel) — this is a new capability, not a fix.
+
+## 4. Usability/UX Problems
+
+1. **Claim discoverability is low** on the doc page: the Claim button renders in the same chrome-toggle style and size as Panel/Focus (frame M3, M5), so a critical ownership action reads as a minor view toggle. Transcript: *"it has a claim button, but maybe make it a little bit more clear, like a banner, like claim this one to your account."*
+2. **Header scanability**: with everything at equal weight, the user could not parse the header quickly ("panel, focus, claim… it's a little bit weird") — grouping and hierarchy are missing rather than any control being broken. M6 (71.2s) is the Stop-and-save click ending the recording, not product friction.

--- a/docs/brainstorms/riffrec-feedback/2026-06-05-1854/requirements-kickoff.md
+++ b/docs/brainstorms/riffrec-feedback/2026-06-05-1854/requirements-kickoff.md
@@ -1,0 +1,98 @@
+---
+date: 2026-06-06
+topic: riffrec-2026-06-05-1854-bc6c4e
+---
+
+# Pruf feedback: claim visibility, header cleanup, and editor modes
+
+## Problem Frame
+
+A 71-second Riffrec feedback session on `https://pruf.kieranklaassen.com/d/VCDx7RNVtk` captured four explicit, evidence-backed asks: (1) claimable docs in the home Recent list have no claim affordance, (2) the doc-page Claim button is too subtle for an ownership-critical action, (3) the doc header chrome is overcrowded and unscannable with Share buried, and (4) the user wants a Google Docs-style Edit / Suggest / Comment mode switcher. Items 1–3 are friction in existing surfaces; item 4 is a new capability.
+
+Evidence bundle (all repo-relative under `docs/brainstorms/riffrec-feedback/2026-06-05-1854/`):
+- `analysis.md` — transcript, selected moments, candidate findings
+- `problem-analysis.md` — confirmed, categorized findings
+- `source-materials.md` — raw source manifest
+- `frames/` — screenshots (local-only)
+
+---
+
+## Actors
+
+- A1. **Browser visitor** — anonymous cookie identity (`owner_token`); can claim unclaimed docs, edit, comment.
+- A2. **Doc owner** — visitor whose token claimed the doc; gets delete rights and "Yours" badge.
+- A3. **Agents** — create docs via API, propose suggestions, post comments; cannot claim.
+
+---
+
+## Key Flows
+
+- F1. **Claim from home page** — Trigger: visitor sees a claimable doc under Recent. Steps: spot claim affordance on the row → claim without leaving the page (or via a one-hop visit) → row moves to "Your docs". Covered by: R1, R2.
+- F2. **Claim from doc page** — Trigger: visitor opens an unclaimed claimable doc. Steps: a prominent banner offers "Claim this doc to your account" → click → doc is theirs, banner dismisses, ownership broadcasts to peers. Covered by: R3, R4.
+- F3. **Scan the header** — Trigger: visitor opens any doc. Steps: header reads as: identity/presence · primary Share action · one menu holding secondary chrome (Panel, Focus, etc.). Covered by: R5, R6.
+- F4. **Switch editor mode** — Trigger: visitor picks Edit / Suggest / Comment from a mode control. Steps: Edit = today's behavior; Suggest = changes become reviewable suggestions instead of direct edits; Comment = read-only with selection-to-comment. Covered by: R7–R10.
+
+---
+
+## Requirements
+
+**Claim visibility**
+- R1. Home-page Recent rows for claimable (unclaimed, non-demo) docs show a claim affordance; claimed and own docs show none.
+- R2. Claiming from the home page binds the doc to the visitor's browser identity using the existing atomic first-claim-wins flow, and the UI reflects the result (row moves to "Your docs"; lost race shows the new owner without an error modal).
+- R3. On the doc page, an unclaimed claimable doc presents a prominent claim banner ("Claim this doc to your account") instead of relying solely on the small header chip.
+- R4. The banner respects existing claim semantics: never on claimed docs, never on the demo doc, GET-inert, dismissible without claiming.
+
+**Header cleanup**
+- R5. Secondary chrome controls (Panel, Focus, feedback) collapse into a single menu; the header right side shows at most: identity/presence, mode control, Share, menu.
+- R6. Share is the visually primary header action.
+
+**Editor modes**
+- R7. The doc page exposes a three-way mode control: Edit, Suggest, Comment. Edit is the default and matches current behavior.
+- R8. In Comment mode the editor content is read-only; selecting text offers comment composition (existing comment flow).
+- R9. In Suggest mode direct typing does not mutate the shared doc; selections offer "Suggest a change," producing a pending suggestion through the existing suggestion pipeline (margin card, accept/reject) attributed to the human visitor.
+- R10. Mode is a per-visitor, per-session UI state — it does not change other collaborators' modes and does not persist server-side.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given an unclaimed agent-created doc in my Recent list, when I activate its claim affordance, then it appears under "Your docs" with me as owner; given someone else claimed it first, I see it's owned by them and no error modal.
+- AE2. **Covers R3, R4.** Given I open an unclaimed doc, then a banner reading "Claim this doc to your account" is visible without hunting the header; dismissing it leaves the doc unclaimed and the header chip still available.
+- AE3. **Covers R5, R6.** Given I open any doc, then Panel and Focus are inside one menu, Share renders as the single primary button, and the header right side has at most four groups.
+- AE4. **Covers R7, R8.** Given I switch to Comment mode, when I type into the doc body, nothing changes in the document; when I select text, I can post a comment.
+- AE5. **Covers R9.** Given I switch to Suggest mode and select a sentence, when I submit "Suggest a change" with replacement text, then a pending suggestion appears in the margin attributed to my display name, and the doc body is unchanged until someone accepts it.
+
+---
+
+## Success Criteria
+
+- A claimable doc can be claimed from the home page without opening it.
+- The claim CTA on the doc page is unmissable to a first-time visitor.
+- The header reads in one scan: who's here, what mode, Share, everything-else menu.
+- All three modes work for a guest visitor with no account.
+
+## Scope Boundaries
+
+- **In scope:** the four findings above, on existing browser-identity trust model.
+- **Deferred for later:** inline track-changes rendering for Suggest mode (Google Docs-style in-text diff marks) — first version routes suggestions through the existing margin-card pipeline; server-persisted mode preference; comment-mode for agents.
+- **Out of scope:** accounts/auth, ownership transfer, edit-gating by mode for *other* collaborators.
+
+---
+
+## Key Decisions
+
+- Evidence first: every requirement traces to the transcript and frames (see `problem-analysis.md`).
+- Suggest mode v1 reuses the existing `Suggestion` pipeline rather than introducing track-changes editor infrastructure.
+- Mode is client-side per-visitor state, mirroring Google Docs' per-user mode semantics.
+
+## Dependencies / Assumptions
+
+- Claim flow, ownership props, and broadcast events from the 2026-06-05 claim-ownership plan are shipped and stable.
+- Suggestion model currently allows `AUTHOR_KINDS = %w[ai agent]`; human-suggested changes need that surface widened.
+- Pipeline run (LFG): findings were promoted from evidence without an interactive brainstorm confirmation; the transcript is short and explicit, so promotion risk is low.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Technical] Exact read-only mechanism in the Milkdown editor for Comment/Suggest modes.
+- [Technical] Whether home-page claim is inline (POST from index) or routes through the doc page.

--- a/docs/brainstorms/riffrec-feedback/2026-06-05-1854/review-prompt.md
+++ b/docs/brainstorms/riffrec-feedback/2026-06-05-1854/review-prompt.md
@@ -1,0 +1,49 @@
+You will be analyzing a product feedback session by examining video frames and a discussion transcript. Your goal is to identify problems, requirements, and feedback points that need to be addressed - focusing on clear problem statements rather than solutions.
+
+Here are the frames extracted from the video:
+
+<video_frames>
+- M1 (00:06.12, click event): `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m1-6.12s-click-event.png`. Events: click div Stop & saveRecordingPrufA collaborative editor that remembers who wrote what — humans and AI, side by side, every word...
+- M2 (00:13.18, click event): `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m2-13.18s-click-event.png`. Events: click a Ideation: Cora Page-Load Speedups
+- M3 (00:51.11, late-session click near complaint transcript): `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m3-51.11s-late-session-click-near-complaint-transcript.png`. Events: click div
+- M4 (00:52.79, late-session click near complaint transcript): `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m4-52.79s-late-session-click-near-complaint-transcript.png`. Events: click div date: 2026-06-05 topic: cora-page-load-speedups focus: find pages that load slow for humans and ways to speed them up (...
+- M5 (00:58.81, late-session click near complaint transcript): `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m5-58.81s-late-session-click-near-complaint-transcript.png`. Events: click p Codebase Context: Rails 8 + Inertia React (julik fork) + esbuild, no SSR, Redis cache, Sprockets assets, Cloudflare on...
+- M6 (01:11.17, late-session click near complaint transcript): `n/a`. Events: click button Stop and save
+</video_frames>
+
+Here is the transcript of the discussion that occurred during the feedback session:
+
+<discussion_transcript>
+Okay, I wanna do some feedback if I see these recents. Maybe I wanna see an icon here to claim them as well. If I open it here, it has the claim button, but maybe make it a little bit more clear, like a banner, like claim this one to your account. Also, this menu here is a little bit messy. Can we just maybe do a menu or pull it a little bit together? Share is the most important thing, I think, and just clean it up a little bit. Yeah. Yeah, panel, focus, claim, yeah, focus and claim. It's a little bit weird. And also, I want this mode similar to Google Docs where you go edit mode, suggest mode, or comment mode. So, yeah. I can go into one of the three modes, like edit, suggest, or comments.
+</discussion_transcript>
+
+Your task is to carefully analyze both the visual content and the discussion to extract actionable problem statements. Follow these guidelines:
+
+**Visual Analysis Requirements:**
+- Examine each frame carefully for UI/UX issues, bugs, design inconsistencies, or usability problems
+- Be extremely precise about what you observe: specify exact locations (e.g., "top-right corner," "navigation bar," "third item in the list")
+- Identify specific UI elements by type (button, input field, dropdown, modal, etc.)
+- Note visual problems like misalignment, poor contrast, truncated text, overlapping elements, broken layouts, etc.
+
+**Discussion Analysis Requirements:**
+- Extract feedback points, feature requests, and problems mentioned in the conversation
+- Identify requirements that are stated or implied
+- Note any pain points or frustrations expressed by participants
+- Connect visual observations with relevant discussion points when applicable
+
+**Problem Statement Guidelines:**
+- Focus on describing WHAT the problem is, not HOW to fix it
+- Be specific and actionable - avoid vague statements
+- Each problem should be clear enough that a developer or designer can understand what needs to be addressed
+- Include context about where the problem occurs and why it matters
+
+Structure your final output as follows:
+
+1. **Visual/UI Problems**: Issues observed directly in the interface
+2. **Functional Problems**: Issues related to behavior, workflow, or functionality mentioned in discussion
+3. **Requirements**: New features or capabilities requested
+4. **Usability/UX Problems**: Issues related to user experience, confusion, or workflow friction
+
+Format each problem as a clear, numbered item within its category.
+
+Your final output should contain only the analysis section with clearly categorized, numbered problem statements. Do not include scratchpad notes.

--- a/docs/brainstorms/riffrec-feedback/2026-06-05-1854/source-materials.md
+++ b/docs/brainstorms/riffrec-feedback/2026-06-05-1854/source-materials.md
@@ -1,0 +1,55 @@
+# Source Materials
+
+Use this manifest during brainstorm so requirements can be traced back to the raw feedback evidence.
+
+## Original Source
+
+- Source kind: `riffrec_zip`
+- Original path: `/Users/kieranklaassen/pruf/riffrec-2026-06-05-1854-bc6c4e.zip`
+- Local raw copy: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/raw/recording.webm`
+- Commit policy: raw media, audio chunks, zip contents, session dumps, and extracted screenshots are local-only by default; commit generated Markdown/JSON/manifests when useful for brainstorm/planning traceability.
+- Session URL: `https://pruf.kieranklaassen.com/d/VCDx7RNVtk`
+- Duration: `71.18` seconds
+
+## Analysis Artifacts
+
+- Analysis summary: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/analysis.md`
+- Problem statements: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/problem-analysis.md`
+- Review prompt: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/review-prompt.md`
+- Requirements kickoff: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/requirements-kickoff.md`
+- Structured JSON: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/analysis.json`
+
+## Transcript
+
+- Transcript status: `ok`
+- Transcript source: `riffrec_zip`
+- Transcript text lives in: `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/analysis.md` and `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/review-prompt.md`
+
+## Local-Only Frames
+
+Extracted screenshots are retained locally for agent inspection and should not be committed by default.
+
+| Moment | Time | Screenshot | Why selected |
+|---|---:|---|---|
+| M1 | 00:06.12 | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m1-6.12s-click-event.png` | click event |
+| M2 | 00:13.18 | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m2-13.18s-click-event.png` | click event |
+| M3 | 00:51.11 | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m3-51.11s-late-session-click-near-complaint-transcript.png` | late-session click near complaint transcript |
+| M4 | 00:52.79 | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m4-52.79s-late-session-click-near-complaint-transcript.png` | late-session click near complaint transcript |
+| M5 | 00:58.81 | `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m5-58.81s-late-session-click-near-complaint-transcript.png` | late-session click near complaint transcript |
+| M6 | 01:11.17 | `n/a` | late-session click near complaint transcript |
+
+All frame files:
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m1-6.12s-click-event.png`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m2-13.18s-click-event.png`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m3-51.11s-late-session-click-near-complaint-transcript.png`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m4-52.79s-late-session-click-near-complaint-transcript.png`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/frames/m5-58.81s-late-session-click-near-complaint-transcript.png`
+
+## Local Raw Files
+
+Raw files are intentionally local-only by default. Do not commit these unless the user explicitly asks and privacy/security is acceptable.
+
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/raw/events.json`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/raw/recording.webm`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/raw/session.json`
+- `/Users/kieranklaassen/pruf/docs/brainstorms/riffrec-feedback/2026-06-05-1854/raw/voice.webm`

--- a/docs/plans/2026-06-05-007-feat-claim-visibility-editor-modes-plan.md
+++ b/docs/plans/2026-06-05-007-feat-claim-visibility-editor-modes-plan.md
@@ -1,0 +1,261 @@
+---
+title: "feat: Claim visibility, header cleanup, and editor modes"
+type: feat
+status: active
+date: 2026-06-05
+origin: docs/brainstorms/riffrec-feedback/2026-06-05-1854/requirements-kickoff.md
+---
+
+# feat: Claim Visibility, Header Cleanup, and Editor Modes
+
+## Summary
+
+A Riffrec feedback session (71s, voice + screen, evidence in `docs/brainstorms/riffrec-feedback/2026-06-05-1854/`) surfaced four explicit asks: a claim affordance on home-page Recent rows, a prominent "claim this doc" banner on the doc page, a consolidated doc header with Share as the primary action, and a Google Docs-style Edit / Suggest / Comment mode switcher. The first three are visibility/hierarchy fixes on existing flows; the fourth is a new capability that reuses the existing Suggestion and Comment pipelines rather than introducing track-changes editor infrastructure.
+
+---
+
+## Problem Frame
+
+Pruf's ownership model (anonymous `owner_token` cookie, atomic first-claim-wins) shipped recently, but its UI surface is too quiet: the home Recent list ships no ownership metadata at all, and the doc-page Claim button renders at the same visual weight as the Panel/Focus view toggles. Transcript: *"it has a claim button, but maybe make it a little bit more clear, like a banner."* Meanwhile the doc header has grown to 8 equal-weight elements — *"this menu here is a little bit messy… Share is the most important thing"* — and the user wants per-visitor editor modes: *"edit mode, suggest mode, or comment mode."* Suggestions today are agent-only margin cards; comments exist but there is no read-only stance a human can adopt.
+
+---
+
+## Assumptions
+
+Headless-mode inferred bets (pipeline run; flow-analysis defaults adopted — see origin doc for evidence):
+
+- **Ownership status moves into the overflow menu after header consolidation.** "Yours" + delete confirm, "Owned by ‹name›", and a fallback "Claim" item live in the new menu; the banner is the primary claim CTA. The standalone `OwnershipChip` placement in the header row goes away.
+- **Accepted human suggestions carry human provenance and skip the AI review-state machinery.** Threading `author_kind` through the accept path is in scope — silently counting human prose as AI would break the product's core attribution promise.
+- **Read-only modes restrict direct typing only.** Accepting/rejecting suggestions, advancing AI review states, and resolving comments remain available in all three modes.
+- **Suggest composer is limited to single-block selections** (the existing `findTextRange` anchor matching is per-block); multi-block selections show a hint instead of a composer.
+- **Banner dismissal is per-doc localStorage** following the existing stored-flag pattern; dismissing hides the banner only — claiming stays reachable via the menu.
+- **Mode is per-doc client state** (localStorage, default Edit), never persisted server-side, never affecting other collaborators.
+- **Home-page claim is inline** (POST from the index with optimistic UI), not a detour through the doc page.
+
+---
+
+## Requirements
+
+From origin (`docs/brainstorms/riffrec-feedback/2026-06-05-1854/requirements-kickoff.md`):
+
+- **R1–R2** Claim affordance on claimable Recent rows; inline atomic claim with race-tolerant UI (F1, AE1)
+- **R3–R4** Prominent dismissible claim banner on unclaimed claimable docs; never on demo, GET-inert (F2, AE2)
+- **R5–R6** Header right side collapses to ≤4 groups; Share is the primary action (F3, AE3)
+- **R7–R8** Three-way mode control, Edit default; Comment mode = read-only + selection-to-comment (F4, AE4)
+- **R9** Suggest mode routes changes through the existing suggestion pipeline, human-attributed (F4, AE5)
+- **R10** Mode is per-visitor, client-side only (F4)
+
+---
+
+## Key Technical Decisions
+
+1. **One `useClaim(slug)` hook for all three claim surfaces** (index row, banner, menu item). The claim flow already exists server-side; three independent implementations of double-fire guards, `claimFailed` state, and race handling would drift. The hook owns POST, optimistic state, and silent `onError` (a lost race must re-render ownership, not raise Inertia's default error modal).
+2. **Index ships ownership metadata per row.** `documents#index` props expand from `{title, slug}` to include `{claimed, claimable, yours, owner_name}` via the existing `Document#ownership_props`. The index has no live channel; staleness is handled at click time by the race-tolerant claim flow with `router.reload(only: ['yours', 'recent'])` on settle (the show page's `only: ['ownership']` scoping does not transfer).
+3. **Read-only modes are implemented as ProseMirror `editable: () => false` only.** Never gate provider connection, Yjs sync, or seed application on mode — a visitor with `seed_granted: true` loading into a restored read-only mode must still seed programmatically, or the seed claim burns for the timeout window (see `docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md` context).
+4. **Suggest mode v1 = selection-based propose, not track-changes.** Reuses `Suggestion.propose!` + margin cards + accept/reject. Inline track-changes rendering is deferred (origin scope boundary).
+5. **Human suggestion authorship is a first-class backend change.** `Suggestion::AUTHOR_KINDS` widens to include `human`; a browser-facing create endpoint mirrors `CommentsController#create` conventions (`preferred_name` precedence, `propose!` for activity + broadcast, `redirect_back`, body-size cap). The accept path threads `author_kind` so inserted text gets human provenance marks instead of hardcoded `kind: ai, state: pending`.
+6. **Header contract: `[identity/presence] [mode control] [Share (primary)] [⋯ menu]`.** Menu contains Panel, Focus, Feedback, and ownership status/actions. Provenance summary chip joins the identity/presence group or the menu, whichever keeps groups ≤4.
+
+---
+
+## High-Level Technical Design
+
+### Header layout (before → after)
+
+```
+BEFORE  [P. title status] ............ [Identity][Provenance][Presence][Panel][Focus][Ownership][Feedback][Share]
+AFTER   [P. title status] ............ [Identity·Provenance·Presence] [Edit ▾] [Share] [⋯]
+                                                                        │               └─ Panel / Focus / Feedback /
+                                                                        │                  ownership (Yours·Delete / Owned by X / Claim)
+                                                                        └─ Edit | Suggest | Comment
+```
+
+### Mode state machine (per visitor, per doc)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Edit : default / restore from localStorage
+    Edit --> Suggest : mode control
+    Edit --> Comment : mode control
+    Suggest --> Edit
+    Suggest --> Comment
+    Comment --> Edit
+    Comment --> Suggest
+    note right of Suggest : editable=false<br/>selection → "Suggest a change"
+    note right of Comment : editable=false<br/>selection → comment composer
+```
+
+### Per-mode capability matrix (directional contract)
+
+| Capability | Edit | Suggest | Comment |
+|---|---|---|---|
+| Direct typing into doc | ✅ | ❌ | ❌ |
+| Selection toolbar | Comment · Ask AI | Suggest a change | Comment |
+| Accept/reject suggestions | ✅ | ✅ | ✅ |
+| Advance AI review states / resolve comments | ✅ | ✅ | ✅ |
+| Presence/caret broadcast | ✅ | ✅ | ✅ |
+
+### Suggest-mode flow (directional, not implementation spec)
+
+```mermaid
+sequenceDiagram
+    participant V as Visitor (Suggest mode)
+    participant UI as Suggest composer
+    participant API as POST /d/:slug/suggestions
+    participant S as Suggestion.propose!
+    participant All as All clients
+    V->>UI: select single-block text, write replacement
+    UI->>API: anchor_text, replaces, body (capped), name
+    API->>S: author_kind: human, preferred_name
+    S->>All: broadcast :suggestions (margin card, human treatment)
+    All->>All: accept → insert with HUMAN provenance marks
+```
+
+---
+
+## Implementation Units
+
+Shipping order is serial on the UI track — U1 → U2 → U3 → U5 → U6 (the banner must exist before the chip loses its header slot, and the header slot before the mode control) — with U4 as the only fully parallel track.
+
+### U1. Ship ownership metadata to the home page and add the shared claim hook
+
+**Goal:** Index rows know their claim state; one reusable claim primitive exists.
+**Requirements:** R1, R2 (AE1)
+**Dependencies:** none
+**Files:**
+- `app/controllers/documents_controller.rb` (index props)
+- `app/frontend/lib/use_claim.ts` (new)
+- `app/frontend/pages/documents/index.tsx`
+- `test/integration/ownership_flow_test.rb` (or a new `test/integration/home_claim_test.rb`)
+
+**Approach:** Expand `yours`/`recent` props with `ownership_props(viewer_token)` fields per row. Build `useClaim(slug)` owning POST to the existing claim route, in-flight guard, silent `onError`, and settle-time reload scoped to the page's props. Render a claim affordance (icon-button per the transcript ask) only when `claimable && !claimed`; claimed rows show nothing (own docs already sit under "Your docs"). The icon button carries `aria-label="Claim this document"` and a matching tooltip, copy-consistent with the U2 banner. On win, the row moves lists via the scoped reload; on lost race, the row re-renders with the winner's name — no modal.
+**Patterns to follow:** `app/frontend/components/ownership_chip.tsx` optimistic claim + scope reload; `assert_inertia_props` usage in `test/integration/ownership_flow_test.rb`.
+**Test scenarios:**
+- Covers AE1. Index props include `claimable: true` for an unclaimed agent-created doc in recents, and `claimable: false` + `owner_name` for a doc claimed by another token.
+- Demo doc row is never claimable in props.
+- POST claim from index context with an unclaimed doc → 200-family redirect, doc owned by caller, subsequent index props place it under `yours`.
+- Lost race (doc claimed between render and click) → response carries updated ownership, no 5xx; props show the winner.
+- Recents dedupe still holds after claim (doc no longer duplicated in `recent`).
+**Verification:** Home page shows claim affordances on claimable recents; claiming moves the row without leaving the page; race produces no error modal.
+
+### U2. Doc-page claim banner
+
+**Goal:** Unclaimed claimable docs greet visitors with a prominent, dismissible claim CTA.
+**Requirements:** R3, R4 (AE2)
+**Dependencies:** U1 (consumes `useClaim`)
+**Files:**
+- `app/frontend/components/claim_banner.tsx` (new)
+- `app/frontend/pages/documents/show.tsx`
+- `app/frontend/entrypoints/application.css`
+- `test/integration/ownership_flow_test.rb`
+
+**Approach:** Banner renders below the sticky header when `ownership.claimable` and not locally dismissed ("Claim this doc to your account" + claim button + dismiss). Dismissal writes a per-slug stored flag (existing `readStoredFlag` pattern); the dismiss flag gates **only the banner element** — it never suppresses the ownership update path, so on any `:ownership` broadcast or scoped reload that transitions claimable→claimed-by-other, the header/menu ownership state switches to "Owned by ‹name›" regardless of the stored dismiss flag (a dismissed visitor must not be offered a doomed claim). On claim or on `:ownership` broadcast showing the doc claimed, the banner unmounts for all viewers via the existing scoped reload. Check the popover `anchorPosition` threshold against the shifted header geometry (flow-analysis gap: hardcoded sticky-header offset).
+**Test scenarios:**
+- Covers AE2. Unclaimed claimable doc → ownership props mark `claimable`; claimed doc and demo doc → not claimable (banner precondition false).
+- GET requests never mutate ownership (existing tests already lock this — extend only if banner introduces a new route, which it should not).
+- Claim via banner path is the same POST as the chip path (no new endpoint).
+- Test expectation note: dismissal persistence is client-only localStorage — covered by the browser-test pass, not Minitest.
+**Verification:** First visit to an unclaimed doc shows the banner without hunting the header; dismiss survives reload; claimed docs never show it.
+
+### U3. Header consolidation — overflow menu and primary Share
+
+**Goal:** Header right side reads in one scan: identity/presence · mode · Share · menu.
+**Requirements:** R5, R6 (AE3)
+**Dependencies:** U2 (banner is the claim CTA before the chip loses its slot); U5 reserves the mode-control slot but can land after — leave a placeholder gap, not a hard dependency
+**Files:**
+- `app/frontend/components/header_menu.tsx` (new)
+- `app/frontend/pages/documents/show.tsx`
+- `app/frontend/components/ownership_chip.tsx` (content reused/relocated into menu)
+- `app/frontend/entrypoints/application.css`
+
+**Approach:** New `⋯` menu holding: Panel toggle, Focus toggle, Feedback, and ownership section ("Yours" + two-step delete confirm / "Owned by ‹name›" / "Claim" fallback item). `header_menu.tsx` is a content-layer component that **composes** the existing popover primitive from `share_popover.tsx` (extract/reuse its open-close/positioning mechanics rather than reimplementing them). Share gets primary-button styling. Provenance summary chip merges into the identity/presence group or menu — implementer's call, bounded by the ≤4-groups contract. Preserve the mobile dock behavior; decide the menu's mobile placement by mirroring existing MobileDock patterns.
+**Test scenarios:** Test expectation: none for Minitest — pure presentation reshuffle over existing flows (delete/claim/panel/focus behavior is already integration-tested); regression coverage comes from the browser-test pass (AE3: Panel and Focus reachable inside the menu, Share visually primary, ≤4 groups).
+**Verification:** No control is lost: panel/focus toggles, feedback, delete-with-confirm, claim, share all reachable; header matches the layout contract on desktop and mobile.
+
+### U4. Backend: human-authored suggestions
+
+**Goal:** Browsers can propose suggestions; the model and API treat `human` as a first-class author kind.
+**Requirements:** R9 (AE5 server half)
+**Dependencies:** none (parallel with U1–U3)
+**Files:**
+- `app/models/suggestion.rb`
+- `app/controllers/suggestions_controller.rb` (extend the existing controller — add a `create` action alongside the existing accept/reject actions)
+- `config/routes.rb`
+- `test/integration/suggestion_flow_test.rb`
+
+**Approach:** Widen `AUTHOR_KINDS` to `%w[ai agent human]`. New `POST /d/:slug/suggestions` mirroring `CommentsController#create`: `preferred_name` precedence (session display name wins over posted name), `author_kind: "human"` fixed server-side (never client-supplied), `Suggestion.propose!` so activity logging + `:suggestions` broadcast stay uniform, `redirect_back` with Inertia error shape on validation failure, rescue deleted-doc as the claim action does. Cap field sizes: `body` AND `anchor_text` AND `replaces` (all three are unbounded strings stored and broadcast; `replaces` is inserted verbatim into every client's CRDT on accept — a multi-megabyte payload would propagate to all connected clients). Cap magnitude consistent with `MAX_SNAPSHOT_BYTES` thinking; `anchor_text` can be tighter (~10 KB — it must match a real span in the doc).
+**Test scenarios:**
+- Covers AE5. POST with anchor_text/replaces/body on a live doc → pending suggestion, `author_kind: "human"`, attributed to session display name, activity row created, `:suggestions` broadcast asserted.
+- Posted `author_kind: "agent"` (or any client value) is ignored — server forces `human` on this route.
+- Body over the cap → validation error via Inertia error shape, no record. Same validation-failure assertions for oversized `anchor_text` and `replaces`.
+- Session display name wins over a client-posted name; absent both → guest naming convention matches comments.
+- POST to a deleted doc → graceful redirect, no 500.
+- Agent API suggestion creation is unaffected (existing tests still green).
+**Verification:** `Suggestion.propose!` path identical for all author kinds; existing agent suggestion tests untouched and passing.
+
+### U5. Mode switcher infrastructure (Edit / Suggest / Comment)
+
+**Goal:** Per-visitor mode control with read-only enforcement, per the capability matrix.
+**Requirements:** R7, R8 (AE4), R10
+**Dependencies:** U3 (header slot)
+**Files:**
+- `app/frontend/components/mode_control.tsx` (new)
+- `app/frontend/editor/milkdown_editor.tsx` (editable wiring)
+- `app/frontend/pages/documents/show.tsx` (mode state, selection-toolbar matrix)
+- `app/frontend/components/selection_toolbar.tsx`
+
+**Approach:** Mode state lives in `show.tsx`, persisted per-doc via the stored-flag pattern, default Edit. On the demo doc the mode control renders locked to Edit with a tooltip explaining mode switching is disabled there. During editor initialization (before seed/sync settles), switching is a no-op — the editable toggle is idempotent, so no separate disabled visual state is needed. Editor read-only is **exclusively** ProseMirror `editable: () => false` through Milkdown's view options — provider connection, Yjs sync, agent edits, and seed application must be mode-independent (KTD 3; this is the seeding-burn trap from the flicker fix). Selection toolbar renders per the capability matrix; review actions (accept/reject, review states, comment resolution) remain enabled in all modes. Presence/caret broadcast unchanged.
+**Execution note:** Verify the restored-mode + fresh-seed path early — load an unseeded doc with Suggest mode pre-stored and confirm content seeds.
+**Test scenarios:** Test expectation for Minitest: none — mode is client-only state with no server surface (R10). Behavioral coverage lands in the browser-test pass: Covers AE4 — in Comment mode typing mutates nothing and selection offers comment; mode persists across reload per doc; other collaborators' editors unaffected; seeding works when a read-only mode is restored on first load.
+**Verification:** All three modes switchable by a guest; Edit identical to current behavior; no Yjs/seed regression with read-only modes active.
+
+### U6. Suggest-mode composer and human provenance threading
+
+**Goal:** Suggest mode produces human-attributed margin suggestions whose acceptance inserts human-provenance text.
+**Requirements:** R9 (AE5 client half)
+**Dependencies:** U4, U5
+**Files:**
+- `app/frontend/components/suggest_composer.tsx` (new; mirror comment composer mechanics, including the mobile sheet route)
+- `app/frontend/editor/suggestions.ts` (`applySuggestion` author-kind threading)
+- `app/frontend/components/margin_suggestions.tsx` (human card treatment)
+- `app/frontend/pages/documents/show.tsx` (aiPendingCount keying)
+
+**Approach:** Before building `suggest_composer.tsx`, assess whether the existing comment composer can be parameterized (submit handler + title/placeholder props) instead of cloned; create the new file only if the anchor/replaces fields genuinely require a distinct form, and note the decision in the commit. In Suggest mode, single-block selections offer "Suggest a change" → composer posts to the U4 endpoint; for multi-block selections the toolbar renders "Suggest a change" disabled with a tooltip ("Suggestions work on single paragraphs — narrow your selection") — the anchor matching in `suggestions.ts` is per-block (flow-analysis gap 5). Composer states mirror the comment composer: empty body disables submit (no round-trip); validation/cap errors render inline via the Inertia error shape; deleted-doc follows `redirect_back`. Thread `author_kind` through `applySuggestion`: accepted human suggestions insert text with human provenance marks — `kind: "human"` with the human-text state used by the provenance writer, NOT `state: "pending"` (the review-state machinery keys on `kind === "ai"` and must ignore human spans) — and skip the AI pending-review state machine (KTD 5). This protects `provenance_summary` percentages, the product's core promise. Margin cards branch on `author_kind` for icon/label/activity copy. Fix the `aiPendingCount` decrement to key on suggestion `author_kind` (or request correlation) instead of list length, so a human suggestion arriving mid-Ask-AI doesn't clear the AI-thinking state.
+**Test scenarios:**
+- Covers AE5. Accepting a human suggestion via the existing accept route leaves provenance summary's AI percentage unchanged (server-side proxy for the provenance contract — assert via provenance summary props/state after accept where the test surface allows).
+- Margin/activity strings name the human display name, not an agent label (integration-level where strings are server-rendered; otherwise browser pass).
+- Browser pass: full AE5 loop — select, suggest, margin card appears for a second client, accept, text lands attributed as human; Ask AI pending state survives an unrelated human suggestion arriving.
+**Verification:** End-to-end suggest loop works for a guest; provenance percentages stay honest; agent suggestion flow visually unchanged.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the four feedback findings, on the existing anonymous browser-identity trust model.
+
+### Deferred to Follow-Up Work
+- Inline track-changes rendering for Suggest mode (in-text diff marks à la Google Docs) — v1 routes through margin cards (origin: Deferred for later).
+- Server-persisted mode preference; comment mode surfaces for agents (origin: Deferred for later).
+- Multi-block suggestion anchoring (requires reworking `findTextRange`'s per-block matching).
+- Live ownership channel for the home page (index stays render-time + claim-time reconciliation).
+- "Your docs" reordering by `claimed_at` (cosmetic; flow-analysis minor gap 12).
+
+**Outside this product's identity:** accounts/auth, ownership transfer, per-mode edit-gating of *other* collaborators (origin: Outside this product's identity).
+
+---
+
+## Risks & Dependencies
+
+- **Provenance misattribution (highest risk).** Hardcoded `kind: ai` in the accept path means a missed thread silently counts human prose as AI. U6 test scenarios pin this; treat it as the unit's acceptance bar.
+- **Seed-claim burn under restored read-only mode.** Mitigated by KTD 3 (editable-only enforcement) and U5's execution note; regression risk against the just-shipped flicker fix (`docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md`).
+- **Inertia error-modal leak on claim races from the index.** The claim controller returns Inertia errors; `useClaim` must handle `onError` silently (U1).
+- **Unbounded suggestion bodies** from an unauthenticated endpoint — capped in U4; same trust model as comments otherwise.
+- **Header regressions on mobile.** U3/U5 must mirror MobileDock and sheet patterns; browser pass covers it.
+
+---
+
+## Sources & Research
+
+- Origin requirements + evidence: `docs/brainstorms/riffrec-feedback/2026-06-05-1854/` (transcript, frames M1–M6, problem analysis).
+- Source mapping and flow analysis: repo-grounded (claim flow `app/models/document.rb`, ownership UI `app/frontend/components/ownership_chip.tsx`, suggestion pipeline `app/models/suggestion.rb` + `app/frontend/editor/suggestions.ts`, header `app/frontend/pages/documents/show.tsx`). No external research run — strong local patterns for every surface; the Milkdown editable toggle is a known ProseMirror surface resolved at implementation time.
+- Prior art in-repo: `docs/plans/2026-06-05-003-feat-claim-doc-ownership-plan.md` (claim semantics), `docs/plans/2026-06-05-006-fix-document-load-flicker-plan.md` (seed-grant constraints).

--- a/test/integration/home_claim_test.rb
+++ b/test/integration/home_claim_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+# U1: the home page Recent rows carry ownership metadata so claimable docs
+# can offer an inline claim affordance, and claiming from the index moves
+# the row into "Your docs" via the same race-tolerant claim flow.
+class HomeClaimTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(title: "Agent Made This")
+  end
+
+  def establish_identity
+    get root_path
+    assert_response :success
+  end
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+
+  test "recent rows include claimable true for an unclaimed agent-created doc" do
+    establish_identity
+    get document_page_path(@document.slug), headers: browser # adds to recents
+
+    get root_path
+    assert_inertia_props do |props|
+      row = props[:recent].find { |d| d[:slug] == @document.slug }
+      row && row[:claimable] == true && row[:claimed] == false && row[:yours] == false
+    end
+  end
+
+  test "recent rows show claimed state and owner name for a doc claimed by another token" do
+    establish_identity
+    get document_page_path(@document.slug), headers: browser
+    Document.where(id: @document.id).update_all(
+      owner_token: "someone-else", owner_name: "Winner", claimed_at: Time.current
+    )
+
+    get root_path
+    assert_inertia_props do |props|
+      row = props[:recent].find { |d| d[:slug] == @document.slug }
+      row && row[:claimable] == false && row[:claimed] == true &&
+        row[:owner_name] == "Winner" && row[:yours] == false
+    end
+  end
+
+  test "recent rows never include the owner token" do
+    establish_identity
+    get document_page_path(@document.slug), headers: browser
+
+    get root_path
+    refute_match(/owner_token/, response.body)
+  end
+
+  test "demo doc row is never claimable" do
+    Document.create!(title: "Demo", slug: "demo")
+    establish_identity
+    get document_page_path("demo"), headers: browser
+
+    get root_path
+    assert_inertia_props do |props|
+      row = props[:recent].find { |d| d[:slug] == "demo" }
+      row && row[:claimable] == false
+    end
+  end
+
+  test "claiming from the index moves the doc into yours and out of recent" do
+    establish_identity
+    get document_page_path(@document.slug), headers: browser
+
+    post claim_document_path(@document.slug), params: { name: "Me" }
+    assert_response :see_other
+    assert @document.reload.claimed?
+
+    get root_path
+    assert_inertia_props do |props|
+      props[:yours].any? { |d| d[:slug] == @document.slug } &&
+        props[:recent].none? { |d| d[:slug] == @document.slug }
+    end
+  end
+
+  test "lost race from the index surfaces the winner without a server error" do
+    establish_identity
+    get document_page_path(@document.slug), headers: browser
+    Document.where(id: @document.id).update_all(
+      owner_token: "someone-else", owner_name: "Winner", claimed_at: Time.current
+    )
+
+    post claim_document_path(@document.slug), params: { name: "Loser" }
+    assert_response :see_other
+    assert_equal "Winner", @document.reload.owner_name
+
+    get root_path
+    assert_inertia_props do |props|
+      row = props[:recent].find { |d| d[:slug] == @document.slug }
+      row && row[:claimed] == true && row[:owner_name] == "Winner"
+    end
+  end
+end

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -130,6 +130,14 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "oversized intent is rejected" do
+    assert_no_difference -> { @document.suggestions.count } do
+      post document_suggestions_path(@document.slug), params: {
+        body: "ok", intent: "a" * (Suggestion::MAX_INTENT_BYTES + 1)
+      }
+    end
+  end
+
   test "empty body is rejected" do
     assert_no_difference -> { @document.suggestions.count } do
       post document_suggestions_path(@document.slug), params: { body: "" }

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -141,4 +141,15 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     post document_suggestions_path("gone-doc"), params: { body: "text" }
     assert_redirected_to root_path
   end
+
+  test "a human-authored suggestion flows through the same accept machinery" do
+    suggestion = Suggestion.propose!(
+      document: @document, author_name: "Quiet Falcon", author_kind: "human",
+      body: "Better wording.", replaces: "Old wording."
+    )
+
+    patch accept_suggestion_path(suggestion), params: { by: "Reviewer" }
+    assert_equal "accepted", suggestion.reload.status
+    assert_includes @document.activities.last.detail, "Quiet Falcon"
+  end
 end

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -64,4 +64,81 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
       props[:suggestions].any? { |s| s[:body] == "New paragraph." }
     end
   end
+
+  # --- U4: browser-facing suggest-a-change (Suggest mode) ---
+
+  test "browser POST creates a pending human suggestion with activity and broadcast" do
+    assert_difference -> { @document.suggestions.pending.count }, 1 do
+      assert_broadcasts(DocumentMetaChannel.broadcasting_for(@document), 2) do
+        # one :activities event from Activity.log!, one :suggestions event
+        post document_suggestions_path(@document.slug), params: {
+          author_name: "Quiet Falcon",
+          body: "Tighter phrasing.",
+          anchor_text: "Original sentence.",
+          replaces: "Original sentence.",
+          intent: "tighten"
+        }
+      end
+    end
+
+    assert_response :see_other
+    suggestion = @document.suggestions.pending.last
+    assert_equal "human", suggestion.author_kind
+    assert_equal "Quiet Falcon", suggestion.author_name
+    assert_equal "Tighter phrasing.", suggestion.body
+    assert_equal "suggested", @document.activities.last.action
+  end
+
+  test "browser POST ignores a client-posted author_kind — always human" do
+    post document_suggestions_path(@document.slug), params: {
+      author_name: "Sneaky", author_kind: "agent", body: "text"
+    }
+    assert_equal "human", @document.suggestions.last.author_kind
+  end
+
+  test "session display name wins over a client-posted author name" do
+    post identity_path, params: { name: "Session Name" }
+
+    post document_suggestions_path(@document.slug), params: {
+      author_name: "Posted Name", body: "text"
+    }
+    assert_equal "Session Name", @document.suggestions.last.author_name
+  end
+
+  test "missing author name falls back to Anonymous" do
+    post document_suggestions_path(@document.slug), params: { body: "text" }
+    assert_equal "Anonymous", @document.suggestions.last.author_name
+  end
+
+  test "oversized body is rejected with a validation error and no record" do
+    assert_no_difference -> { @document.suggestions.count } do
+      post document_suggestions_path(@document.slug), params: {
+        body: "a" * (Suggestion::MAX_BODY_BYTES + 1)
+      }
+    end
+    assert_response :see_other
+  end
+
+  test "oversized replaces and anchor_text are rejected" do
+    assert_no_difference -> { @document.suggestions.count } do
+      post document_suggestions_path(@document.slug), params: {
+        body: "ok", replaces: "a" * (Suggestion::MAX_BODY_BYTES + 1)
+      }
+      post document_suggestions_path(@document.slug), params: {
+        body: "ok", anchor_text: "a" * (Suggestion::MAX_ANCHOR_BYTES + 1)
+      }
+    end
+  end
+
+  test "empty body is rejected" do
+    assert_no_difference -> { @document.suggestions.count } do
+      post document_suggestions_path(@document.slug), params: { body: "" }
+    end
+    assert_response :see_other
+  end
+
+  test "browser POST to an unknown doc redirects home without a 500" do
+    post document_suggestions_path("gone-doc"), params: { body: "text" }
+    assert_redirected_to root_path
+  end
 end

--- a/test/models/suggestion_test.rb
+++ b/test/models/suggestion_test.rb
@@ -24,10 +24,15 @@ class SuggestionTest < ActiveSupport::TestCase
     assert_includes suggestion.errors[:author_name], "can't be blank"
   end
 
-  test "author_kind restricted to ai or agent" do
+  test "author_kind restricted to ai, agent, or human" do
     suggestion = build_suggestion
-    suggestion.author_kind = "human"
+    suggestion.author_kind = "robot"
     assert_not suggestion.valid?
+
+    Suggestion::AUTHOR_KINDS.each do |kind|
+      suggestion.author_kind = kind
+      assert suggestion.valid?, "expected #{kind} to be a valid author_kind"
+    end
   end
 
   test "accept! transitions pending to accepted and records resolver" do

--- a/test/services/gemini_suggester_test.rb
+++ b/test/services/gemini_suggester_test.rb
@@ -24,7 +24,7 @@ class GeminiSuggesterTest < ActiveSupport::TestCase
     end
     activity = @document.activities.last
     assert_equal "suggested", activity.action
-    assert_equal "agent", Suggestion::AUTHOR_KINDS.last
+    assert_includes Suggestion::AUTHOR_KINDS, "agent"
     assert_equal "add a summary", @document.suggestions.last.intent
   end
 


### PR DESCRIPTION
Four features driven by a Riffrec feedback session (evidence: `docs/brainstorms/riffrec-feedback/2026-06-05-1854/`, plan: `docs/plans/2026-06-05-007-feat-claim-visibility-editor-modes-plan.md`):

## What changed

- **Claim from the home page** — Recent rows now ship ownership metadata and show a claim icon on claimable docs; claiming is inline, race-tolerant, and moves the row to "Your docs". One shared `useClaim` hook powers every claim surface.
- **Claim banner** — unclaimed docs greet visitors with a prominent dismissible "claim this doc" banner (dismissal is per-doc localStorage and gates only the banner — ownership transitions always surface).
- **Header cleanup** — Panel/Focus/Feedback/ownership collapse into a `⋯` overflow menu; **Share** is now the single primary header action. Right side reads: identity/presence · mode · Share · menu.
- **Edit / Suggest / Comment modes** (Google Docs-style, per-visitor, client-side only):
  - *Comment*: read-only editor; selection offers comment.
  - *Suggest*: read-only; selection offers "Suggest a change" → human-authored suggestion through the existing margin-card pipeline (`POST /d/:slug/suggestions`, `author_kind` forced server-side, byte caps on body/replaces/anchor/intent).
  - Accepted human suggestions insert with **human** provenance (`kind=human, state=verbatim`) — they never inflate AI percentages or enter the AI review-state machinery.
  - Read-only is exclusively ProseMirror `editable: () => false`; Yjs sync, seeding, and agent edits stay mode-independent (no seed-claim burn).

## Review & verification

- Multi-agent code review (7 reviewers + 5 independent validators): both P1s and five P2s fixed in `fix(review)` commit — including a feature-breaking focus-gate bug that made the selection toolbar unreachable in read-only modes.
- 154 backend tests green (×3 runs); tsc clean; rubocop clean.
- Live browser pass: all 8 flows verified (claim from index, banner + dismiss persistence, menu, all three modes, human-provenance accept, delete flow).

## Residual Review Findings

- P2 `test/integration/suggestion_flow_test.rb:113` — Validation-failure tests assert only HTTP status, not Inertia error shape → https://github.com/kieranklaassen/pruf/issues/8
- P3 `test/integration/suggestion_flow_test.rb:122` — Split shared assert_no_difference in oversized replaces/anchor_text test → https://github.com/kieranklaassen/pruf/issues/9
- P3 `app/services/agent_guide.rb:63` — AgentGuide notes do not mention human-authored suggestions → https://github.com/kieranklaassen/pruf/issues/10
- P3 (advisory, not filed) `show.tsx` — code-block selections are always blocked from Suggest (literal newlines trip the multi-block guard); structural `$from/$to` detection would allow them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)