### PR TITLE
feat: anchored, measured placement for selection/comment/review chrome

### DIFF
--- a/app/frontend/components/anchored_composer.tsx
+++ b/app/frontend/components/anchored_composer.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState, type FormEvent, type RefObject } from 'react'
+import { truncate } from '../lib/truncate'
+
+interface Props {
+  /** Placement ref from useAnchoredPopover — also the outside-click boundary. */
+  rootRef: RefObject<HTMLFormElement | null>
+  anchor: string
+  position: { x: number; y: number; detached: boolean } | null
+  onSubmit: (body: string) => void
+  onCancel: () => void
+}
+
+/**
+ * The desktop comment composer, anchored next to the selected text
+ * (Google-Docs style). Lifecycle contract: only Escape, Cancel, and Submit
+ * close it — an outside click dismisses only while the draft is empty, so
+ * typed text is never silently lost.
+ */
+export function AnchoredComposer({ rootRef, anchor, position, onSubmit, onCancel }: Props) {
+  const [body, setBody] = useState('')
+  const bodyRef = useRef(body)
+  bodyRef.current = body
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const focusedOnce = useRef(false)
+
+  // Autofocus once placed — the pre-measure hidden phase isn't focusable.
+  const placed = position !== null
+  useEffect(() => {
+    if (placed && !focusedOnce.current) {
+      focusedOnce.current = true
+      textareaRef.current?.focus()
+    }
+  }, [placed])
+
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+      if (!root || root.contains(event.target as Node)) return
+      if (!bodyRef.current.trim()) onCancel()
+    }
+    window.addEventListener('pointerdown', onPointerDown, true)
+    return () => window.removeEventListener('pointerdown', onPointerDown, true)
+  }, [rootRef, onCancel])
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    const trimmed = body.trim()
+    if (!trimmed) return
+    onSubmit(trimmed)
+  }
+
+  return (
+    <form
+      ref={rootRef}
+      className={`comment-composer comment-composer--anchored ${placed ? 'is-placed' : ''}`}
+      style={position ? { left: position.x, top: position.y } : undefined}
+      inert={!placed}
+      onSubmit={submit}
+      aria-label="Add a comment"
+    >
+      {anchor && <blockquote className="comment-quote">{truncate(anchor, 120)}</blockquote>}
+      {position?.detached && (
+        <p className="comment-composer-note">Original text changed — comment still posts.</p>
+      )}
+      <textarea
+        ref={textareaRef}
+        className="comment-input"
+        rows={2}
+        placeholder="Say something about this…"
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) submit(event)
+          if (event.key === 'Escape') onCancel()
+        }}
+      />
+      <div className="comment-composer-actions">
+        <button type="submit" className="btn-accept" disabled={!body.trim()}>
+          Comment
+        </button>
+        <button type="button" className="btn-reject" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/app/frontend/components/margin_suggestions.tsx
+++ b/app/frontend/components/margin_suggestions.tsx
@@ -6,6 +6,7 @@ import type { EditorHandle } from '../editor/milkdown_editor'
 import type { ProvenanceSpan } from '../editor/provenance'
 import { findTextRange, type SuggestionPayload } from '../editor/suggestions'
 import { truncate } from '../lib/truncate'
+import { clearHighlight, domRange, setHighlight, supportsHighlights } from '../lib/highlights'
 
 interface Props {
   suggestions: SuggestionPayload[]
@@ -22,23 +23,7 @@ interface Props {
 
 const CARD_GAP = 10
 
-const supportsHighlights = typeof CSS !== 'undefined' && 'highlights' in CSS
-
 const anchorOf = (s: SuggestionPayload) => s.replaces ?? s.anchor_text
-
-/** A DOM Range for a ProseMirror position span — for the Custom Highlight API. */
-function domRange(view: EditorView, from: number, to: number): Range | null {
-  try {
-    const start = view.domAtPos(from)
-    const end = view.domAtPos(to)
-    const range = document.createRange()
-    range.setStart(start.node, start.offset)
-    range.setEnd(end.node, end.offset)
-    return range
-  } catch {
-    return null
-  }
-}
 
 /**
  * Pending suggestions as cards in the document's right margin, Google-Docs
@@ -157,25 +142,22 @@ export function MarginSuggestions({
       })
     })
 
-    if (supportsHighlights) {
-      CSS.highlights.set('sug-anchor', new Highlight(...rangesRef.current.values()))
-    }
+    setHighlight('sug-anchor', [...rangesRef.current.values()])
     return () => cancelAnimationFrame(raf)
   }, [suggestions, spans, handle, focusMode, resizeTick])
 
   useEffect(() => {
     if (!supportsHighlights) return
     return () => {
-      CSS.highlights.delete('sug-anchor')
-      CSS.highlights.delete('sug-anchor-hot')
+      clearHighlight('sug-anchor')
+      clearHighlight('sug-anchor-hot')
     }
   }, [])
 
   const hover = useCallback((id: number | null) => {
-    if (!supportsHighlights) return
     const range = id === null ? null : rangesRef.current.get(id)
-    if (range) CSS.highlights.set('sug-anchor-hot', new Highlight(range))
-    else CSS.highlights.delete('sug-anchor-hot')
+    if (range) setHighlight('sug-anchor-hot', [range])
+    else clearHighlight('sug-anchor-hot')
   }, [])
 
   const jumpToSuggestion = useCallback(

--- a/app/frontend/components/review_popover.tsx
+++ b/app/frontend/components/review_popover.tsx
@@ -1,8 +1,12 @@
+import { type RefObject } from 'react'
 import { REVIEW_ORDER, nextReviewState, type AiSpan, type ReviewState } from '../editor/provenance'
 
 interface Props {
+  /** Placement ref from useAnchoredPopover — measured for real-width clamping. */
+  rootRef: RefObject<HTMLDivElement | null>
   span: AiSpan
-  position: { x: number; y: number }
+  /** Measured position; null during the pre-measure hidden phase. */
+  position: { x: number; y: number } | null
   onAdvance: (state: ReviewState) => void
 }
 
@@ -17,13 +21,16 @@ const ADVANCE_LABELS: Record<string, string> = {
   endorsed: 'Endorse',
 }
 
-export function ReviewPopover({ span, position, onAdvance }: Props) {
+export function ReviewPopover({ rootRef, span, position, onAdvance }: Props) {
   const next = nextReviewState(span.attrs.state)
+  const placed = position !== null
 
   return (
     <div
-      className="review-popover"
-      style={{ left: position.x, top: position.y }}
+      ref={rootRef}
+      className={`review-popover ${placed ? 'is-placed' : ''}`}
+      style={position ? { left: position.x, top: position.y } : undefined}
+      inert={!placed}
       // Keep the editor selection alive while interacting.
       onMouseDown={(event) => event.preventDefault()}
       role="toolbar"

--- a/app/frontend/components/selection_toolbar.tsx
+++ b/app/frontend/components/selection_toolbar.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, type RefObject } from 'react'
 
 interface Action {
   label: string
@@ -8,19 +8,25 @@ interface Action {
 }
 
 interface Props {
-  position: { x: number; y: number }
+  /** Placement ref from useAnchoredPopover — measured for real-width clamping. */
+  rootRef: RefObject<HTMLDivElement | null>
+  /** Measured position; null during the pre-measure hidden phase. */
+  position: { x: number; y: number } | null
   /** Mode-gated action list (Edit: Comment · Ask AI; Suggest: Suggest a
    *  change; Comment: Comment). Renders nothing when empty. */
   actions: Action[]
 }
 
 /** Floating actions over a non-empty text selection. */
-export function SelectionToolbar({ position, actions }: Props) {
+export function SelectionToolbar({ rootRef, position, actions }: Props) {
   if (actions.length === 0) return null
+  const placed = position !== null
   return (
     <div
-      className="selection-toolbar"
-      style={{ left: position.x, top: position.y }}
+      ref={rootRef}
+      className={`selection-toolbar ${placed ? 'is-placed' : ''}`}
+      style={position ? { left: position.x, top: position.y } : undefined}
+      inert={!placed}
       onMouseDown={(event) => event.preventDefault()}
       role="toolbar"
       aria-label="Selection actions"

--- a/app/frontend/components/share_popover.tsx
+++ b/app/frontend/components/share_popover.tsx
@@ -7,14 +7,32 @@ import { ThemePicker } from './theme_picker'
 /** Share is two audiences, one URL: humans get the editor, agents fetching the
  *  same link discover the API. The popover teaches both — copy the link for a
  *  person, or copy an agent invite that tells an agent exactly how to join. */
-export function SharePopover({ agentsActive }: { agentsActive: number }) {
-  const [open, setOpen] = useState(false)
+export function SharePopover({
+  agentsActive,
+  onOpenChange,
+}: {
+  agentsActive: number
+  /** Lets the page suppress selection chrome while the popover is open. */
+  onOpenChange?: (open: boolean) => void
+}) {
+  const [open, setOpenState] = useState(false)
   const [copied, setCopied] = useState<'link' | 'agent' | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   // The sticky header's backdrop-filter makes it the containing block for
   // fixed descendants — so the mobile full-width sheet must portal to body.
   const isMobile = useMediaQuery('(max-width: 48rem)')
+
+  const setOpen = useCallback(
+    (next: boolean | ((value: boolean) => boolean)) => {
+      setOpenState((value) => {
+        const resolved = typeof next === 'function' ? next(value) : next
+        if (resolved !== value) onOpenChange?.(resolved)
+        return resolved
+      })
+    },
+    [onOpenChange],
+  )
 
   const url = typeof window === 'undefined' ? '' : window.location.href
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1266,7 +1266,45 @@ a:focus-visible {
   gap: 0.5rem;
 }
 
+/* The desktop composer floats anchored below the selected text (the rail
+ * keeps the comment list; the mobile sheet keeps the inline composer). */
+.comment-composer--anchored {
+  position: fixed;
+  z-index: 50;
+  width: min(20rem, calc(100vw - 16px));
+  box-shadow: 0 8px 28px rgb(0 0 0 / 0.12);
+  visibility: hidden;
+  animation: none;
+}
+
+.comment-composer--anchored.is-placed {
+  visibility: visible;
+  animation: popover-in 140ms ease;
+}
+
+.comment-composer-note {
+  font-size: 0.7rem;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+/* The anchored text stays tinted while its composer is open. */
+::highlight(comment-anchor) {
+  background-color: rgb(157 78 221 / 0.18);
+}
+
+[data-theme='whitey'] ::highlight(comment-anchor) {
+  background-color: rgb(65 131 196 / 0.18);
+}
+
 /* --------------------------- Selection toolbar ---------------------------- */
+/* Fixed-chrome z-index ladder: header 30 · selection chrome (toolbar,
+ * review popover, anchored composer) 50 · share popover / mobile dock 60 ·
+ * sheets 70+. Selection chrome is also suppressed in React while the share
+ * popover or the anchored composer is open — one floating form at a time. */
+/* Floating chrome renders hidden for one measuring pass, then `is-placed`
+ * reveals it at its final measured position — the entrance animation plays
+ * on reveal, never at an unmeasured spot. */
 .selection-toolbar {
   position: fixed;
   z-index: 50;
@@ -1276,6 +1314,11 @@ a:focus-visible {
   border-radius: 8px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 0.18);
   padding: 0.2rem 0.25rem;
+  visibility: hidden;
+}
+
+.selection-toolbar.is-placed {
+  visibility: visible;
   animation: popover-in 140ms ease;
 }
 
@@ -1413,6 +1456,11 @@ a:focus-visible {
   box-shadow: 0 4px 16px rgb(0 0 0 / 0.08);
   padding: 0.3rem 0.6rem;
   font-size: 0.72rem;
+  visibility: hidden;
+}
+
+.review-popover.is-placed {
+  visibility: visible;
   animation: popover-in 140ms ease;
 }
 

--- a/app/frontend/lib/highlights.ts
+++ b/app/frontend/lib/highlights.ts
@@ -1,0 +1,32 @@
+import type { EditorView } from '@milkdown/kit/prose/view'
+
+/** CSS Custom Highlight API feature gate (Safari < 17.2, older Firefox). */
+export const supportsHighlights = typeof CSS !== 'undefined' && 'highlights' in CSS
+
+/** A DOM Range for a ProseMirror position span — for the Custom Highlight API. */
+export function domRange(view: EditorView, from: number, to: number): Range | null {
+  try {
+    const start = view.domAtPos(from)
+    const end = view.domAtPos(to)
+    const range = document.createRange()
+    range.setStart(start.node, start.offset)
+    range.setEnd(end.node, end.offset)
+    return range
+  } catch {
+    return null
+  }
+}
+
+export function setHighlight(name: string, ranges: Range[]): void {
+  if (!supportsHighlights) return
+  if (ranges.length === 0) {
+    CSS.highlights.delete(name)
+    return
+  }
+  CSS.highlights.set(name, new Highlight(...ranges))
+}
+
+export function clearHighlight(name: string): void {
+  if (!supportsHighlights) return
+  CSS.highlights.delete(name)
+}

--- a/app/frontend/lib/use_anchored_popover.ts
+++ b/app/frontend/lib/use_anchored_popover.ts
@@ -24,10 +24,11 @@ interface Options {
    *  default to above the first line. Either way the popover never covers
    *  the anchored text. */
   preferBelow?: boolean
-  /** Keep the last good position when the anchor stops resolving instead of
-   *  hiding — for stateful chrome (an open composer) that must not vanish
-   *  mid-draft. */
-  freezeWhenLost?: boolean
+  /** Stateful chrome (an open composer) must never be invisible: when the
+   *  anchor stops resolving it freezes at the last good position, and when
+   *  the anchor is offscreen it clamps into the viewport edge nearest the
+   *  anchor instead of hiding. */
+  persistent?: boolean
   /** Distance between anchor line and popover edge. */
   gap?: number
   /** Invalidation signals: scroll/resize tick, doc tick, anchor identity. */
@@ -60,7 +61,7 @@ export function useAnchoredPopover<T extends HTMLElement>({
   getView,
   getRange,
   preferBelow = false,
-  freezeWhenLost = false,
+  persistent = false,
   gap = 8,
   deps,
 }: Options): { ref: RefObject<T | null>; position: AnchoredPosition | null } {
@@ -100,7 +101,7 @@ export function useAnchoredPopover<T extends HTMLElement>({
     const range = getRange()
     if (!range) {
       // Anchor gone: stateful chrome freezes where it was; stateless hides.
-      place(freezeWhenLost && lastGood.current ? { ...lastGood.current, detached: true } : null)
+      place(persistent && lastGood.current ? { ...lastGood.current, detached: true } : null)
       return
     }
 
@@ -115,11 +116,13 @@ export function useAnchoredPopover<T extends HTMLElement>({
       return
     }
 
-    // Hide while the placement anchor line is scrolled out of view.
+    // Stateless chrome hides while the placement anchor line is scrolled out
+    // of view; persistent chrome stays visible (clamped below) instead.
     const anchorLine = preferBelow ? end : start
     if (
-      anchorLine.top < -OFFSCREEN_SLACK ||
-      anchorLine.top > window.innerHeight + OFFSCREEN_SLACK
+      !persistent &&
+      (anchorLine.top < -OFFSCREEN_SLACK ||
+        anchorLine.top > window.innerHeight + OFFSCREEN_SLACK)
     ) {
       place(null)
       return
@@ -152,6 +155,11 @@ export function useAnchoredPopover<T extends HTMLElement>({
       if (y + height > window.innerHeight - VIEWPORT_PAD && y === above) {
         y = Math.max(HEADER_CLEARANCE, window.innerHeight - height - VIEWPORT_PAD)
       }
+    }
+    if (persistent) {
+      // A form must stay reachable even when its anchor is far offscreen —
+      // pin it inside the viewport, toward the anchor's direction.
+      y = clamp(y, HEADER_CLEARANCE, Math.max(HEADER_CLEARANCE, window.innerHeight - height - VIEWPORT_PAD))
     }
 
     const next = { x, y, detached: false }

--- a/app/frontend/lib/use_anchored_popover.ts
+++ b/app/frontend/lib/use_anchored_popover.ts
@@ -1,0 +1,166 @@
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import type { EditorView } from '@milkdown/kit/prose/view'
+
+export interface AnchorRange {
+  from: number
+  to: number
+}
+
+export interface AnchoredPosition {
+  x: number
+  y: number
+  /** Anchor text vanished (e.g. remote edit) — frozen at the last good spot. */
+  detached: boolean
+}
+
+interface Options {
+  /** Whether the popover is open at all. False resets all placement state. */
+  active: boolean
+  /** Live view getter — geometry re-derives from current state every pass. */
+  getView: () => EditorView | null
+  /** Anchor range in the current doc, or null when the anchor is gone. */
+  getRange: () => AnchorRange | null
+  /** Place below the anchor's last line by default (composers); popovers
+   *  default to above the first line. Either way the popover never covers
+   *  the anchored text. */
+  preferBelow?: boolean
+  /** Keep the last good position when the anchor stops resolving instead of
+   *  hiding — for stateful chrome (an open composer) that must not vanish
+   *  mid-draft. */
+  freezeWhenLost?: boolean
+  /** Distance between anchor line and popover edge. */
+  gap?: number
+  /** Invalidation signals: scroll/resize tick, doc tick, anchor identity. */
+  deps: unknown[]
+}
+
+const VIEWPORT_PAD = 8
+// Clearance for the sticky header — placements above this line flip below.
+const HEADER_CLEARANCE = 52
+// Anchor lines this far outside the viewport hide the popover entirely.
+const OFFSCREEN_SLACK = 24
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(value, max))
+
+/**
+ * Measured, selection-centered placement for fixed-position floating chrome.
+ *
+ * Two-pass: the caller renders the popover (hidden via CSS until a position
+ * exists), this hook measures the real box in a layout effect, then positions
+ * before paint — first visible frame is already at its final spot, and
+ * viewport clamping uses true dimensions instead of estimates.
+ *
+ * Returns `position: null` while unmeasured, inactive, or the anchor is
+ * offscreen/gone. Attach `ref` to the popover root; gate visibility (and
+ * `inert`) on `position` being non-null.
+ */
+export function useAnchoredPopover<T extends HTMLElement>({
+  active,
+  getView,
+  getRange,
+  preferBelow = false,
+  freezeWhenLost = false,
+  gap = 8,
+  deps,
+}: Options): { ref: RefObject<T | null>; position: AnchoredPosition | null } {
+  const ref = useRef<T | null>(null)
+  const lastGood = useRef<AnchoredPosition | null>(null)
+  const [position, setPosition] = useState<AnchoredPosition | null>(null)
+
+  const place = (next: AnchoredPosition | null) => {
+    setPosition((prev) => {
+      if (
+        prev === next ||
+        (prev &&
+          next &&
+          prev.x === next.x &&
+          prev.y === next.y &&
+          prev.detached === next.detached)
+      ) {
+        return prev
+      }
+      return next
+    })
+  }
+
+  useLayoutEffect(() => {
+    if (!active) {
+      lastGood.current = null
+      place(null)
+      return
+    }
+    const view = getView()
+    const el = ref.current
+    if (!view || !el) {
+      place(null)
+      return
+    }
+
+    const range = getRange()
+    if (!range) {
+      // Anchor gone: stateful chrome freezes where it was; stateless hides.
+      place(freezeWhenLost && lastGood.current ? { ...lastGood.current, detached: true } : null)
+      return
+    }
+
+    let start: { left: number; top: number; bottom: number }
+    let end: { left: number; top: number; bottom: number }
+    try {
+      start = view.coordsAtPos(range.from)
+      end = view.coordsAtPos(range.to)
+    } catch {
+      // Editor mid-teardown or stale positions.
+      place(null)
+      return
+    }
+
+    // Hide while the placement anchor line is scrolled out of view.
+    const anchorLine = preferBelow ? end : start
+    if (
+      anchorLine.top < -OFFSCREEN_SLACK ||
+      anchorLine.top > window.innerHeight + OFFSCREEN_SLACK
+    ) {
+      place(null)
+      return
+    }
+
+    const width = el.offsetWidth
+    const height = el.offsetHeight
+
+    // Center over the selection when it sits on one line; for multi-line
+    // selections, center on the anchor line's endpoint instead.
+    const sameLine = Math.abs(start.top - end.top) < 4
+    const centerX = sameLine ? (start.left + end.left) / 2 : anchorLine.left
+    const maxX = window.innerWidth - width - VIEWPORT_PAD
+    const x = maxX < VIEWPORT_PAD ? VIEWPORT_PAD : clamp(centerX - width / 2, VIEWPORT_PAD, maxX)
+
+    const above = start.top - height - gap
+    const below = end.bottom + gap
+    let y: number
+    if (preferBelow) {
+      y = below
+      if (y + height > window.innerHeight - VIEWPORT_PAD) {
+        // Flip above only when that clears the header AND the anchor;
+        // otherwise clamp upward with a hard floor below the selection —
+        // the popover never sits on top of the anchored text.
+        y = above >= HEADER_CLEARANCE ? above : Math.max(window.innerHeight - height - VIEWPORT_PAD, below)
+      }
+    } else {
+      y = above
+      if (y < HEADER_CLEARANCE) y = below
+      if (y + height > window.innerHeight - VIEWPORT_PAD && y === above) {
+        y = Math.max(HEADER_CLEARANCE, window.innerHeight - height - VIEWPORT_PAD)
+      }
+    }
+
+    const next = { x, y, detached: false }
+    lastGood.current = next
+    place(next)
+    // Geometry is re-derived from the live view; deps carry the invalidation
+    // signals (scroll/resize tick, doc changes, anchor identity).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, ...deps])
+
+  return { ref, position }
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -660,7 +660,7 @@ export default function DocumentShow({
       return findTextRange(view.state.doc, composerAnchor)
     },
     preferBelow: true,
-    freezeWhenLost: true,
+    persistent: true,
     gap: popoverGap,
     deps: [composerAnchor, spans, popoverTick, docTick],
   })

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -35,6 +35,7 @@ import { ReviewPopover } from '../../components/review_popover'
 import { AskAiPanel } from '../../components/suggestions_panel'
 import { MarginSuggestions } from '../../components/margin_suggestions'
 import { CommentsPanel, type CommentPayload } from '../../components/comments_panel'
+import { AnchoredComposer } from '../../components/anchored_composer'
 import { SelectionToolbar } from '../../components/selection_toolbar'
 import { PresenceBar, type AgentPresencePayload } from '../../components/presence_bar'
 import { ActivityPanel } from '../../components/activity_panel'
@@ -52,6 +53,8 @@ import {
 } from '../../components/mobile_dock'
 import { useMetaChannel } from '../../lib/use_meta_channel'
 import { useMediaQuery } from '../../lib/use_media_query'
+import { useAnchoredPopover } from '../../lib/use_anchored_popover'
+import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import { postJSON } from '../../lib/csrf'
 import {
   getStoredFlag,
@@ -374,7 +377,11 @@ export default function DocumentShow({
   // While a popover is open, any scroll or resize schedules one rAF-throttled
   // reposition pass (coordsAtPos for a single anchor is cheap).
   const [popoverTick, setPopoverTick] = useState(0)
-  const popoverOpen = Boolean(reviewTarget) || Boolean(selectionTarget) || Boolean(commentTarget)
+  const popoverOpen =
+    Boolean(reviewTarget) ||
+    Boolean(selectionTarget) ||
+    Boolean(commentTarget) ||
+    composerAnchor !== null
   useEffect(() => {
     if (!popoverOpen) return
     let raf = 0
@@ -393,56 +400,6 @@ export default function DocumentShow({
       window.removeEventListener('resize', schedule)
     }
   }, [popoverOpen])
-
-  // Anchor geometry in viewport coords — null while the anchor is off-screen
-  // or gone, hiding the popover until the text scrolls back into view.
-  // Prefers above the anchor (clear of the on-screen keyboard on touch),
-  // flips below when that would cover the sticky header, and clamps x into
-  // the viewport using the popover's estimated width.
-  const anchorPosition = useCallback((view: EditorView, pos: number, estWidth = 200) => {
-    try {
-      const coords = view.coordsAtPos(pos)
-      if (coords.top < -24 || coords.top > window.innerHeight + 24) return null
-      const offset = isMobileRef.current ? 60 : 44
-      const above = coords.top - offset
-      const y = above < 52 ? coords.bottom + 8 : above
-      const x = Math.max(8, Math.min(coords.left, window.innerWidth - estWidth - 8))
-      return { x, y }
-    } catch {
-      return null
-    }
-  }, [])
-
-  const liveSelectionPosition = useMemo(() => {
-    if (!selectionTarget) return null
-    const view = viewRef.current
-    if (!view || view.state.selection.empty) return null
-    return anchorPosition(view, view.state.selection.from, 190)
-    // spans (doc updates) + popoverTick (scroll/resize) drive repositioning.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectionTarget, spans, popoverTick, anchorPosition])
-
-  const liveCommentPosition = useMemo(() => {
-    if (!commentTarget) return null
-    const view = viewRef.current
-    if (!view) return null
-    return anchorPosition(view, view.state.selection.head, 190)
-    // spans (doc updates) + popoverTick (scroll/resize) drive repositioning.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [commentTarget, spans, popoverTick, anchorPosition])
-
-  const liveReview = useMemo(() => {
-    if (!reviewTarget) return null
-    const view = viewRef.current
-    if (!view) return null
-    // Re-derive the span from current state: edits shift positions, and
-    // advancing the review state changes the attrs the popover renders.
-    const span = aiSpanAt(view.state)
-    if (!span) return null
-    const position = anchorPosition(view, span.from, 320)
-    return position ? { span, position } : null
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reviewTarget, spans, popoverTick, anchorPosition])
 
   const handleAdvance = useCallback((state: ReviewState) => {
     const view = viewRef.current
@@ -602,6 +559,144 @@ export default function DocumentShow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handle, docTick])
 
+  // ---- Floating chrome placement (measured, selection-centered) ----
+
+  // Mouse-drag gating: selection chrome stays hidden while the primary
+  // button is down so the toolbar doesn't chase the cursor mid-drag; it
+  // reveals once on release at the settled position. Keyboard selections
+  // reveal immediately (no pointer down). Pointerdowns on the chrome itself
+  // are exempt so pressing a toolbar button doesn't hide it mid-click.
+  const [pointerHeld, setPointerHeld] = useState(false)
+  useEffect(() => {
+    const onChrome = (target: EventTarget | null) =>
+      target instanceof Element &&
+      Boolean(target.closest('.selection-toolbar, .review-popover, .comment-composer--anchored'))
+    const down = (event: PointerEvent) => {
+      if (event.button !== 0 || onChrome(event.target)) return
+      setPointerHeld(true)
+    }
+    const up = () => setPointerHeld(false)
+    window.addEventListener('pointerdown', down, true)
+    window.addEventListener('pointerup', up, true)
+    window.addEventListener('pointercancel', up, true)
+    window.addEventListener('blur', up)
+    return () => {
+      window.removeEventListener('pointerdown', down, true)
+      window.removeEventListener('pointerup', up, true)
+      window.removeEventListener('pointercancel', up, true)
+      window.removeEventListener('blur', up)
+    }
+  }, [])
+
+  // One floating form at a time: an open composer suppresses the selection
+  // chrome, and so does the share popover (z-60, above the chrome's z-50).
+  const [shareOpen, setShareOpen] = useState(false)
+  const composerOpen = !isMobile && composerAnchor !== null
+  const chromeSuppressed = composerOpen || shareOpen
+
+  const popoverGap = isMobile ? 20 : 8
+
+  const selectionToolbarActive =
+    Boolean(selectionTarget) && !pointerHeld && !chromeSuppressed
+  const selectionPopover = useAnchoredPopover<HTMLDivElement>({
+    active: selectionToolbarActive,
+    getView: () => viewRef.current,
+    getRange: () => {
+      const view = viewRef.current
+      if (!view || view.state.selection.empty) return null
+      return { from: view.state.selection.from, to: view.state.selection.to }
+    },
+    gap: popoverGap,
+    deps: [selectionTarget, spans, popoverTick],
+  })
+
+  const commentAffordanceActive =
+    Boolean(commentTarget) && !selectionTarget && !pointerHeld && !chromeSuppressed
+  const commentAffordance = useAnchoredPopover<HTMLDivElement>({
+    active: commentAffordanceActive,
+    getView: () => viewRef.current,
+    getRange: () => {
+      const view = viewRef.current
+      if (!view) return null
+      const head = view.state.selection.head
+      return { from: head, to: head }
+    },
+    gap: popoverGap,
+    deps: [commentTarget, spans, popoverTick],
+  })
+
+  // Re-derive the span from current state: edits shift positions, and
+  // advancing the review state changes the attrs the popover renders.
+  const liveReviewSpan = useMemo(() => {
+    if (!reviewTarget) return null
+    const view = viewRef.current
+    if (!view) return null
+    return aiSpanAt(view.state)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reviewTarget, spans, popoverTick])
+  const reviewActive = Boolean(liveReviewSpan) && !pointerHeld && !chromeSuppressed
+  const reviewPopover = useAnchoredPopover<HTMLDivElement>({
+    active: reviewActive,
+    getView: () => viewRef.current,
+    getRange: () => {
+      const view = viewRef.current
+      if (!view) return null
+      const span = aiSpanAt(view.state)
+      return span ? { from: span.from, to: span.to } : null
+    },
+    gap: popoverGap,
+    deps: [reviewTarget, spans, popoverTick],
+  })
+
+  // The composer anchors below the selection's last line and never overlaps
+  // the anchored text; if a remote edit removes the anchor it freezes in
+  // place (detached) instead of vanishing mid-draft.
+  const composerPopover = useAnchoredPopover<HTMLFormElement>({
+    active: composerOpen,
+    getView: () => viewRef.current,
+    getRange: () => {
+      const view = viewRef.current
+      if (!view || composerAnchor === null) return null
+      return findTextRange(view.state.doc, composerAnchor)
+    },
+    preferBelow: true,
+    freezeWhenLost: true,
+    gap: popoverGap,
+    deps: [composerAnchor, spans, popoverTick, docTick],
+  })
+
+  // Mode switches close the composer without posting (same as Cancel).
+  useEffect(() => {
+    setComposerAnchor(null)
+  }, [mode])
+
+  // The anchored text stays visibly marked while the composer is open —
+  // the editor selection itself collapses when focus moves to the textarea.
+  useEffect(() => {
+    if (!composerOpen || composerAnchor === null) return
+    const view = viewRef.current
+    if (!view) return
+    const range = findTextRange(view.state.doc, composerAnchor)
+    const dom = range ? domRange(view, range.from, range.to) : null
+    setHighlight('comment-anchor', dom ? [dom] : [])
+    return () => clearHighlight('comment-anchor')
+    // docTick keeps the highlight tracking edits around the anchor.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [composerOpen, composerAnchor, docTick])
+
+  const closeComposer = useCallback(() => {
+    setComposerAnchor(null)
+    viewRef.current?.focus()
+  }, [])
+
+  const submitAnchoredComment = useCallback(
+    (body: string) => {
+      submitComment(body, composerAnchor)
+      viewRef.current?.focus()
+    },
+    [submitComment, composerAnchor],
+  )
+
   const jumpToAnchor = useCallback((anchorText: string) => {
     const view = viewRef.current
     if (!view) return
@@ -638,7 +733,7 @@ export default function DocumentShow({
               <PresenceBar humans={peers} agents={presences} compact={isMobile} />
             </div>
             <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
-            <SharePopover agentsActive={presences.length} />
+            <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
             <HeaderMenu
               panelOpen={panelOpen}
               onTogglePanel={() => setPanelOpen((open) => !open)}
@@ -700,9 +795,11 @@ export default function DocumentShow({
               <AskAiPanel aiPending={aiPending} onAskAi={(instruction) => askAi(instruction)} />
               <CommentsPanel
                 comments={comments}
-                composerAnchor={composerAnchor}
+                // The desktop composer is the anchored card next to the
+                // selection — the rail keeps the list only.
+                composerAnchor={null}
                 onSubmit={submitComment}
-                onCancelComposer={() => setComposerAnchor(null)}
+                onCancelComposer={closeComposer}
                 onResolve={resolveComment}
                 onJumpTo={jumpToAnchor}
               />
@@ -710,9 +807,10 @@ export default function DocumentShow({
             </aside>
           )}
         </main>
-        {selectionTarget && liveSelectionPosition && (
+        {selectionTarget && selectionToolbarActive && (
           <SelectionToolbar
-            position={liveSelectionPosition}
+            rootRef={selectionPopover.ref}
+            position={selectionPopover.position}
             actions={[
               // Per-mode capability matrix — Edit: Comment · Ask AI;
               // Suggest: Comment (typing IS the suggestion mechanism);
@@ -738,9 +836,10 @@ export default function DocumentShow({
             ]}
           />
         )}
-        {commentTarget && !selectionTarget && liveCommentPosition && (
+        {commentTarget && commentAffordanceActive && (
           <SelectionToolbar
-            position={liveCommentPosition}
+            rootRef={commentAffordance.ref}
+            position={commentAffordance.position}
             actions={[
               {
                 label: 'Comment on this paragraph',
@@ -752,11 +851,22 @@ export default function DocumentShow({
             ]}
           />
         )}
-        {reviewTarget && liveReview && (
+        {liveReviewSpan && reviewActive && (
           <ReviewPopover
-            span={liveReview.span}
-            position={liveReview.position}
+            rootRef={reviewPopover.ref}
+            span={liveReviewSpan}
+            position={reviewPopover.position}
             onAdvance={handleAdvance}
+          />
+        )}
+        {composerOpen && composerAnchor !== null && (
+          <AnchoredComposer
+            key={composerAnchor}
+            rootRef={composerPopover.ref}
+            anchor={composerAnchor}
+            position={composerPopover.position}
+            onSubmit={submitAnchoredComment}
+            onCancel={closeComposer}
           />
         )}
         {isMobile && (

--- a/docs/plans/2026-06-06-002-feat-anchored-popover-placement-plan.md
+++ b/docs/plans/2026-06-06-002-feat-anchored-popover-placement-plan.md
@@ -1,0 +1,262 @@
+---
+title: "feat: Slick anchored placement for selection, comment, and review chrome"
+type: feat
+status: completed
+date: 2026-06-06
+---
+
+# feat: Slick Anchored Placement for Selection, Comment, and Review Chrome
+
+## Summary
+
+Polish the positioning and UX of the floating forms around the edit/suggest/comment modes: the selection toolbar, the click-to-comment affordance, the AI review popover, and the comment composer. Replace estimated-width placement with measured, selection-centered placement that never covers selected text; stop the toolbar from jittering during drag-selection; and move the desktop comment composer from the far-right rail to an anchored card next to the selection (Google Docs style), which also fixes a real bug where the composer is invisible when the side panel is hidden.
+
+---
+
+## Problem Frame
+
+A design critique of the current floating chrome (all in `app/frontend/pages/documents/show.tsx` + `app/frontend/entrypoints/application.css`) surfaces five placement problems:
+
+1. **Left-edge anchoring, not selection-centered.** `anchorPosition()` (show.tsx) anchors every popover at `view.coordsAtPos(selection.from)` and left-aligns at `coords.left`. Selecting mid-line or selecting backwards puts the toolbar far from where the user's eye and cursor are. Google Docs, Medium, and Notion center the toolbar horizontally over the selection.
+2. **Estimated widths, not measured.** Clamping uses hardcoded guesses (`estWidth` of 190/200/320). The actual rendered width differs (label lengths vary by mode — "Comment on this paragraph" vs "Comment · Ask AI"), so near the right viewport edge the toolbar either overflows or over-clamps. There is no bottom-edge clamping at all.
+3. **Flip-below covers the selection.** When there's no room above (`above < 52`), the toolbar flips to `coords.bottom + 8` of the *start* position — for a multi-line selection that lands on top of the selected text.
+4. **Drag jitter.** `handleSelection` fires on every selection change, so the toolbar appears and chases the cursor while the user is still dragging. Polished editors show selection chrome only after the pointer is released.
+5. **Composer disconnect + hidden-panel bug.** Clicking "Comment" opens the composer in the right rail (`CommentsPanel`), ~36rem of eye travel away from the selected text, with only a truncated quote as context. Worse: when the panel is hidden (⌘\, `doc-page.is-panel-hidden .doc-rail { display: none }`), the composer opens invisibly — "Comment" appears to do nothing.
+
+The margin suggestion cards already have a strong placement system (anchor-height stacking, two-pass measure, placed-then-animate); the popover chrome deserves the same level of craft.
+
+---
+
+## Key Technical Decisions
+
+- **Keep positioning hand-rolled; centralize it in one shared hook.** No `@floating-ui/dom` dependency. The repo is deliberately dependency-light and the needed logic (measure, center, clamp, flip) is ~60 lines. Today the math lives inline in `show.tsx` with per-callsite estimates; the fix is one `useAnchoredPopover`-style hook all three popovers share.
+- **Two-pass measure-then-place, mirroring the margin-card pattern.** Render the popover invisibly (`visibility: hidden` or opacity 0) on first mount, measure its real box in `useLayoutEffect`, then position before paint. This is the same discipline `MarginSuggestions` already uses (`is-placed` flag) — initial placement never flashes at a wrong position and clamping uses true dimensions.
+- **Anchor geometry stays identity-based and re-derived live.** Preserve the existing architecture: popover state stores *what* is anchored (selection text, span), never coordinates; geometry re-derives from the live editor on the existing rAF-throttled scroll/resize tick (`popoverTick`) and doc changes. This plan changes *how* coordinates are computed, not *when*.
+- **Center over the selection range, flip below the selection's end.** Horizontal: midpoint between `coordsAtPos(from)` and `coordsAtPos(to)` when they're on the same line; on multi-line selections, center over the line containing the toolbar's vertical anchor. Vertical: prefer above `from`'s line; when blocked by the sticky header, place below `coordsAtPos(to).bottom` — below the *last* line of the selection, never on top of it.
+- **Show selection chrome on settle, not mid-drag.** Track primary-pointer-down state (window-level `pointerdown`/`pointerup`); while the pointer is down with a growing selection, defer showing the toolbar until release. Keyboard selections (shift+arrows) show after the existing selection-change signal settles — no timer-based debounce of position updates, only of first reveal.
+- **Desktop comment composer becomes an anchored floating card; the rail keeps the comment list.** The composer renders adjacent to the selection using the same shared positioning hook (below the selection's last line by default — composers are taller than toolbars and reading flows downward). Submitting posts exactly as today (`anchor_text` semantics, optimistic insert into the rail list). Mobile keeps the comments sheet path untouched. This removes the rail-visibility dependency, fixing the hidden-panel bug structurally rather than by force-opening the panel.
+- **Anchor stays visibly marked while composing.** Reuse the CSS Custom Highlight API pattern from `MarginSuggestions` (`CSS.highlights`) to tint the anchored text while the composer is open, so the connection between form and text is explicit even though the selection itself collapses when focus moves into the textarea.
+
+---
+
+## High-Level Technical Design
+
+Placement algorithm for the shared hook (directional guidance, not implementation specification):
+
+```mermaid
+flowchart TB
+  A[Anchor identity set\nselection / span / comment target] --> B[Render popover hidden]
+  B --> C[useLayoutEffect: measure real width and height]
+  C --> D[Derive anchor rects from live view\ncoordsAtPos from and to]
+  D --> E{Anchor on screen?}
+  E -->|no| F[Return null - popover hidden\nuntil text scrolls back]
+  E -->|yes| G[x = center over selection,\nclamped to viewport with real width]
+  G --> H{Room above from-line\nclear of sticky header?}
+  H -->|yes| I[y = above from-line]
+  H -->|no| J[y = below to-line bottom\nnever over the selection]
+  I --> K[Clamp y to viewport bottom\nwith real height]
+  J --> K
+  K --> L[Reveal popover - entrance animation]
+  L --> M[Scroll / resize / doc tick\nre-derives D..K each rAF]
+```
+
+Reveal gating sits in front of this pipeline: while the primary pointer is down, a non-empty selection sets the anchor identity but holds reveal until `pointerup`.
+
+---
+
+## Requirements
+
+**Placement correctness**
+
+- R1. Selection toolbar and click-to-comment affordance render horizontally centered over the selection (or the anchor line for multi-line selections), clamped fully inside the viewport on both axes using measured dimensions — no hardcoded width estimates remain.
+- R2. Popovers never cover selected text: above the selection's first line by default; when blocked by the header, below the selection's last line.
+- R3. First paint is already correctly placed — no visible jump from an unmeasured position (two-pass measure before reveal).
+- R4. Scroll, resize, and document-change tracking continue to work exactly as today (rAF-throttled, identity-anchored, hide-when-offscreen), with no additional per-frame cost beyond one `getBoundingClientRect` of the popover.
+
+**Interaction feel**
+
+- R5. During a mouse drag-selection the toolbar does not appear or chase the cursor; it reveals once the pointer is released over a non-empty selection. Keyboard-driven selections still reveal without requiring a pointer event.
+- R6. The existing entrance animation (`popover-in`) plays on reveal; repositioning while open (scroll/typing) remains instant with no transition lag.
+
+**Comment composer**
+
+- R7. On desktop, choosing "Comment" opens an anchored composer card adjacent to the selection instead of (not in addition to) the rail composer; Escape and Cancel dismiss it; ⌘/Ctrl+Enter submits; submit behavior (optimistic comment, `anchor_text`, server POST) is byte-identical to today.
+- R8. The composer is fully usable when the side panel is hidden — the hidden-panel invisible-composer bug is gone.
+- R9. While the composer is open, its anchored text is visibly highlighted; the highlight clears on submit, cancel, or dismiss.
+- R10. Mobile (≤64rem) behavior is unchanged: "Comment" routes into the comments sheet with the composer at the top, as today.
+
+**Review popover parity**
+
+- R11. The AI review popover adopts the same measured, centered, flip-safe placement (it currently shares the worst of the estimate-based logic with `estWidth = 320`).
+
+---
+
+## Implementation Units
+
+### U1. Shared anchored-popover placement hook
+
+**Goal:** One reusable hook that turns an anchor (ProseMirror position range) plus a popover element ref into measured, centered, clamped, flip-safe viewport coordinates.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** none
+
+**Files:**
+- `app/frontend/lib/use_anchored_popover.ts` (new)
+- `app/frontend/pages/documents/show.tsx` (replace `anchorPosition` and the three `useMemo` position derivations)
+- `app/frontend/entrypoints/application.css` (pre-measure hidden state)
+
+**Approach:** The hook owns the two-pass cycle: callers pass a function deriving the anchor range (`from`/`to`) from the live view, plus the existing invalidation signals (`spans`, `popoverTick`, doc tick). It measures the popover element via ref, computes x (centered, clamped with real width), y (above-first-line preferred, below-last-line fallback, bottom-clamped with real height), and returns `null` when the anchor is offscreen. The mobile offset constants (44/60) and header clearance (52) move into the hook as named constants. Keep the `try/catch` around `coordsAtPos` — the editor can be mid-teardown. Note: today's `anchorPosition` is already a single shared helper — what's per-callsite is only the width estimates; the hook replaces it with measured geometry, it is not a first-time extraction. During the pre-measure hidden phase the popover element is inert to keyboard focus (`aria-hidden="true"` and unfocusable children) so a Tab press can never land inside an invisible popover.
+
+**Patterns to follow:** `MarginSuggestions`' two-pass `useLayoutEffect` measure + `is-placed` reveal flag (`app/frontend/components/margin_suggestions.tsx`); the existing rAF-throttled `popoverTick` effect in `show.tsx`.
+
+**Test scenarios:**
+- Happy path: selecting a short mid-line phrase shows the toolbar centered above it; toolbar's box never overlaps the selection rect.
+- Edge: selection beginning near the right viewport edge — toolbar clamps inside the viewport (assert `boundingBox().x + width <= viewport width - 8`), with its real width, not an estimate.
+- Edge: selection on the first visible line under the sticky header — toolbar flips below the selection's *last* line (assert toolbar top ≥ selection bottom).
+- Edge: selection scrolled offscreen — popover unmounts/hides; scrolling back restores it at the right place.
+- Edge: multi-line (3+ lines) selection — flip-below places the toolbar under the final line, not inside the block.
+- First-paint (R3): the popover's first visible frame is already at its final position — assert no positional mutation between reveal and the next frame (e.g., compare `boundingBox()` across two rAFs after appearance).
+- Performance (R4): repositioning work per scroll/resize tick stays at one `coordsAtPos` per anchor end plus one `getBoundingClientRect` of the popover — verified by code review of the hook, not instrumentation; the existing rAF-throttle effect is reused unchanged.
+- Test expectation: these run as Playwright assertions in U5's check script (the repo has no JS unit-test framework; `npm run check` covers types).
+
+**Verification:** `npm run check` passes; U5 browser-check scenarios for placement pass.
+
+### U2. Reveal-on-settle for drag selections
+
+**Goal:** The selection toolbar appears once per settled selection instead of chasing the cursor mid-drag.
+
+**Requirements:** R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/frontend/pages/documents/show.tsx`
+
+**Approach:** Track primary-pointer state with window-level listeners (capture phase, passive). While the pointer is down, `handleSelection` still records the selection target (anchor identity) but the render gate holds the toolbar hidden; `pointerup` flips the gate and the toolbar reveals with its entrance animation at the final, settled position. Keyboard selections: reveal on the first non-empty selection-change event with no pointer down — no timer or debounce anywhere. A held Shift+Arrow sweep will reposition the visible toolbar per keystroke; that is accepted (only mouse drag gets the hold-until-release gate). Mode switches and Escape clear the gate state. Click-to-comment in Comment mode is a bare click (empty selection) and is unaffected by the drag gate.
+
+**Patterns to follow:** the existing window-level listener effects in `show.tsx` (keyboard shortcuts, scroll/resize tick) — add/remove in one effect with cleanup.
+
+**Test scenarios:**
+- Happy path: mouse-drag a selection slowly — toolbar is absent during the drag, appears after release (Playwright: assert `.selection-toolbar` not visible between `mouse.down()` and `mouse.up()`).
+- Happy path: select via Shift+ArrowRight — toolbar appears without any pointer event.
+- Edge: drag that ends with an empty/whitespace selection — no toolbar appears after release.
+- Edge: pointer released outside the editor (drag out of the window) — toolbar still reveals (listener is window-level).
+
+**Verification:** U5 browser-check drag scenario passes; manual feel check during `bin/dev`.
+
+### U3. Anchored desktop comment composer
+
+**Goal:** "Comment" opens a floating composer card next to the selection on desktop, replacing the rail composer entry point and structurally fixing the hidden-panel invisibility bug.
+
+**Requirements:** R7, R8, R9, R10
+
+**Dependencies:** U1
+
+**Files:**
+- `app/frontend/components/anchored_composer.tsx` (new — composer card: quote, textarea, Comment/Cancel)
+- `app/frontend/components/comments_panel.tsx` (desktop no longer renders the inline composer; keep it for the mobile sheet path)
+- `app/frontend/lib/highlights.ts` (new — extract the `domRange` + `supportsHighlights` + set/clear lifecycle from `margin_suggestions.tsx` into a small shared helper consumed by both)
+- `app/frontend/components/margin_suggestions.tsx` (consume the extracted highlight helper)
+- `app/frontend/pages/documents/show.tsx` (desktop branch renders the anchored composer via U1's hook, positioned below the selection's last line; submit wires to the existing `submitComment`)
+- `app/frontend/entrypoints/application.css` (composer card styles — reuse `comment-composer` tokens: `--surface-raised`, `--accent-soft`, radius 10px, `card-in` animation)
+- `script/browser_check.mjs` (the existing comment flow asserts `.comment-composer` and `.comment-input` in the rail — update those selector paths to the anchored card)
+
+**Approach:** `composerAnchor` (existing state) drives the anchored card on desktop and the sheet on mobile — the state shape doesn't change, only the desktop render target. The card autofocuses its textarea (the existing `CommentsPanel` focus effect moves with the composer). Anchor highlight: on open, resolve the anchor text to a range via `findTextRange` and set a `CSS.highlights` entry (new name, e.g. `comment-anchor`) through the shared `lib/highlights.ts` helper; clear it on close. While the composer is open, suppress the selection toolbar (one floating form at a time).
+
+Lifecycle contract (the floating card is the most stateful chrome in the plan — these are pinned, not implementer-invented):
+- **Dismissal:** only Escape, Cancel, and Submit close the card. Clicking outside (editor, margin cards, header) does not dismiss a composer with a non-empty draft — drafts are never silently lost. An outside click with an empty draft dismisses.
+- **Mode switch:** switching editor mode while the composer is open closes it without posting (same as Cancel) and clears the highlight.
+- **Anchor lost to a remote edit:** if re-derivation (`popoverTick`/doc tick) finds the anchor text no longer locatable, the card stays open but detaches to a stable position (stops tracking), shows a one-line "original text changed" note, and submit still posts with the captured `anchor_text` (the server already tolerates non-matching anchors; the rail quote remains as context). The highlight clears.
+- **Placement:** below the selection's last line by default; if that would overflow the viewport bottom, flip above the selection's first line; if neither side fully fits, clamp downward with the hard floor `selectionBottom + 8` — the card never overlaps the selected text (R2 applies to the composer too).
+- **Anchor change while open:** the card remounts (`key={composerAnchor}`), resetting the draft — same behavior as dismissing and reopening.
+- **Focus:** textarea autofocuses on open; on close (any path), focus returns to the editor (`view.focus()`).
+- **Stacking:** the composer joins the selection-chrome layer (z-50, same as toolbar/review popover, below the share popover's z-60); opening the share popover suppresses selection chrome.
+
+**Patterns to follow:** composer markup/behavior from `CommentsPanel` (Escape, ⌘Enter, disabled-submit-when-empty); highlight lifecycle from `MarginSuggestions.hover`; optimistic submit already in `show.tsx`.
+
+**Test scenarios:**
+- Happy path: select text → Comment → composer card appears below the selection, textarea focused; type and ⌘Enter → comment appears in the rail list with the right quote; composer closes; highlight clears.
+- Happy path (bug fix): hide the panel (⌘\) → select → Comment → composer is visible and submits successfully (this is the regression test for the invisible-composer bug).
+- Edge: Escape with text typed — composer closes, no comment posted.
+- Edge: selection near the bottom of the viewport — composer clamps upward enough to stay fully visible (taller-than-toolbar case exercises R1's height clamping).
+- Edge: click-to-comment in Comment mode (collapsed selection on a paragraph) — composer anchors below that block's line.
+- Integration: mobile viewport — "Comment" still opens the comments sheet, composer inside the sheet, unchanged.
+
+**Verification:** U5 browser-check composer scenarios pass; existing Rails `test/integration/comment_flow_test.rb` stays green (server contract untouched).
+
+### U4. Review popover and CSS polish on the shared system
+
+**Goal:** `ReviewPopover` and the click-to-comment affordance adopt the shared hook; floating-chrome CSS is consolidated so all popovers share entrance, radius, shadow, and z-index tokens.
+
+**Requirements:** R11, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/frontend/pages/documents/show.tsx` (review position derivation moves to the hook)
+- `app/frontend/components/review_popover.tsx` (accept ref-based measurement if the hook requires forwarding)
+- `app/frontend/entrypoints/application.css` (dedupe `.selection-toolbar` / `.review-popover` shared properties; keep the existing mobile touch-target overrides at ≤64rem)
+
+**Approach:** Mechanical adoption of U1. While here, verify the mobile `max-width: calc(100vw - 16px)` wrap behavior for the review popover still holds under measured clamping. Pin the z-index ladder explicitly in the CSS (header 30 · selection chrome — toolbar/review popover/anchored composer — 50 · share popover 60 · mobile dock 60 · sheets 70+) and make opening the share popover suppress selection chrome so the two never stack ambiguously.
+
+**Test scenarios:**
+- Happy path: caret inside an AI-attributed span — review popover appears centered over the span start, fully in-viewport.
+- Edge: AI span at the far right margin — popover clamps with its real (≈320px+) width.
+- Test expectation: covered by U5 script scenarios; no behavioral change to review-state advancing (existing logic untouched).
+
+**Verification:** `npm run check`; U5 scenarios pass.
+
+### U5. Browser-check coverage for floating-chrome placement
+
+**Goal:** Executable regression coverage for the placement behaviors, in the repo's established Playwright-script style.
+
+**Requirements:** R1, R2, R5, R7, R8 (the browser-executable placement/reveal behaviors). R3, R4, R6, R9, R10, and R11 are verified within their owning units (U1–U4) via their own scenarios, `npm run check`, and manual feel checks — this script does not claim coverage of them.
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- `script/browser_check.mjs` (default: append a placement section to the existing script — it already owns the comment flow and selection-toolbar assertions, and one CI entry point beats two; split into a separate `script/popover_check.mjs` only if the section makes the script unwieldy)
+
+**Approach:** Follow `script/browser_check.mjs` conventions exactly: plain `node` script, `BASE_URL` env, `ok`/`fail` helpers, fresh doc created via `POST /api/docs`, console/pageerror capture. Scenarios: centered placement, right-edge clamp, header flip-below, drag-hold-no-toolbar, hidden-panel composer (⌘\ → select → Comment → visible textarea → submit → comment card in rail after panel reopen), bottom-edge composer clamp.
+
+**Test scenarios:** the script *is* the test enumeration (see U1–U3 scenarios). Test expectation beyond the script: none — pure verification harness, no app behavior of its own.
+
+**Verification:** `node script/browser_check.mjs` (including the new placement section) exits 0 against a local `bin/dev` server.
+
+---
+
+## Scope Boundaries
+
+**In scope:** placement/reveal of the selection toolbar, click-to-comment affordance, review popover, and desktop comment composer; the hidden-panel composer bug; anchor highlighting while composing.
+
+**Non-goals:**
+- Mode semantics, suggest-mode tracked-changes behavior, accept/reject flows, and all server APIs — untouched.
+- Margin card stacking (`margin_suggestions.tsx`, `margin_inline_suggestions.tsx`) — already well-placed; only referenced as the pattern source.
+- Adding a positioning dependency (`@floating-ui/dom`) — rejected in KTDs.
+
+**Deferred to Follow-Up Work:**
+- Ask AI panel placement (rail) — the same anchored-card treatment could apply to an "Ask AI about this selection" composer, but it's a product decision beyond placement polish.
+- Comment threads/replies anchored in the margin (full Google Docs margin-thread model) — a larger feature; this plan only moves the *composer* to the anchor.
+- Animated reposition (springy follow) — explicitly keeping instant tracking on scroll for now.
+
+---
+
+## Assumptions
+
+Headless-run inferred bets (pipeline mode; flag at review if wrong):
+
+- "Edit/suggest/comment forms" means the floating chrome around those modes (selection toolbar, click-to-comment affordance, comment composer, review popover) — not the `ModeControl` switcher in the header, which recent work already placed.
+- Replacing the rail composer with the anchored composer on desktop (rather than keeping both) is the intended "slick" outcome; the rail remains the home of the comment *list*.
+- One floating form at a time is acceptable UX (composer suppresses the selection toolbar while open).
+
+---
+
+## Sources & Research
+
+- Current placement logic: `app/frontend/pages/documents/show.tsx` (`anchorPosition`, `liveSelectionPosition`, `liveCommentPosition`, `liveReview`, `popoverTick` effect).
+- Popover components: `app/frontend/components/selection_toolbar.tsx`, `app/frontend/components/review_popover.tsx`; composer: `app/frontend/components/comments_panel.tsx`.
+- Placement pattern source: `app/frontend/components/margin_suggestions.tsx` (two-pass measure, `is-placed`, `CSS.highlights`).
+- Styling/tokens: `app/frontend/entrypoints/application.css` (`.selection-toolbar`, `.review-popover`, `.comment-composer`, `popover-in`, `card-in`, mobile overrides at ≤64rem).
+- Prior mode work: `docs/plans/2026-06-05-008-feat-google-docs-suggest-comment-modes-plan.md` (origin of the mode-gated action matrix and click-to-comment).
+- Verification harness convention: `script/browser_check.mjs`.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -480,7 +480,7 @@ try {
     a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
 
   // Centered over the selection, fully in-viewport, never covering it.
-  await p.locator('.milkdown .ProseMirror p').nth(1).dblclick()
+  await p.locator('.milkdown .ProseMirror p').nth(1).dblclick({ position: { x: 12, y: 10 } })
   const toolbar = p.locator('.selection-toolbar.is-placed')
   await toolbar.waitFor({ timeout: 5000 })
   await p.waitForTimeout(250) // entrance animation settles
@@ -544,7 +544,7 @@ try {
   await p.keyboard.press('Meta+\\')
   const anchorPara = p.locator('.milkdown .ProseMirror p').nth(5)
   await anchorPara.scrollIntoViewIfNeeded()
-  await anchorPara.dblclick()
+  await anchorPara.dblclick({ position: { x: 12, y: 10 } })
   await p.locator('.selection-toolbar.is-placed').waitFor({ timeout: 5000 })
   await p.locator('.selection-toolbar button', { hasText: 'Comment' }).first().click()
   const composer = p.locator('.comment-composer--anchored.is-placed')

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -449,6 +449,132 @@ try {
   else fail(`demo doc mode after tamper: "${demoMode}"`)
   await demoPage.close()
 
+  // --- Floating chrome placement: measured, centered, never covering ---
+  const placeDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Placement check',
+        markdown: Array.from(
+          { length: 12 },
+          (_, i) =>
+            `Placement paragraph number ${i} with enough words to span a comfortable line of prose in the editor.`,
+        ).join('\n\n'),
+      }),
+    })
+  ).json()
+  const p = await makePage('a')
+  await p.goto(`${BASE}/d/${placeDoc.slug}`)
+  await p.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await p.waitForTimeout(1000)
+
+  const selectionRect = () =>
+    p.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel || sel.rangeCount === 0) return null
+      const r = sel.getRangeAt(0).getBoundingClientRect()
+      return r.width > 0 ? { x: r.x, y: r.y, width: r.width, height: r.height } : null
+    })
+  const boxesOverlap = (a, b) =>
+    a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+
+  // Centered over the selection, fully in-viewport, never covering it.
+  await p.locator('.milkdown .ProseMirror p').nth(1).dblclick()
+  const toolbar = p.locator('.selection-toolbar.is-placed')
+  await toolbar.waitFor({ timeout: 5000 })
+  await p.waitForTimeout(250) // entrance animation settles
+  let tb = await toolbar.boundingBox()
+  let sel = await selectionRect()
+  const vp = p.viewportSize()
+  if (tb && sel && vp) {
+    const drift = Math.abs(tb.x + tb.width / 2 - (sel.x + sel.width / 2))
+    if (drift <= Math.max(40, tb.width / 2)) ok('toolbar centers over the selection')
+    else fail(`toolbar off-center by ${Math.round(drift)}px`)
+    if (tb.x >= 0 && tb.y >= 0 && tb.x + tb.width <= vp.width && tb.y + tb.height <= vp.height) {
+      ok('toolbar fully inside the viewport (measured clamp)')
+    } else fail(`toolbar escapes the viewport: ${JSON.stringify(tb)}`)
+    if (!boxesOverlap(tb, sel)) ok('toolbar does not cover the selected text')
+    else fail('toolbar covers the selection')
+  } else fail('could not measure toolbar/selection geometry')
+
+  // First visible frame is final: position is stable across frames.
+  const tbAgain = await (async () => {
+    await p.evaluate(() => new Promise((r) => requestAnimationFrame(r)))
+    return toolbar.boundingBox()
+  })()
+  if (tb && tbAgain && Math.abs(tb.x - tbAgain.x) < 1 && Math.abs(tb.y - tbAgain.y) < 1) {
+    ok('toolbar placement stable after reveal (no post-paint jump)')
+  } else fail('toolbar moved after reveal')
+
+  // Header flip: with the anchor line tight under the sticky header, the
+  // toolbar moves below the selection instead of covering the header.
+  await p.evaluate(() => {
+    const r = window.getSelection()?.getRangeAt(0)?.getBoundingClientRect()
+    if (r) window.scrollBy(0, r.top - 58)
+  })
+  await p.waitForTimeout(200) // rAF-throttled reposition pass
+  tb = await toolbar.boundingBox()
+  sel = await selectionRect()
+  if (tb && sel && tb.y >= sel.y + sel.height - 1) {
+    ok('toolbar flips below the selection when the header blocks above')
+  } else fail(`toolbar did not flip below: toolbar ${JSON.stringify(tb)} sel ${JSON.stringify(sel)}`)
+
+  // Drag settle: no toolbar chasing the cursor mid-drag; one reveal on release.
+  const dragPara = p.locator('.milkdown .ProseMirror p').nth(3)
+  await dragPara.scrollIntoViewIfNeeded()
+  const dragBox = await dragPara.boundingBox()
+  await p.mouse.move(dragBox.x + 4, dragBox.y + 8)
+  await p.mouse.down()
+  let seenMidDrag = false
+  for (let i = 1; i <= 6; i += 1) {
+    await p.mouse.move(dragBox.x + 4 + i * 30, dragBox.y + 8, { steps: 2 })
+    await p.waitForTimeout(40)
+    if (await p.locator('.selection-toolbar').isVisible().catch(() => false)) seenMidDrag = true
+  }
+  if (!seenMidDrag) ok('toolbar held back while dragging a selection')
+  else fail('toolbar appeared mid-drag')
+  await p.mouse.up()
+  await p.locator('.selection-toolbar.is-placed').waitFor({ timeout: 5000 })
+  ok('toolbar revealed once on release at the settled position')
+
+  // Anchored composer: visible and usable with the side panel hidden (the
+  // old rail composer rendered into display:none), never covering its
+  // anchor, clamped into the viewport even with the anchor near the bottom.
+  await p.keyboard.press('Meta+\\')
+  const anchorPara = p.locator('.milkdown .ProseMirror p').nth(5)
+  await anchorPara.scrollIntoViewIfNeeded()
+  await anchorPara.dblclick()
+  await p.locator('.selection-toolbar.is-placed').waitFor({ timeout: 5000 })
+  await p.locator('.selection-toolbar button', { hasText: 'Comment' }).first().click()
+  const composer = p.locator('.comment-composer--anchored.is-placed')
+  await composer.waitFor({ timeout: 5000 })
+  ok('anchored composer visible with the side panel hidden')
+
+  await p.evaluate(() => {
+    // Push the anchor near the viewport bottom — the composer must clamp
+    // or flip, staying fully visible without covering the anchored text.
+    window.scrollBy(0, -Math.max(0, window.innerHeight * 0.6))
+  })
+  await p.waitForTimeout(200)
+  const composerBox = await composer.boundingBox()
+  const anchorBox = await anchorPara.boundingBox()
+  if (composerBox && anchorBox && vp) {
+    if (composerBox.y >= 0 && composerBox.y + composerBox.height <= vp.height) {
+      ok('composer stays fully inside the viewport near the bottom edge')
+    } else fail(`composer clipped by the viewport: ${JSON.stringify(composerBox)}`)
+    if (!boxesOverlap(composerBox, anchorBox)) ok('composer does not cover its anchor paragraph')
+    else fail('composer covers the anchored text')
+  } else fail('could not measure composer/anchor geometry')
+
+  const hiddenPanelComment = `Hidden panel comment ${Date.now()}`
+  await p.fill('.comment-composer--anchored .comment-input', hiddenPanelComment)
+  await p.locator('.comment-composer--anchored .btn-accept').click()
+  await p.keyboard.press('Meta+\\')
+  await p.locator('.comment-card', { hasText: hiddenPanelComment }).waitFor({ timeout: 10000 })
+  ok('comment posted from the anchored composer landed in the rail')
+  await p.close()
+
   for (const [label, errs] of Object.entries(errors)) {
     const fatal = errs.filter(
       (e) =>


### PR DESCRIPTION
## What this does

Makes the floating chrome around the edit/suggest/comment modes feel deliberate instead of approximate. The selection toolbar, click-to-comment affordance, AI review popover, and comment composer now share one measured placement system — and the desktop comment composer moves from the far-right rail to a card anchored at the selection, Google Docs style.

**Why it matters:** the old placement guessed popover widths (hardcoded 190/320px), anchored everything to the selection's *start* (so flipping below covered multi-line selections), chased the cursor mid-drag, and — worst — opening a comment with the side panel hidden rendered the composer into `display:none`, so "Comment" silently did nothing.

## How it works

- **`lib/use_anchored_popover.ts`** — two-pass measure-then-place: render hidden + inert, measure the real box in a layout effect, then center over the selection, clamp into the viewport on both axes, and flip *below the selection's last line* when the header blocks above. First visible frame is final (no jump). Geometry stays identity-anchored and re-derives on the existing rAF scroll/resize tick.
- **Reveal-on-settle** — window-level pointer tracking holds selection chrome while the mouse button is down; one reveal at the settled position. Keyboard selections reveal immediately.
- **`components/anchored_composer.tsx`** — the desktop composer floats below the selection with a pinned lifecycle: outside clicks never discard a non-empty draft, mode switches cancel, a remote edit deleting the anchor detaches the card (with a note) instead of hiding it, focus returns to the editor on close, drafts reset on anchor change via key remount. Fixes the hidden-panel bug structurally. Mobile keeps the comments sheet.
- **Anchor tinting** — the anchored text stays highlighted while composing (`lib/highlights.ts`, extracted from margin_suggestions and now shared).
- **Z-index ladder pinned** — header 30 · selection chrome 50 · share popover 60 · sheets 70+; share popover and composer suppress the rest ("one floating form at a time").

## Testing

- `npm run check` (tsc) green; `bin/rails test` 173 runs, 0 failures.
- New placement section in `script/browser_check.mjs` — 11 live assertions: centered toolbar, measured viewport clamp, no-cover guarantee, header flip-below, drag-hold reveal gating, post-reveal stability, hidden-panel composer regression, bottom-edge composer clamp, and the full anchored-composer comment flow. All passing locally.
- Plan: `docs/plans/2026-06-06-002-feat-anchored-popover-placement-plan.md` (R1–R11 verified per unit).

## Known Residuals

- Multi-agent code review (ce-code-review) could not run — subagent session limit. A single-context review pass was done instead; treat review coverage as degraded.
- Comment-mode click-to-comment with the new reveal gating is code-verified + covered by the (currently wedging) legacy browser flow, but was not re-verified live this session.
- Pre-existing (reproduces on `main`, not introduced here): the two-window demo-doc browser-check sequence wedges the renderer in Shiki/Oniguruma tokenization (`@milkdown/plugin-highlight`) — worth a follow-up issue.

## Post-Deploy Monitoring & Validation

- Watch browser console errors on `/d/:slug` pages (any `use_anchored_popover` / `anchored_composer` stack frames).
- Healthy signal: `POST /d/:slug/comments` rate unchanged or up; comment submissions succeed (2xx).
- Failure signal: comment POST rate dropping to zero post-deploy (composer unreachable) → rollback trigger; this is a frontend-only change, revert is safe.
- Validation window: first day of normal use; owner: @kieranklaassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
