### PR TITLE
fix(provenance): attribute agent-seeded documents as AI, not human

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -22,8 +22,10 @@ class SyncChannel < ApplicationCable::Channel
     if claim_seed?
       message[:seed] = true
       message[:seed_markdown] = @document.seed_markdown
-      message[:seed_author_kind] = @document.seed_author_kind
-      message[:seed_author_name] = @document.seed_author_name
+      # Omitted (not null) for legacy docs without recorded authorship —
+      # keeps the wire format minimal and presence-of-key meaningful.
+      message[:seed_author_kind] = @document.seed_author_kind if @document.seed_author_kind
+      message[:seed_author_name] = @document.seed_author_name if @document.seed_author_name
     end
     transmit(message)
   end

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -3,7 +3,7 @@
 # ({ update: <base64> } JSON) so the yrb-actioncable client could be swapped in.
 #
 # Protocol:
-#   server -> joining client : { type: "sync", update, sv, seed?, seed_markdown? }
+#   server -> joining client : { type: "sync", update, sv, seed?, seed_markdown?, seed_author_kind?, seed_author_name? }
 #   client -> server         : { type: "sync-reply", update, cid }   # everything server was missing
 #                              { type: "update", update, cid }       # incremental edit
 #                              { type: "awareness", update, cid }    # presence/cursors, relay-only
@@ -22,6 +22,8 @@ class SyncChannel < ApplicationCable::Channel
     if claim_seed?
       message[:seed] = true
       message[:seed_markdown] = @document.seed_markdown
+      message[:seed_author_kind] = @document.seed_author_kind
+      message[:seed_author_name] = @document.seed_author_name
     end
     transmit(message)
   end

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -2,9 +2,16 @@ module Api
   class DocsController < BaseController
     # POST /api/docs — create a document from markdown, get back its slug.
     def create
+      markdown = params[:markdown].presence
+      # Authorship is recorded only for agent-supplied markdown: the seeding
+      # client attributes that text as AI prose. DEFAULT_SEED boilerplate
+      # stays unattributed — placeholder text must never be claimed as AI.
+      agent_authored = current_agent.present? && markdown.present?
       doc = Document.create!(
         title: params[:title].presence || "Untitled",
-        seed_markdown: params[:markdown].presence || Document::DEFAULT_SEED
+        seed_markdown: markdown || Document::DEFAULT_SEED,
+        seed_author_kind: agent_authored ? "agent" : nil,
+        seed_author_name: agent_authored ? Document.normalize_display_name(current_agent) : nil
       )
 
       if current_agent

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -6,12 +6,15 @@ module Api
       # Authorship is recorded only for agent-supplied markdown: the seeding
       # client attributes that text as AI prose. DEFAULT_SEED boilerplate
       # stays unattributed — placeholder text must never be claimed as AI.
-      agent_authored = current_agent.present? && markdown.present?
+      # Gate on the normalized name so a whitespace-only header can never
+      # produce kind "agent" with a blank author.
+      agent_name = Document.normalize_display_name(current_agent)
+      agent_authored = agent_name.present? && markdown.present?
       doc = Document.create!(
         title: params[:title].presence || "Untitled",
         seed_markdown: markdown || Document::DEFAULT_SEED,
         seed_author_kind: agent_authored ? "agent" : nil,
-        seed_author_name: agent_authored ? Document.normalize_display_name(current_agent) : nil
+        seed_author_name: agent_authored ? agent_name : nil
       )
 
       if current_agent

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -49,6 +49,8 @@ class DocumentsController < InertiaController
       document: document.slice(:id, :slug, :title).merge(
         seed_markdown: document.seed_markdown,
         seed_granted: seed_granted,
+        seed_author_kind: document.seed_author_kind,
+        seed_author_name: document.seed_author_name,
         has_state: document.yjs_state.present?,
         yjs_state_b64: (Base64.strict_encode64(document.yjs_state) if document.yjs_state.present?)
       ),

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -66,11 +66,14 @@ class DocumentsController < InertiaController
     # UI-created docs are owned by their creator from the same INSERT — a UI
     # doc never exists momentarily unclaimed, and no claim activity is logged
     # (the doc was never up for grabs).
+    creator_name = Document.normalize_owner_name(preferred_name(params[:name], fallback: nil))
     document = Document.create!(
       title: params[:title].presence || "Untitled",
       seed_markdown: params[:markdown].presence || Document::DEFAULT_SEED,
       owner_token: owner_token,
-      owner_name: Document.normalize_owner_name(preferred_name(params[:name], fallback: nil)),
+      owner_name: creator_name,
+      seed_author_kind: "human",
+      seed_author_name: creator_name,
       claimed_at: Time.current
     )
     remember_recent(document)

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -14,6 +14,8 @@ type SyncMessage = {
   sv?: string
   seed?: boolean
   seed_markdown?: string
+  seed_author_kind?: string | null
+  seed_author_name?: string | null
   cid?: string
 }
 
@@ -40,6 +42,11 @@ export class CableProvider {
   readonly clientId = crypto.randomUUID()
   synced = false
   seedMarkdown: string | null = null
+  // Seed authorship rides alongside seedMarkdown with the same one-shot
+  // consume semantics: the editor reads and nulls all three together so a
+  // remount can never re-attribute.
+  seedAuthorKind: string | null = null
+  seedAuthorName: string | null = null
 
   private subscription: Subscription
   private consumer: Consumer
@@ -133,6 +140,8 @@ export class CableProvider {
           // it on purpose. Handling the seed in a 'seed' listener instead
           // would double-apply the template.
           this.seedMarkdown = data.seed_markdown
+          this.seedAuthorKind = data.seed_author_kind ?? null
+          this.seedAuthorName = data.seed_author_name ?? null
           this.emit('seed')
         }
         this.synced = true

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -65,6 +65,12 @@ interface EditorProps {
   /** True when documents#show atomically claimed the seed for this page
    *  load — the props-first path that skips the WebSocket round-trip. */
   seedGranted?: boolean
+  /** Who authored the seed markdown ('human' | 'agent' | null). Non-human
+   *  seeds get their text explicitly AI-attributed after the collab
+   *  connection renders them — otherwise seeded text is unmarked and
+   *  counts as human in the provenance summary. */
+  seedAuthorKind?: string | null
+  seedAuthorName?: string | null
   /** Read-only gate for Comment mode. Implemented EXCLUSIVELY as
    *  ProseMirror `editable: () => false` — provider connection, Yjs sync,
    *  agent edits, programmatic dispatch, and seed application stay
@@ -185,6 +191,8 @@ function CollabEditor({
   initialStateB64,
   seedMarkdown,
   seedGranted,
+  seedAuthorKind,
+  seedAuthorName,
   editable = true,
   suggesting = false,
   onReady,
@@ -357,6 +365,8 @@ function CollabEditor({
     } else if (seedGranted && seedMarkdown && !seedAlreadyApplied(slug)) {
       markSeedApplied(slug)
       provider.seedMarkdown = seedMarkdown
+      provider.seedAuthorKind = seedAuthorKind ?? null
+      provider.seedAuthorName = seedAuthorName ?? null
       start()
     } else {
       provider.on('synced', start)

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -337,7 +337,11 @@ function CollabEditor({
         const markdown = getMarkdown()(ctx)
         const view = ctx.get(editorViewCtx)
         const spans = collectSpans(view.state.doc)
-        void postJSON(`/d/${slug}/snapshot`, { markdown, spans }).catch(() => {})
+        void postJSON(`/d/${slug}/snapshot`, { markdown, spans }).catch((error) => {
+          // Best-effort persistence, but never silent: the agent API serves
+          // these spans, so a permanently failing push must be observable.
+          console.warn('pruf: snapshot push failed', error)
+        })
       })
     }
 
@@ -380,6 +384,13 @@ function CollabEditor({
           // seeded Yjs content into the view. The dispatched marks flow back
           // through the binding, so peers receive attributed content.
           attributeSeedToAgent(ctx.get(editorViewCtx), seedAuthor ?? '')
+          // The updated listener skips addToHistory:false transactions, so
+          // the chip never sees the marked doc on its own — push it directly.
+          callbacksRef.current.onSpans?.(
+            collectSpans(ctx.get(editorViewCtx).state.doc, {
+              excludePendingInsertions: true,
+            }),
+          )
         }
 
         ctx.set(selectionCallbackCtx.key, {

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -25,7 +25,13 @@ import { CableProvider } from './cable_provider'
 import { lazyShikiParser, loadShikiParser } from './highlighter'
 import { imageUploader } from './upload'
 import type { UserIdentity } from './identity'
-import { provenance, provenanceIdentityCtx, collectSpans, type ProvenanceSpan } from './provenance'
+import {
+  provenance,
+  provenanceIdentityCtx,
+  collectSpans,
+  SKIP_PROVENANCE,
+  type ProvenanceSpan,
+} from './provenance'
 import { suggestChangesMarks } from './suggest_changes'
 import { suggestState, suggestDispatch } from './suggest_changes/intercept'
 import { suggestGuard } from './suggest_changes/normalize'
@@ -171,6 +177,38 @@ function markSeedApplied(slug: string): void {
   } catch {
     // best effort — worst case is the pre-fix behavior on history restore
   }
+}
+
+// Attributes a freshly seeded document to its agent author. applyTemplate
+// writes the Yjs fragment directly; the content reaches the ProseMirror view
+// via ySyncPlugin's init render (a remote-tagged transaction the provenance
+// writer skips), so seeded text lands unmarked — and collectSpans counts
+// unmarked text as human. This mirrors applySuggestion's explicit-attribution
+// + SKIP_PROVENANCE pattern, doc-wide. Only unmarked text is touched: if
+// applyTemplate no-opped against another seeder's content, that content
+// already carries marks and this dispatches nothing.
+function attributeSeedToAgent(view: EditorView, author: string): void {
+  const markType = view.state.schema.marks.provenance
+  if (!markType) return
+
+  let tr = view.state.tr
+  let changed = false
+  view.state.doc.descendants((node, pos, parent) => {
+    if (!node.isText) return
+    if (parent && !parent.type.allowsMarkType(markType)) return
+    if (markType.isInSet(node.marks)) return
+    tr = tr.addMark(
+      pos,
+      pos + node.nodeSize,
+      markType.create({ kind: 'ai', author, state: 'pending' }),
+    )
+    changed = true
+  })
+
+  if (!changed) return
+  tr.setMeta(SKIP_PROVENANCE, true)
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
 }
 
 function releaseSession(slug: string): void {
@@ -322,14 +360,27 @@ function CollabEditor({
       editor.action((ctx) => {
         const service = ctx.get(collabServiceCtx)
         service.bindDoc(ydoc).setAwareness(provider.awareness)
-        if (provider.seedMarkdown) {
+        // Consume the seed one-shot: capture to locals before nulling so a
+        // remounted editor never re-applies or re-attributes, and a later
+        // refactor can't clear the author fields out from under the re-mark.
+        const seed = provider.seedMarkdown
+        const seedKind = provider.seedAuthorKind
+        const seedAuthor = provider.seedAuthorName
+        provider.seedMarkdown = null
+        provider.seedAuthorKind = null
+        provider.seedAuthorName = null
+        if (seed) {
           // Server granted this client the seed claim; the default condition
           // (remote doc empty) double-guards against racing another seeder.
-          // Consume one-shot so a remounted editor never re-applies.
-          service.applyTemplate(provider.seedMarkdown)
-          provider.seedMarkdown = null
+          service.applyTemplate(seed)
         }
         service.connect()
+        if (seed && seedKind && seedKind !== 'human') {
+          // Must run after connect(): only then has ySyncPlugin rendered the
+          // seeded Yjs content into the view. The dispatched marks flow back
+          // through the binding, so peers receive attributed content.
+          attributeSeedToAgent(ctx.get(editorViewCtx), seedAuthor ?? '')
+        }
 
         ctx.set(selectionCallbackCtx.key, {
           fn: (view) => callbacksRef.current.onSelection?.(view),

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -81,6 +81,8 @@ export interface DocumentProps {
     title: string
     seed_markdown: string | null
     seed_granted: boolean
+    seed_author_kind: string | null
+    seed_author_name: string | null
     has_state: boolean
     yjs_state_b64: string | null
   }
@@ -658,6 +660,8 @@ export default function DocumentShow({
                 initialStateB64={doc.yjs_state_b64}
                 seedMarkdown={doc.seed_markdown}
                 seedGranted={doc.seed_granted}
+                seedAuthorKind={doc.seed_author_kind}
+                seedAuthorName={doc.seed_author_name}
                 editable={mode !== 'comment'}
                 suggesting={mode === 'suggest'}
                 onReady={setHandle}

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -147,7 +147,7 @@ class Document < ApplicationRecord
   def provenance_summary
     spans = Array(provenance_spans)
     total = spans.sum { |s| s["chars"].to_i }
-    return { total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 } if total.zero?
+    return seed_authorship_summary if total.zero?
 
     human = spans.select { |s| s["kind"] == "human" }.sum { |s| s["chars"].to_i }
     ai = total - human
@@ -162,6 +162,18 @@ class Document < ApplicationRecord
   end
 
   private
+
+  # Cold-read fallback: before any editor session pushes a snapshot, an
+  # agent-seeded doc is 100% unreviewed AI prose — report that instead of
+  # zeros. The total approximates rendered length from the markdown source
+  # (syntax overhead inflates it); the first real snapshot replaces it.
+  # Human and legacy seeds keep returning zeros (no behavior change).
+  def seed_authorship_summary
+    zeros = { total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 }
+    return zeros unless seed_author_kind == "agent" && seed_markdown.present?
+
+    { total: seed_markdown.length, human_pct: 0, ai_pct: 100, unreviewed_pct: 100 }
+  end
 
   def ensure_slug
     self.slug ||= SecureRandom.base58(10)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,6 +33,9 @@ class Document < ApplicationRecord
   # names are an amplification vector, so cap it (deliberate exception to the
   # no-validation convention on author_name).
   validates :owner_name, length: { maximum: 255 }, allow_nil: true
+  # seed_author_name travels to every doc opener via props and the channel
+  # seed grant — same amplification surface as owner_name, same cap.
+  validates :seed_author_name, length: { maximum: 255 }, allow_nil: true
 
   def to_param = slug
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -36,6 +36,10 @@ class Document < ApplicationRecord
   # seed_author_name travels to every doc opener via props and the channel
   # seed grant — same amplification surface as owner_name, same cap.
   validates :seed_author_name, length: { maximum: 255 }, allow_nil: true
+  # The editor AI-attributes any non-nil, non-"human" kind, so an unrecognized
+  # value written by a future code path would silently claim text as AI —
+  # constrain the vocabulary at the model.
+  validates :seed_author_kind, inclusion: { in: %w[human agent] }, allow_nil: true
 
   def to_param = slug
 
@@ -147,7 +151,10 @@ class Document < ApplicationRecord
   def provenance_summary
     spans = Array(provenance_spans)
     total = spans.sum { |s| s["chars"].to_i }
-    return seed_authorship_summary if total.zero?
+    # Fallback only when no snapshot was ever pushed — a pushed snapshot with
+    # degenerate zero-char spans must not resurrect the seed-based claim.
+    return seed_authorship_summary if spans.empty?
+    return { total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 } if total.zero?
 
     human = spans.select { |s| s["kind"] == "human" }.sum { |s| s["chars"].to_i }
     ai = total - human

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -17,6 +17,11 @@ class AgentGuide
         markdown: document.content_markdown.presence || document.seed_markdown,
         plain_markdown: document.plain_markdown.presence || document.seed_markdown,
         provenance: {
+          # Who authored the seed markdown (nil for docs without recorded
+          # authorship) — the same attribution the editor uses to mark
+          # seeded text, exposed so agents see what humans see in the chip.
+          seed_author_kind: document.seed_author_kind,
+          seed_author_name: document.seed_author_name,
           spans: document.provenance_spans,
           summary: document.provenance_summary
         },
@@ -61,6 +66,7 @@ class AgentGuide
         "Identity: send an X-Agent-Name header on every request. That name flows through everything — suggestion attribution, provenance marks when your text is accepted, the presence area, and the activity feed.",
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
         "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
+        "Documents you create with markdown are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from your seed markdown — its total counts markdown source characters (syntax included), so it slightly exceeds the rendered character count and is replaced by the first editor snapshot. spans stays empty until that snapshot.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_markdown as your working context for proposals; markdown embeds provenance span HTML. Both reflect the last snapshot pushed by a connected editor and may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Tracked changes: <ins data-suggestion-id> / <del data-suggestion-id> spans in markdown are human-typed suggestions pending human review — not your proposals, and not resolvable through this API. <del> text is still in the document until accepted; plain_markdown unwraps both, so use markdown when you need to reason about pending changes.",

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -60,7 +60,7 @@ class AgentGuide
       [
         "Identity: send an X-Agent-Name header on every request. That name flows through everything — suggestion attribution, provenance marks when your text is accepted, the presence area, and the activity feed.",
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
-        "Text you contribute is marked kind=agent provenance and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
+        "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_markdown as your working context for proposals; markdown embeds provenance span HTML. Both reflect the last snapshot pushed by a connected editor and may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Tracked changes: <ins data-suggestion-id> / <del data-suggestion-id> spans in markdown are human-typed suggestions pending human review — not your proposals, and not resolvable through this API. <del> text is still in the document until accepted; plain_markdown unwraps both, so use markdown when you need to reason about pending changes.",

--- a/db/migrate/20260606090000_add_seed_authorship_to_documents.rb
+++ b/db/migrate/20260606090000_add_seed_authorship_to_documents.rb
@@ -1,0 +1,6 @@
+class AddSeedAuthorshipToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :seed_author_kind, :string
+    add_column :documents, :seed_author_name, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_05_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_06_090000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -83,6 +83,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_200000) do
     t.string "owner_name", limit: 255
     t.string "owner_token"
     t.json "provenance_spans", default: []
+    t.string "seed_author_kind"
+    t.string "seed_author_name", limit: 255
     t.datetime "seed_claimed_at"
     t.text "seed_markdown"
     t.string "seed_state", default: "pending", null: false

--- a/docs/plans/2026-06-06-001-fix-agent-seed-provenance-plan.md
+++ b/docs/plans/2026-06-06-001-fix-agent-seed-provenance-plan.md
@@ -1,0 +1,216 @@
+---
+title: "fix: Attribute agent-seeded documents to the agent, not the opening human"
+type: fix
+status: completed
+date: 2026-06-06
+---
+
+# fix: Attribute agent-seeded documents to the agent, not the opening human
+
+## Summary
+
+When an AI agent creates a document via `POST /api/docs` with markdown, the provenance chip shows **"100% human · 0% AI"** — exactly backwards. The seed markdown is stored on the document and applied into the shared Yjs doc by the first browser client; the seeded text ends up carrying **no provenance mark at all**, and `collectSpans` counts unmarked text as human. The fix: record seed authorship on the `Document` row, carry it through both seed-grant paths (HTTP props and SyncChannel), and explicitly mark seeded text as AI-authored after the collab connection renders it — mirroring how accepted agent suggestions are already attributed.
+
+---
+
+## Problem Frame
+
+Pruf tracks character-level provenance via a ProseMirror mark (`kind: 'human' | 'ai'`, `author`, `state`). Attribution happens in three places today:
+
+1. **Typed input** — `provenanceWriter` (`app/frontend/editor/provenance/writer.ts`) auto-marks locally inserted text as `{kind: 'human', author: me, state: 'verbatim'}`. It skips remote transactions (`ySyncPluginKey` meta) and explicitly opted-out transactions (`SKIP_PROVENANCE` meta).
+2. **Accepted agent suggestions** — `applySuggestion` (`app/frontend/editor/suggestions.ts`) explicitly marks merged text `{kind: 'ai', author, state: 'pending'}` and sets `SKIP_PROVENANCE` so the writer doesn't re-attribute. **Correct today.**
+3. **Document seeding** — `collabService.applyTemplate(seedMarkdown)` in `app/frontend/editor/milkdown_editor.tsx` `start()`. Verified against the Milkdown source (`@milkdown/plugin-collab`): `applyTemplate` writes the parsed template **directly into the Yjs XmlFragment** (`fragment.delete` + `applyUpdate`) — it never dispatches a ProseMirror transaction. The content only reaches the editor view when `service.connect()` installs `ySyncPlugin`, whose initial render transaction carries `ySyncPluginKey` meta — which `provenanceWriter` skips as remote. Net result: **seeded text carries no provenance mark.** `collectSpans` (`app/frontend/editor/provenance/summary.ts`) defaults unmarked text to `kind: 'human'`, so a fully agent-written doc reads "100% human · 0% AI". **Wrong when the seed came from an agent.**
+
+Nothing records *who authored the seed*. `Api::DocsController#create` logs an `Activity` but the `documents` table has no seed-authorship columns, so neither grant path can tell the editor "this content is AI-written."
+
+Secondary symptom: before any browser opens the doc, `provenance_spans` is empty, so `GET /api/docs/:slug` serves `summary: {total: 0, ...}` for a doc that is 100% agent-written. And once the bug fires, the first debounced snapshot persists the *wrong* spans (100% human) to the server, which the agent API then serves indefinitely.
+
+## Requirements
+
+- R1: A document created by an agent via `POST /api/docs` with markdown shows the seed content as AI-authored in the editor chip (0% human · 100% AI for a doc the human hasn't touched).
+- R2: Attribution survives both seed-grant paths: the HTTP page-render grant and the SyncChannel subscribe-handshake grant (including stale-claim reclaim).
+- R3: Human-created documents keep current behavior — seed attributed to the human (no AI inflation).
+- R4: Subsequent human edits inside or around AI-seeded text are still attributed to the human (existing `provenanceWriter` typed-input override must keep working).
+- R5: The persisted snapshot (`provenance_spans`) and the agent API summary reflect the corrected attribution.
+- R6: The agent API cold-read (`GET /api/docs/:slug` before any browser session) reports attribution consistent with seed authorship rather than `total: 0`.
+
+---
+
+## Key Technical Decisions
+
+1. **Store seed authorship on the `Document` model** (`seed_author_kind: "human" | "agent"`, `seed_author_name`), set at create time by both controllers. Both grant paths (HTTP props and channel transmit) read from the row, so authorship survives the stale-claim reclaim path where a different client than the original grantee ends up seeding. Nullable, no default — `nil` means "legacy doc or no attributable author, treat as human" for backward compatibility. **Agent authorship is recorded only when the agent actually supplied markdown** — an agent create that falls back to `Document::DEFAULT_SEED` leaves the columns nil, so placeholder boilerplate is never claimed as AI prose (and the U4 cold-read can't lie about it).
+2. **Attribute after `connect()` with a re-mark transaction over unmarked text only.** `applyTemplate` mutates the Yjs fragment directly; the content first exists in the ProseMirror view after `service.connect()` installs `ySyncPlugin` (its init render runs synchronously inside `connect()` via `view.updateState`). So the re-mark dispatches **immediately after `service.connect()`**: walk text nodes, and for each text node that carries **no existing provenance mark**, `addMark` `{kind: 'ai', author: seedAuthorName, state: 'pending'}`, with `SKIP_PROVENANCE` and `addToHistory: false` metas. Marking only unmarked text is the race guard: if `applyTemplate` no-opped (its remote-empty condition found content from another seeder), that content already carries marks and the re-mark touches nothing. This mirrors the established `applySuggestion` pattern (explicit attribution + `SKIP_PROVENANCE`) and avoids widening `provenanceWriter`'s skip logic. The dispatched re-mark propagates to all peers through the now-installed ySync binding.
+3. **Agent-seeded text gets `state: 'pending'`**, consistent with accepted agent suggestions: machine prose stays visibly machine prose until a human reviews it. The chip will read "0% human · 100% AI · 100% unreviewed" and the seed content plugs into the existing review-state machinery (`reviewed`/`endorsed` advancement). **Deliberate UX consequence:** the entire seeded document renders with the pending-AI tint on first open, and any AI span is clickable for review — that is the product's existing visual language for unreviewed AI text, applied doc-wide because the whole doc *is* unreviewed AI text. If this proves too heavy in practice, dialing the initial state back is a one-line change.
+4. **`seed_author_kind` uses `"human" | "agent"` values** — a deliberate two-value subset of the `suggestions.author_kind` vocabulary (`ai | agent | human`): seeds come either from the browser create form (human) or the agent API with an `X-Agent-Name` header (agent); there is no third source. The frontend maps any non-`human` kind to the provenance mark kind `'ai'`, same as `applySuggestion` does (`const human = suggestion.author_kind === 'human'`).
+5. **`seed_author_name` is normalized and length-capped at write time.** The name flows to every doc opener via Inertia props and the SyncChannel transmit — the same broadcast-amplification surface that motivated the `owner_name` 255-char cap (`app/models/document.rb`). Reuse `Document.normalize_owner_name` (strip, cap 255, "Anonymous" fallback) for the human path and `Document.normalize_display_name` (strip, cap 255, nil for blank) for the agent path, plus a `length: { maximum: 255 }, allow_nil: true` validation mirroring `owner_name`.
+6. **Cold-read fallback in `Document#provenance_summary`:** when `provenance_spans` is empty, `seed_markdown` is present, and `seed_author_kind == "agent"`, return a summary derived from a synthetic single span (`kind: "ai"`, `state: "pending"`, `chars: seed_markdown.length`) so `AgentGuide.state` serves honest numbers before the first client snapshot arrives. The total is an approximation (markdown source length exceeds rendered text length — syntax overhead), acceptable as an upper bound that gets replaced by the first real snapshot. Human-authored or legacy seeds keep returning zeros (chip hides at `total: 0`; claiming 100% human for never-opened human seeds is also defensible but a behavior change beyond the bug — deferred).
+
+## Assumptions
+
+- "Should be 100% AI" means AI-authored **and unreviewed** (`state: 'pending'`), not pre-endorsed. This matches the existing accepted-suggestion convention; the doc-wide tint consequence is accepted (KTD 3).
+- An agent creating a doc *without* markdown gets `Document::DEFAULT_SEED` boilerplate with **nil** authorship (treated as human, no AI claim) — see KTD 1.
+- Human-created docs (`documents#create`) record `seed_author_kind: "human"` with the same normalized name used for `owner_name`; editor behavior for them is unchanged.
+- `X-Agent-Name` remains self-asserted (pre-existing trust model; suggestion author names already flow the same way). This plan caps and normalizes the value but does not add authentication.
+
+---
+
+## High-Level Technical Design
+
+Seed authorship flow across the two grant paths:
+
+```mermaid
+flowchart TD
+    A["POST /api/docs (agent, markdown present)\nseed_author_kind: agent\nseed_author_name: X-Agent-Name (normalized)"] --> D[(documents row)]
+    B["POST /documents (human)\nseed_author_kind: human\nseed_author_name: display name (normalized)"] --> D
+
+    D -->|"HTTP grant: documents#show props\nseed_granted + seed_markdown\n+ seed_author_kind/name"| E["show.tsx → milkdown_editor.tsx"]
+    D -->|"Channel grant: SyncChannel sync msg\nseed + seed_markdown\n+ seed_author_kind/name"| F["cable_provider.ts\nseedAuthorKind/Name fields"]
+    F --> E
+
+    E --> G["start(): capture author fields to locals,\napplyTemplate(seed) → writes Yjs fragment,\nservice.connect() → ySyncPlugin renders doc"]
+    G -->|"seed author = agent"| H["re-mark unmarked text only\nkind: ai, author, state: pending\nSKIP_PROVENANCE, addToHistory: false"]
+    G -->|"seed author = human / nil"| I["no re-mark\n(text stays unmarked = human in collectSpans)"]
+    H --> J["ySync binding pushes marks to peers;\nsnapshot persists corrected spans"]
+    I --> J
+```
+
+---
+
+## Implementation Units
+
+### U1. Record seed authorship on Document
+
+**Goal:** The `documents` row knows who authored its seed markdown.
+
+**Requirements:** R1, R2, R3 (foundation), R6
+
+**Dependencies:** none
+
+**Files:**
+- `db/migrate/` (new migration: add `seed_author_kind` and `seed_author_name` string columns to documents, nullable, no default; `seed_author_name` with `limit: 255` mirroring `owner_name`)
+- `app/models/document.rb`
+- `app/controllers/api/docs_controller.rb`
+- `app/controllers/documents_controller.rb`
+- `test/integration/agent_api_test.rb`
+- `test/integration/document_create_test.rb` (**new file** — no integration test for `documents#create` exists today; create it as an `ActionDispatch::IntegrationTest` following the structure of `test/integration/document_seed_claim_test.rb`)
+
+**Approach:** Follow the `add_ownership_to_documents` migration pattern (`db/migrate/20260605200000_add_ownership_to_documents.rb`). `Api::DocsController#create` sets `seed_author_kind: "agent"`, `seed_author_name: Document.normalize_display_name(current_agent)` **only when `current_agent` is present AND `params[:markdown]` is present** (KTD 1 — DEFAULT_SEED fallback docs stay nil). `DocumentsController#create` sets `seed_author_kind: "human"`, `seed_author_name:` the exact same `Document.normalize_owner_name(...)` value already computed for `owner_name` (assign once to a local, use for both). Add `validates :seed_author_name, length: { maximum: 255 }, allow_nil: true` to the model, mirroring the `owner_name` cap and its rationale comment (the value is transmitted to every doc opener).
+
+**Test scenarios:**
+- `POST /api/docs` with `X-Agent-Name: Claude` and markdown → document persists `seed_author_kind == "agent"`, `seed_author_name == "Claude"`.
+- `POST /api/docs` with `X-Agent-Name` but **no markdown** → DEFAULT_SEED stored, `seed_author_kind` nil (KTD 1).
+- `POST /api/docs` with markdown but no `X-Agent-Name` header → `seed_author_kind` nil (no attributable author).
+- `POST /api/docs` with an oversized (>255 chars) agent name → stored name capped, create succeeds.
+- `POST /documents` as a human with a session display name → `seed_author_kind == "human"`, `seed_author_name` matches `owner_name`.
+- `POST /documents` with no name at all → `seed_author_name == "Anonymous"` (normalize_owner_name fallback), kind `"human"`.
+
+**Verification:** `bin/rails test` green; new assertions pass.
+
+### U2. Carry seed authorship through both grant paths to the client
+
+**Goal:** Whichever path grants the seed claim, the editor receives `seed_author_kind`/`seed_author_name` alongside `seed_markdown`.
+
+**Requirements:** R2
+
+**Dependencies:** U1 (run the U1 migration before writing or running U2 tests — the props/channel code reads the new columns)
+
+**Files:**
+- `app/controllers/documents_controller.rb` (show props)
+- `app/channels/sync_channel.rb` (seed message)
+- `app/frontend/pages/documents/show.tsx` (`DocumentProps` interface + `<DocumentEditor>` props)
+- `app/frontend/editor/cable_provider.ts` (`SyncMessage` type, `seedAuthorKind`/`seedAuthorName` fields, `case 'sync'` handler)
+- `app/frontend/editor/milkdown_editor.tsx` (`EditorProps`, prop→provider threading)
+- `test/integration/document_seed_claim_test.rb`
+- `test/channels/sync_channel_test.rb`
+
+**Approach:** Symmetric extension of the existing seed-grant fields. HTTP path: add the two fields to the `document:` props hash in `documents#show` (always include them — they're cheap and the client gates on `seed_granted`). Channel path: add them to the `message` hash inside the `claim_seed?` branch in `SyncChannel#subscribed`. Client: extend `SyncMessage`, store on the provider next to `seedMarkdown` (same one-shot consume semantics — consumed and nulled together with `seedMarkdown` in `start()`), and in `milkdown_editor.tsx` assign provider fields on the HTTP-grant branch (`provider.seedMarkdown = seedMarkdown` gains sibling assignments). Both paths converge on `provider.seedAuthorKind`/`seedAuthorName` read inside `start()`.
+
+**Patterns to follow:** The existing `seed`/`seed_markdown` threading at `sync_channel.rb` (subscribed transmit), `cable_provider.ts` (`case 'sync'` handler), and `milkdown_editor.tsx` (seed-grant branch).
+
+**Test scenarios:**
+- Channel grant: subscribing to a fresh agent-seeded doc transmits `seed: true` with `seed_author_kind: "agent"` and the agent's name (`sync_channel_test.rb`).
+- Channel no-grant: a hydrated doc (yjs_state present) transmits no seed authorship fields.
+- HTTP grant: `GET /d/:slug` first HTML render includes `seed_author_kind`/`seed_author_name` in Inertia props (`document_seed_claim_test.rb`, `assert_inertia_props`).
+- Stale-claim reclaim: after the HTTP grant times out, the channel reclaim still carries the agent authorship (it reads the same row).
+
+**Verification:** `bin/rails test` green; TypeScript compiles (Vite build / typecheck used by the repo).
+
+### U3. Attribute seeded text as AI after the collab connection renders it
+
+**Goal:** An agent-seeded doc renders "0% human · 100% AI" in the chip from the first settled frame after seeding, and the corrected marks sync to all clients and the snapshot.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** U2
+
+**Files:**
+- `app/frontend/editor/milkdown_editor.tsx` (inside `start()`)
+
+**Approach:** In `start()`, capture `provider.seedAuthorKind`/`seedAuthorName` into **local constants before the one-shot null-out** (same consume discipline as `seedMarkdown` — a later refactor that clears provider fields must not silently disable attribution). Then, **after `service.connect()`** (the point at which `ySyncPlugin`'s init render has populated the ProseMirror view from the Yjs fragment — `applyTemplate` itself writes only to the fragment), when the captured kind is `"agent"`: dispatch a single re-mark transaction that walks text nodes (respecting `parent.type.allowsMarkType`, mirroring the writer's guard) and adds `{kind: 'ai', author: seedAuthorName ?? '', state: 'pending'}` **only to text nodes with no existing provenance mark**. Set `SKIP_PROVENANCE` and `addToHistory: false`, then dispatch. Guard rationale: seeded text is unmarked; if `applyTemplate` no-opped because another seeder's content was already present, that content carries marks and the re-mark touches nothing (race-safe), and `nil`/`"human"` kinds skip the re-mark entirely (legacy + human docs keep today's behavior). The ySync binding (installed by `connect()`) writes the marks back into the Yjs doc, so peers receive correctly attributed content. If the doc is empty after `connect()` (template skipped and no remote content yet), the walk finds nothing — harmless.
+
+Two implementation notes:
+- The mark is `inclusive: true`, so text typed at an AI-span boundary momentarily inherits the AI mark within the dispatch cycle before `provenanceWriter`'s appendTransaction replaces it with the local-human mark (the writer only skips when the existing mark is already local-human). No code change needed — expected behavior when debugging intermediate states; this is what satisfies R4.
+- Verify during implementation that the view contains the seeded content immediately after `connect()` returns (ySyncPlugin's init render is synchronous inside `view.updateState`); if a Milkdown upgrade ever makes it async, the re-mark needs to chain on the first ySync render instead.
+
+**Technical design (directional, not prescriptive):** the re-mark mirrors the explicit-attribution + `SKIP_PROVENANCE` pattern of `applySuggestion` in `app/frontend/editor/suggestions.ts`, applied doc-wide to unmarked text instead of to an inserted range.
+
+**Test scenarios** (no frontend unit-test runner exists in this repo; cover via Rails-side snapshot assertions plus the browser pass in the pipeline's test phase):
+- Agent-seeded doc opened in a browser → chip shows 0% human · 100% AI · 100% unreviewed (browser verification).
+- Human types a sentence into the agent-seeded doc → chip human percentage rises; typed range carries the human mark (browser verification; exercises R4).
+- Snapshot after seeding persists `provenance_spans` with `kind: "ai"`, `state: "pending"` spans (browser-phase verification; server shape already covered by `test/integration/snapshot_test.rb`).
+- Human-created doc seed → no AI spans (regression guard, browser verification).
+- Second client joining an agent-seeded doc sees the same AI attribution (Yjs propagation, browser verification if feasible).
+
+**Verification:** Manual/Playwright pass: create a doc via `POST /api/docs` with markdown and an `X-Agent-Name` header, open `/d/:slug` in a browser, confirm the chip; type text and confirm human percentage appears; reload and confirm marks persisted through Yjs state.
+
+### U4. Honest cold-read summary for never-opened agent docs
+
+**Goal:** `GET /api/docs/:slug` reports AI authorship for an agent-seeded doc even before any browser session has pushed a snapshot.
+
+**Requirements:** R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/models/document.rb` (`provenance_summary`)
+- `app/services/agent_guide.rb` (one-line wording fix)
+- `test/models/document_test.rb`
+
+**Approach:** In `Document#provenance_summary`, when `provenance_spans` is empty, `seed_markdown` is present, **and** `seed_author_kind == "agent"`, return a summary derived from a synthetic span covering the seed length (`total: seed_markdown.length, human_pct: 0, ai_pct: 100, unreviewed_pct: 100`). All other empty-span cases keep returning zeros (no behavior change for human or legacy docs; DEFAULT_SEED agent docs are excluded automatically because U1 leaves their `seed_author_kind` nil). The total approximates rendered length from the markdown source (syntax overhead inflates it) — acceptable upper bound, replaced by the first real snapshot. `AgentGuide.state` picks this up with no changes since it calls `provenance_summary` directly. Leave the `spans:` array it serves as-is (empty) — the summary is the headline number; synthesizing fake span *objects* invites drift with the client format. While in `agent_guide.rb`: correct the guide text that says contributed text is marked `kind=agent` — the provenance mark vocabulary is `kind=ai` (`mark.ts` renders only `prov--ai`/`prov--human` classes), and this plan's re-mark uses `'ai'`.
+
+**Test scenarios:**
+- Agent-seeded doc, no spans → summary `{ai_pct: 100, human_pct: 0, unreviewed_pct: 100, total: seed length}`.
+- Human-seeded doc, no spans → all zeros (unchanged).
+- Legacy doc (nil `seed_author_kind`), no spans → all zeros (unchanged).
+- Agent doc created without markdown (DEFAULT_SEED, nil kind) → all zeros — no AI claim on boilerplate.
+- Agent-seeded doc **with** pushed spans → spans win; fallback not used.
+
+**Verification:** `bin/rails test` green.
+
+---
+
+## Scope Boundaries
+
+**In scope:** seed-authorship recording, both grant paths, post-connect attribution, cold-read summary fallback, `seed_author_name` normalization/cap, `agent_guide.rb` provenance-kind wording fix.
+
+**Out of scope (true non-goals):**
+- Changing how typed input, paste, or suggestion acceptance attribute text — all correct today.
+- Backfilling `seed_author_kind` for existing documents (unknowable retroactively; nil-as-human is the honest default).
+- Authenticating `X-Agent-Name` (pre-existing self-asserted trust model shared with the suggestions path).
+
+### Deferred to Follow-Up Work
+
+- Cold-read summary for *human*-seeded never-opened docs (currently zeros; claiming 100% human pre-snapshot is defensible but is a behavior change beyond this bug).
+- Surfacing snapshot push failures (existing P2 finding: failures are silently swallowed in `milkdown_editor.tsx`; a failed first snapshot would delay the corrected spans reaching the agent API).
+- Serving synthetic `spans:` entries (not just summary) on the agent API cold read.
+- Server-side validation of client-pushed `provenance_spans` values (`kind`/`state` enums) — pre-existing surface, slightly more load-bearing now that summaries derive from it.
+
+---
+
+## Risks & Dependencies
+
+- **ySync init-render timing:** the re-mark assumes the ProseMirror view reflects the seeded Yjs content synchronously after `service.connect()` returns (verified against the current `@milkdown/plugin-collab` source: `connect()` → `#flushEditor` → `view.updateState`, and `ySyncPlugin`'s view init renders synchronously). A future Milkdown upgrade could change this — U3 carries an implementation-time verification note.
+- **Unmarked-only guard vs. pre-fix documents:** docs seeded before this fix have unmarked text, but they can never receive a seed grant again (`try_claim_seed` requires blank `yjs_state`), so the re-mark can't fire on them — their text remains human-by-default, same as today.
+- **Suggest-mode interaction:** seeding runs with suggesting off by design (existing invariant in `milkdown_editor.tsx`); the re-mark happens inside `start()` before `syncSuggesting`, so it cannot be intercepted into a suggestion. No change needed, but don't reorder.
+- **Agent-controlled author names:** `seed_author_name` originates from the `X-Agent-Name` header. It is normalized and capped at write time (KTD 5); it then flows into mark attrs the same way suggestion author names already do (rendered via ProseMirror's attribute-setting DOM path, not HTML injection). No new exposure class, but the cap is mandatory, not optional.
+- **y-prosemirror mark fidelity:** provenance attrs are plain JSON and already survive Yjs round-trips for suggestion-merged text; the seed re-mark uses the identical mark, so no new serialization surface.

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -36,6 +36,33 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert_nil transmissions.last["seed"]
   end
 
+  test "seed grant carries agent authorship for agent-seeded docs" do
+    doc = Document.create!(
+      title: "AgentSeed", seed_markdown: "# From an agent",
+      seed_author_kind: "agent", seed_author_name: "Scout"
+    )
+
+    subscribe slug: doc.slug
+
+    message = transmissions.last
+    assert_equal true, message["seed"]
+    assert_equal "agent", message["seed_author_kind"]
+    assert_equal "Scout", message["seed_author_name"]
+  end
+
+  test "no-grant sync carries no seed authorship fields" do
+    doc = Document.create!(title: "Hydrated", seed_markdown: "# Template",
+                           seed_author_kind: "agent", seed_author_name: "Scout")
+    YjsPersistence.merge(doc, build_update_b64("already here"))
+
+    subscribe slug: doc.slug
+
+    message = transmissions.last
+    assert_nil message["seed"]
+    assert_not message.key?("seed_author_kind")
+    assert_not message.key?("seed_author_name")
+  end
+
   test "an HTTP page-render claim blocks the channel grant while fresh" do
     doc = Document.create!(title: "PreClaimed", seed_markdown: "# Template")
     assert doc.try_claim_seed, "HTTP path should win the fresh claim"

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -50,6 +50,23 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert_equal "Scout", message["seed_author_name"]
   end
 
+  test "stale-claim reclaim still carries agent authorship" do
+    doc = Document.create!(
+      title: "Reclaimed", seed_markdown: "# From an agent",
+      seed_author_kind: "agent", seed_author_name: "Scout"
+    )
+    assert doc.try_claim_seed, "HTTP path wins the fresh claim"
+
+    travel Document::SEED_CLAIM_TIMEOUT + 1.second do
+      subscribe slug: doc.slug
+
+      message = transmissions.last
+      assert_equal true, message["seed"]
+      assert_equal "agent", message["seed_author_kind"]
+      assert_equal "Scout", message["seed_author_name"]
+    end
+  end
+
   test "no-grant sync carries no seed authorship fields" do
     doc = Document.create!(title: "Hydrated", seed_markdown: "# Template",
                            seed_author_kind: "agent", seed_author_name: "Scout")

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -104,6 +104,20 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal @document.seed_markdown, response.parsed_body["markdown"]
   end
 
+  test "cold read reports agent-seeded docs as unreviewed AI with authorship" do
+    post "/api/docs", params: { markdown: "# From an agent" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    get "/api/docs/#{slug}", headers: AGENT
+
+    provenance = response.parsed_body["provenance"]
+    assert_equal "agent", provenance["seed_author_kind"]
+    assert_equal "Scout", provenance["seed_author_name"]
+    assert_equal 100, provenance["summary"]["ai_pct"]
+    assert_equal 100, provenance["summary"]["unreviewed_pct"]
+    assert_empty provenance["spans"]
+  end
+
   test "writes without X-Agent-Name are refused with instructive guidance" do
     post "/api/docs/#{@document.slug}/suggestions", params: { body: "Hi" }, as: :json
 

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -29,8 +29,44 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_not doc.claimed?
     assert_includes body["note"], "claim"
 
+    # Agent-supplied markdown records agent seed authorship — the seeding
+    # client uses it to attribute the seeded text as AI prose.
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal "Scout", doc.seed_author_name
+
     get "/d/#{body['slug']}"
     assert_response :success
+  end
+
+  test "agent doc without markdown gets DEFAULT_SEED with no seed authorship" do
+    post "/api/docs", params: { title: "Empty Doc" }, headers: AGENT, as: :json
+
+    assert_response :created
+    doc = Document.find_by!(slug: response.parsed_body["slug"])
+    assert_equal Document::DEFAULT_SEED, doc.seed_markdown
+    # Placeholder boilerplate must never be claimed as AI prose.
+    assert_nil doc.seed_author_kind
+    assert_nil doc.seed_author_name
+  end
+
+  test "doc created without X-Agent-Name records no seed authorship" do
+    post "/api/docs", params: { markdown: "# Anonymous" }, as: :json
+
+    assert_response :created
+    doc = Document.find_by!(slug: response.parsed_body["slug"])
+    assert_nil doc.seed_author_kind
+    assert_nil doc.seed_author_name
+  end
+
+  test "oversized agent name is capped at 255 chars in seed authorship" do
+    post "/api/docs",
+         params: { markdown: "# Big name" },
+         headers: { "X-Agent-Name" => "A" * 300 }, as: :json
+
+    assert_response :created
+    doc = Document.find_by!(slug: response.parsed_body["slug"])
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal 255, doc.seed_author_name.length
   end
 
   test "state read exposes ownership without leaking the token" do

--- a/test/integration/document_create_test.rb
+++ b/test/integration/document_create_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+# UI-created documents record seed authorship at the same INSERT that claims
+# ownership: kind "human", name matching the owner attribution. The agent API
+# counterpart (agent kind, header-derived name) is covered in agent_api_test.
+class DocumentCreateTest < ActionDispatch::IntegrationTest
+  test "human-created doc records human seed authorship matching owner_name" do
+    post identity_path, params: { name: "Quiet Falcon" }, headers: browser
+    post documents_path, params: { title: "Mine", markdown: "# Hello" }, headers: browser
+
+    assert_response :see_other
+    doc = Document.order(:created_at).last
+    assert_equal "human", doc.seed_author_kind
+    assert_equal "Quiet Falcon", doc.seed_author_name
+    assert_equal doc.owner_name, doc.seed_author_name
+  end
+
+  test "human-created doc without a name falls back to Anonymous" do
+    post documents_path, headers: browser
+
+    assert_response :see_other
+    doc = Document.order(:created_at).last
+    assert_equal "human", doc.seed_author_kind
+    assert_equal "Anonymous", doc.seed_author_name
+  end
+
+  private
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+end

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -20,6 +20,21 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
     assert_equal "claimed", @document.reload.seed_state
   end
 
+  test "page render ships seed authorship alongside the grant" do
+    agent_doc = Document.create!(
+      title: "AgentSeed", seed_markdown: "# From an agent",
+      seed_author_kind: "agent", seed_author_name: "Scout"
+    )
+
+    get document_page_path(agent_doc.slug), headers: browser
+
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == true &&
+        props[:document][:seed_author_kind] == "agent" &&
+        props[:document][:seed_author_name] == "Scout"
+    end
+  end
+
   test "second page load while the claim is fresh gets no grant" do
     get document_page_path(@document.slug), headers: browser
     get document_page_path(@document.slug), headers: browser

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -57,6 +57,45 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal({ total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 }, doc.provenance_summary)
   end
 
+  test "provenance_summary cold read reports agent-seeded docs as unreviewed AI" do
+    doc = Document.create!(
+      title: "AgentSeed", seed_markdown: "# From an agent",
+      seed_author_kind: "agent", seed_author_name: "Scout"
+    )
+    summary = doc.provenance_summary
+    assert_equal "# From an agent".length, summary[:total]
+    assert_equal 0, summary[:human_pct]
+    assert_equal 100, summary[:ai_pct]
+    assert_equal 100, summary[:unreviewed_pct]
+  end
+
+  test "provenance_summary cold read stays zeros for human-seeded docs" do
+    doc = Document.create!(
+      title: "HumanSeed", seed_markdown: "# Mine",
+      seed_author_kind: "human", seed_author_name: "Quiet Falcon"
+    )
+    assert_equal({ total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 }, doc.provenance_summary)
+  end
+
+  test "provenance_summary cold read stays zeros for legacy docs without authorship" do
+    doc = Document.create!(title: "Legacy", seed_markdown: "# Old")
+    assert_equal({ total: 0, human_pct: 0, ai_pct: 0, unreviewed_pct: 0 }, doc.provenance_summary)
+  end
+
+  test "provenance_summary prefers pushed spans over the seed fallback" do
+    doc = Document.create!(
+      title: "Snapshotted", seed_markdown: "# From an agent",
+      seed_author_kind: "agent", seed_author_name: "Scout",
+      provenance_spans: [
+        { "kind" => "human", "state" => "verbatim", "chars" => 50 },
+        { "kind" => "ai", "state" => "pending", "chars" => 50 }
+      ]
+    )
+    summary = doc.provenance_summary
+    assert_equal 100, summary[:total]
+    assert_equal 50, summary[:human_pct]
+  end
+
   test "provenance_summary computes percentages from spans" do
     doc = Document.create!(
       title: "Mixed",

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -209,6 +209,21 @@ class DocumentTest < ActiveSupport::TestCase
     assert_includes doc.errors[:owner_name], "is too long (maximum is 255 characters)"
   end
 
+  test "seed_author_name longer than 255 chars is rejected by validation" do
+    doc = Document.new(title: "Long", seed_author_name: "x" * 256)
+    assert_not doc.valid?
+    assert_includes doc.errors[:seed_author_name], "is too long (maximum is 255 characters)"
+  end
+
+  test "seed_author_kind outside human/agent is rejected by validation" do
+    doc = Document.new(title: "Odd", seed_author_kind: "bot")
+    assert_not doc.valid?
+    assert_includes doc.errors[:seed_author_kind], "is not included in the list"
+
+    assert Document.new(title: "OK", seed_author_kind: "agent").valid?
+    assert Document.new(title: "OK", seed_author_kind: nil).valid?
+  end
+
   test "claim truncates oversized names instead of failing" do
     doc = Document.create!(title: "Free")
     doc.claim!(token: "tok-a", name: "y" * 400)


### PR DESCRIPTION
## Summary

A document written entirely by an agent opened showing **"100% human · 0% AI"** — exactly backwards. Now it opens showing "0% human · 100% AI · 100% unreviewed", the seeded text carries the pending-AI tint with the agent's name on it, and the agent API reports honest numbers even before any browser has opened the doc.

The root cause was invisible attribution, not wrong attribution: Milkdown's `applyTemplate` writes seed markdown straight into the Yjs fragment, the content reaches the editor through a remote-tagged ySync render that the provenance writer deliberately skips, and `collectSpans` counts unmarked text as human. Nothing recorded who authored the seed, so no layer could correct it.

## What changed

- **Seed authorship is recorded at create time** (`seed_author_kind`/`seed_author_name` on `documents`, nullable — nil means legacy/human downstream). Living on the row means attribution survives the stale-claim reclaim path, where a different client than the original grantee ends up seeding.
- **Both seed-grant paths carry it**: the Inertia props grant and the SyncChannel handshake grant, symmetric with the existing `seed_markdown` fields.
- **The editor re-marks seeded text after `connect()`** as `{kind: 'ai', state: 'pending'}` — only text with no existing provenance mark, so a no-op `applyTemplate` against another seeder's content touches nothing. `pending` plugs the seed into the existing review-state machinery (reviewed/endorsed), same as accepted agent suggestions.
- **Cold-read fallback**: `GET /api/docs/:slug` now derives a 100%-AI summary from seed authorship before the first snapshot arrives (previously `total: 0`), and the API exposes `seed_author_kind`/`seed_author_name` so agents see what the editor chip shows.
- **Boilerplate is never claimed as AI**: an agent create without markdown stores `DEFAULT_SEED` with nil authorship.

One subtle find from review: the chip's `updated` listener ignores `addToHistory: false` transactions, so the re-mark alone left the chip stale at 100% human for the seeder's session — the chip is now pushed directly after attribution.

## Test plan

- `bin/rails test` — 173 runs, 0 failures (authorship recording, both grant paths incl. stale reclaim, cold-read fallback, validation caps)
- `npm run check` — TypeScript clean
- Browser pass: agent-seeded doc opens at 0/100/100 with AI tint; typing raises human % with untinted text; human-created doc stays 100% human; API cold read and post-snapshot supersede verified end to end

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
