### PR TITLE
fix: accepted/rejected/resolved cards no longer reappear after refresh

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,8 +11,13 @@ class CommentsController < InertiaController
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid => e
+    # No explicit `status:` on error-bag redirects: InertiaRails' middleware
+    # only preserves staged `inertia: { errors: }` session data across 301/302
+    # responses (it upgrades Inertia PATCH/PUT/DELETE redirects to 303 itself).
+    # An explicit 303 here makes the middleware delete the errors before the
+    # follow-up request can render them.
     redirect_back fallback_location: document_page_path(params[:slug]),
-                  inertia: { errors: { comment: e.record.errors.full_messages.to_sentence }, status: :see_other }
+                  inertia: { errors: { comment: e.record.errors.full_messages.to_sentence } }
   end
 
   def resolve
@@ -33,8 +38,8 @@ class CommentsController < InertiaController
   rescue ActiveRecord::RecordNotFound
     # The comment (or its doc) was deleted while the card was on screen, or a
     # stale optimistic id reached the server — redirect back cleanly instead
-    # of a 404 modal over the editor.
-    redirect_back fallback_location: root_path, status: :see_other,
+    # of a 404 modal over the editor. No `status:` — see create's rescue.
+    redirect_back fallback_location: root_path,
                   inertia: { errors: { comment: "is no longer available" } }
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -30,5 +30,11 @@ class CommentsController < InertiaController
     DocumentMetaChannel.broadcast_event(document, :comments)
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
+  rescue ActiveRecord::RecordNotFound
+    # The comment (or its doc) was deleted while the card was on screen, or a
+    # stale optimistic id reached the server — redirect back cleanly instead
+    # of a 404 modal over the editor.
+    redirect_back fallback_location: root_path, status: :see_other,
+                  inertia: { errors: { comment: "is no longer available" } }
   end
 end

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -20,7 +20,12 @@ class SuggestionsController < InertiaController
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid => e
-    redirect_back fallback_location: document_page_path(params[:slug]), status: :see_other,
+    # No explicit `status:` on error-bag redirects: InertiaRails' middleware
+    # only preserves staged `inertia: { errors: }` session data across 301/302
+    # responses (it upgrades Inertia PATCH/PUT/DELETE redirects to 303 itself).
+    # An explicit 303 here makes the middleware delete the errors before the
+    # follow-up request can render them.
+    redirect_back fallback_location: document_page_path(params[:slug]),
                   inertia: { errors: { suggestion: e.record.errors.full_messages.to_sentence } }
   rescue ActiveRecord::RecordNotFound
     # The doc was deleted while the composer was open — go home cleanly.
@@ -32,7 +37,8 @@ class SuggestionsController < InertiaController
     log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
-    redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other,
+    # No `status:` on error-bag redirects — see create's rescue.
+    redirect_back fallback_location: document_page_path(@suggestion.document.slug),
                   inertia: { errors: { suggestion: "is no longer pending" } }
   end
 
@@ -41,7 +47,8 @@ class SuggestionsController < InertiaController
     log_and_broadcast("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
-    redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other,
+    # No `status:` on error-bag redirects — see create's rescue.
+    redirect_back fallback_location: document_page_path(@suggestion.document.slug),
                   inertia: { errors: { suggestion: "is no longer pending" } }
   end
 
@@ -52,7 +59,8 @@ class SuggestionsController < InertiaController
   rescue ActiveRecord::RecordNotFound
     # The suggestion (or its doc) was deleted while the card was on screen —
     # redirect back cleanly instead of a 404 modal over the editor.
-    redirect_back fallback_location: root_path, status: :see_other,
+    # No `status:` on error-bag redirects — see create's rescue.
+    redirect_back fallback_location: root_path,
                   inertia: { errors: { suggestion: "is no longer available" } }
   end
 

--- a/app/frontend/components/comments_panel.tsx
+++ b/app/frontend/components/comments_panel.tsx
@@ -106,9 +106,15 @@ export function CommentsPanel({
               </blockquote>
             )}
             <p className="comment-body">{comment.body}</p>
-            <button className="comment-resolve" onClick={() => onResolve(comment)}>
-              Resolve
-            </button>
+            {/* Optimistic placeholders (negative id) have no server row yet —
+                a resolve PATCH against them would 404. The button appears
+                when the reload delivers the real id (same gate as the
+                suggestion cards' accept/reject). */}
+            {comment.id > 0 && (
+              <button className="comment-resolve" onClick={() => onResolve(comment)}>
+                Resolve
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -507,6 +507,9 @@ export default function DocumentShow({
 
   const resolveComment = useCallback(
     (comment: CommentPayload) => {
+      // Optimistic placeholders (negative id) have no server row yet — a
+      // PATCH against them would 404 (the panel also hides the button).
+      if (comment.id < 0) return
       router
         .optimistic((props: Partial<DocumentProps>) => ({
           comments: (props.comments ?? []).map((c) =>

--- a/docs/plans/2026-06-07-001-fix-resolve-persistence-plan.md
+++ b/docs/plans/2026-06-07-001-fix-resolve-persistence-plan.md
@@ -1,0 +1,171 @@
+---
+title: "fix: Accept/reject/resolve must persist — no silent reappear-on-refresh"
+type: fix
+status: completed
+date: 2026-06-07
+---
+
+# fix: Accept/Reject/Resolve Must Persist — No Silent Reappear-on-Refresh
+
+## Summary
+
+User-reported bug: accepting or rejecting a card makes it disappear, but refreshing the page brings it back — the optimistic UI claims success while the server state never changed. Reproduce the failure across the three resolve flows (server-row suggestion accept/reject, comment resolve, inline tracked-edit accept/reject), fix the confirmed cause(s), and make every resolve flow either persist or *visibly* fail — never silently lie.
+
+---
+
+## Problem Frame
+
+A card that reappears after refresh means the database row is still `pending`/unresolved (`documents#show` serves `suggestions.pending` and comments with a derived `resolved` flag), so the PATCH or Yjs update never landed. Code reading surfaces three concrete defects and one fragile window, any of which produces the reported symptom:
+
+1. **Unguarded optimistic comment resolve.** A freshly posted comment renders optimistically with a negative id (`-Date.now()`, `app/frontend/pages/documents/show.tsx`). Suggestion margin cards hide their Accept/Reject buttons until the real id arrives (`suggestion.id > 0` gate, plus an `id < 0` guard in the handlers); the comments panel has **neither** — clicking Resolve on a not-yet-reconciled comment PATCHes `/comments/-1786…/resolve`, a guaranteed `RecordNotFound`.
+2. **`comments#resolve` 404s raw.** `CommentsController#resolve` has no `RecordNotFound` rescue — unlike `SuggestionsController#set_suggestion`, which redirects back cleanly. A stale card (comment deleted, doc deleted) or the negative-id PATCH above raises a 404 through Inertia.
+3. **No failure reconciliation on optimistic flows.** `acceptSuggestion`, `rejectSuggestion`, and `resolveComment` chain `router.optimistic(...).patch(...)` with `onSuccess` only. Whether Inertia v3 auto-reverts optimistic mutations on a failed/errored response must be verified against the installed package — if it does not (or does not for 404/500 with `async: true` partial reloads), the card stays hidden client-side while the server still has it pending: the exact reported symptom.
+4. **Inline tracked-edit drop window.** Inline accept/reject is a local ProseMirror transaction synced via Yjs. `CableProvider.handleDocUpdate` drops local updates while `!synced`; they are only re-sent at the next reconnect handshake (`sync-reply`). Accept → refresh before the handshake = the resolve never reached the server, and the tracked edit reappears. Two amplifiers make this window user-reachable: (a) the known main-thread wedge in Shiki tokenization (documented in PR #15's residuals) can block the cable send for 30+ seconds — exactly the situation where a user refreshes; (b) `useMetaChannel` (`app/frontend/lib/use_meta_channel.ts`) fires debounced background `router.reload({ only, async: true })` on every broadcast, and its own comment flags the optimistic-mutation interplay as load-bearing — a background reload racing an in-flight optimistic PATCH is a candidate clobber path U1 must check rather than assume safe.
+
+Defect 1 also explains why the report says "comment": post a comment, immediately resolve it — the PATCH 404s against the optimistic id, the comment hides locally, and refresh resurrects it.
+
+---
+
+## Key Technical Decisions
+
+- **Reproduce first, then fix what reproduces.** Multiple candidate causes share one symptom. U1 instruments and bisects before any fix; U2–U4 fix the confirmed cause(s) and harden the adjacent defects that are cheap and clearly correct regardless (the negative-id guard and the missing rescue are defects even if not the user's exact repro).
+- **Settle Inertia v3 optimistic semantics from the installed source, not assumption.** Read `node_modules/@inertiajs/core`'s optimistic implementation to determine rollback-on-error behavior. If rollback is automatic, failure reconciliation needs only error surfacing; if not, each resolve flow adds explicit `onError` reconciliation (e.g., `router.reload({ only: [...] })` so the UI reconverges with server truth).
+- **Mirror existing guards rather than inventing new machinery.** Comments adopt the exact patterns suggestions already use: action gating for optimistic rows, `RecordNotFound` rescue with `redirect_back` + Inertia error. No new abstractions.
+- **The UI may fail, but must not lie.** The fix standard for every flow: success persists across refresh; failure visibly restores the card in-session. Silent divergence between client and server state is the bug class being eliminated, not just this instance.
+
+---
+
+## Requirements
+
+**Persistence**
+
+- R1. Accepting or rejecting a server-row suggestion persists: after a hard refresh the card does not return (DB row left `accepted`/`rejected`).
+- R2. Resolving a comment persists: after a hard refresh the comment stays resolved.
+- R3. Accepting or rejecting an inline tracked edit persists across an immediate refresh in the normal connected case. The disconnected-window boundary is U1's to characterize: U1 reports whether the drop window reproduces and is user-visible; the behavior is then documented in U4 (script comment or plan note) — it is not regression-tested unless U1 shows it reproduces cheaply.
+
+**Failure honesty**
+
+- R4. A resolve/accept/reject whose server request fails does not leave the UI pretending success — the card visibly returns in-session (rollback or reconciliation reload) rather than staying hidden until refresh.
+- R5. The comments panel cannot fire a resolve PATCH for an optimistic (negative-id) comment — the action is hidden or disabled until the server id arrives, matching the suggestion-card pattern.
+- R6. `comments#resolve` handles a missing comment gracefully (redirect back with an Inertia error), parity with `suggestions#set_suggestion`; no raw 404 modal over the editor.
+
+**Coverage**
+
+- R7. Rails integration tests cover the new failure paths; a browser-check scenario proves refresh-persistence for accept and resolve end-to-end.
+
+---
+
+## Implementation Units
+
+### U1. Reproduce and diagnose the reappear-on-refresh
+
+**Goal:** Confirm which flow(s) actually reproduce the user's symptom and capture the failing request/response or dropped update as evidence.
+
+**Requirements:** R1, R2, R3 (diagnosis feeds all)
+
+**Dependencies:** none
+
+**Files:**
+- `tmp/` throwaway Playwright probes (not committed)
+- Reading: `app/frontend/pages/documents/show.tsx`, `node_modules/@inertiajs/core/dist/*` (optimistic semantics), `app/frontend/editor/cable_provider.ts`
+
+**Approach:** Drive each flow against a local server with network/console capture and DB inspection between steps: (a) server-row suggestion accept and reject → check `suggestions.status` in DB → reload page; (b) post comment → resolve immediately (optimistic id window) and after reconciliation → check `resolved_at` → reload; (c) inline tracked edit accept → immediate reload; accept-during-brief-disconnect if cheaply simulable; (d) the broadcast race — a `useMetaChannel`-triggered background reload landing while an optimistic PATCH is in flight (e.g., a second client proposing a suggestion mid-accept) must not clobber the optimistic removal or resurrect the card. While here, read the installed Inertia source to settle the optimistic rollback question (KTD). Record which paths reproduce and the exact failing mechanism.
+
+**Execution note:** Reproduce-first — no fixes in this unit; its output is the confirmed defect list driving U2–U4 scope.
+
+**Test scenarios:** Test expectation: none — diagnostic unit; permanent coverage lands in U2–U4.
+
+**Verification:** A short written diagnosis (in the ce-work session) naming reproduced flow(s) with evidence (HTTP status, DB state, or dropped-update trace), plus a definitive statement of Inertia v3's optimistic revert behavior across response classes (2xx redirect, 4xx, 5xx, network error) backed by installed-source citations — U3's branch choice depends on it being unambiguous.
+
+### U2. Server hardening: comments#resolve parity
+
+**Goal:** `comments#resolve` never 404s raw and never silently diverges — missing rows redirect back with an Inertia error, like suggestions.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U1 (confirms shape; this lands regardless — the defect is real independent of the repro)
+
+**Files:**
+- `app/controllers/comments_controller.rb`
+- `test/integration/comment_flow_test.rb`
+
+**Approach:** Add a `RecordNotFound` rescue mirroring `SuggestionsController#set_suggestion` (redirect_back, `inertia: { errors: { comment: "is no longer available" } }`). Keep `resolve!` idempotent semantics (resolving an already-resolved comment is a no-op update, acceptable as-is).
+
+**Patterns to follow:** `app/controllers/suggestions_controller.rb` `set_suggestion` rescue; existing assertions in `test/integration/comment_flow_test.rb`.
+
+**Test scenarios:**
+- Happy path: PATCH resolve on an open comment → 303 redirect, `resolved_at` set.
+- Error path: PATCH resolve with a nonexistent id (e.g., `-42`) → 303 redirect back (not 404), no exception, errors bag carries the comment message.
+- Edge: PATCH resolve twice → second succeeds idempotently (or remains a clean no-op), `resolved_at` unchanged semantics documented by the assertion.
+
+**Verification:** New integration tests pass; full `bin/rails test` green.
+
+### U3. Client guards and failure reconciliation for optimistic resolve flows
+
+**Goal:** Optimistic comment rows can't fire premature resolves, and every optimistic resolve flow (suggestion accept/reject, comment resolve) visibly reconverges with server truth on failure.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** U1 (Inertia rollback semantics determine the reconciliation shape)
+
+**Files:**
+- `app/frontend/components/comments_panel.tsx` (hide/disable Resolve while `comment.id < 0`)
+- `app/frontend/pages/documents/show.tsx` (`resolveComment` id guard; `onError` reconciliation on `acceptSuggestion`, `rejectSuggestion`, `resolveComment` per the U1 finding)
+
+**Approach:** Mirror the suggestion-card optimistic gating for comments. For failure reconciliation: if U1 shows Inertia auto-reverts optimistic state on error, keep that and ensure the revert is reachable on the 303-with-errors path too; if not, add `onError` handlers that reload the affected props (`only: ['comments']` / `['suggestions']`) so a failed resolve restores the card in-session. Do not add toast infrastructure — the card visibly returning is the honest signal this codebase's patterns support today.
+
+**Patterns to follow:** `margin_suggestions.tsx` optimistic-id action gating (`suggestion.id > 0`); existing `router.optimistic(...).patch(...)` call shape in `show.tsx`.
+
+**Test scenarios:**
+- Happy path: resolve a reconciled comment → card moves to resolved; refresh → stays resolved (also exercised end-to-end by U4's script).
+- Edge: comment still optimistic (negative id) → Resolve affordance absent/disabled; after reconciliation it appears and works.
+- Error path: force a failing resolve (nonexistent id via a stale card, or stubbed route in the probe) → the card returns to the open list in-session; no silent hidden-but-unresolved state.
+- Integration: suggestion accept with server failure (already-accepted race: accept the same suggestion from two windows) → loser's card state reconverges (card clears because the row is genuinely non-pending — verify the winner's accept persisted and no duplicate insert).
+
+**Verification:** `npm run check` green; manual probe of the forced-failure path shows the card returning in-session. (End-to-end refresh-persistence proof lands in U4, which depends on this unit.)
+
+### U4. Refresh-persistence regression coverage
+
+**Goal:** Executable proof that resolve actions survive refresh, in the repo's browser-check style, covering the inline tracked-edit path too.
+
+**Requirements:** R1, R2, R3, R7
+
+**Dependencies:** U2, U3
+
+**Files:**
+- `script/browser_check.mjs` (extend: refresh-persistence section)
+
+**Approach:** Fresh doc via `POST /api/docs`; seed a server-row suggestion via the agent API. Scenarios: (a) accept suggestion → wait for reconcile → `page.reload()` → card absent; (b) reject → reload → absent; (c) post comment → wait for positive id (resolve affordance present) → resolve → reload → comment not in open list; (d) suggest-mode tracked insertion → accept inline → `page.reload()` immediately after the doc update settles → text retained without `ins` marks. Follow existing `ok`/`fail` conventions. For R3's disconnected-window boundary: document (comment in the script or plan note) rather than simulate if ActionCable disconnect simulation proves disproportionate.
+
+**Patterns to follow:** existing suggest-mode and comment-flow sections in `script/browser_check.mjs`.
+
+**Test scenarios:** the script is the enumeration (a–d above); each asserts post-reload server-truth state.
+
+**Verification:** `node script/browser_check.mjs` placement + persistence sections exit 0 against a local server.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the three resolve flows' persistence and failure honesty; the two parity defects (comment guard, controller rescue); regression coverage.
+
+**Non-goals:**
+- Toast/notification infrastructure for error display — the card visibly returning is the failure signal; richer error UX is product work beyond this fix.
+- Reworking the CableProvider offline queue (buffering local updates while `!synced` beyond the existing handshake re-send) — only verify and document the boundary; a full offline story is its own feature.
+- Comment threads/replies, suggestion UI changes — untouched.
+
+**Deferred to Follow-Up Work:**
+- A `beforeunload`-style flush or pending-update indicator when local Yjs updates haven't reached the server (surfaced by R3's boundary documentation if the window proves user-visible in practice).
+
+---
+
+## Sources & Research
+
+- Optimistic flows and negative-id pattern: `app/frontend/pages/documents/show.tsx` (`acceptSuggestion`, `rejectSuggestion`, `resolveComment`, `submitComment`).
+- Guarded counterpart: `app/frontend/components/margin_suggestions.tsx` (`suggestion.id > 0` action gate, `resolving` set).
+- Unguarded panel: `app/frontend/components/comments_panel.tsx` (Resolve button, no id gate).
+- Server flows: `app/controllers/suggestions_controller.rb` (rescues present), `app/controllers/comments_controller.rb` (`resolve` lacks rescue), `app/models/suggestion.rb` (`transition!` raises on non-pending), `app/models/comment.rb` (`resolve!`).
+- Page props refresh-truth: `app/controllers/documents_controller.rb#show` (`suggestions.pending`, comments with derived `resolved`).
+- Yjs sync boundary: `app/frontend/editor/cable_provider.ts` (`handleDocUpdate` drops while `!synced`; `sync-reply` re-sends on handshake).
+- Prior 500-race note relevant to silent failures: `app/controllers/inertia_controller.rb` (`safe_vite_digest` comment).
+- Inertia versions in play: `@inertiajs/react` 3.3.1, `inertia_rails` 3.21.1 — optimistic rollback semantics to be verified from installed source (U1).

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -12,7 +12,7 @@ const fail = (msg) => {
 const ok = (msg) => console.log(`✓ ${msg}`)
 
 const browser = await chromium.launch()
-const errors = { a: [], b: [] }
+const errors = { a: [], b: [], persist: [] }
 
 const makePage = async (label) => {
   const context = await browser.newContext()
@@ -596,10 +596,10 @@ try {
   await seedSuggestion('alpha')
   await seedSuggestion('bravo')
 
-  const q = await makePage('a')
+  const q = await makePage('persist')
   await q.goto(`${BASE}/d/${persistDoc.slug}`)
   await q.waitForSelector('.doc-status--live', { timeout: 15000 })
-  await q.waitForTimeout(800)
+  await q.waitForTimeout(800) // initial Yjs bind + margin card placement settle
 
   // Accept one, reject the other; both decisions must survive a reload.
   await q.locator('.margin-card .btn-accept').first().click()
@@ -612,21 +612,26 @@ try {
   })
   await q.reload()
   await q.waitForSelector('.doc-status--live', { timeout: 15000 })
-  await q.waitForTimeout(800)
+  await q.waitForTimeout(800) // post-reload card re-derivation settle
   const cardsBack = await q.locator('.margin-card').count()
   if (cardsBack === 0) ok('accepted and rejected suggestions stayed resolved across reload')
   else fail(`${cardsBack} resolved suggestion card(s) reappeared after reload`)
 
   // A freshly posted (optimistic) comment must not offer Resolve until the
   // server id arrives — hold the POST open to keep the optimistic window.
-  await q.route(
-    '**/comments',
-    async (route) => {
-      await new Promise((resolve) => setTimeout(resolve, 1500))
+  let commentPostHeld = false
+  await q.route('**/comments', async (route) => {
+    // Hold only the FIRST comment-creation POST; anything else (and any
+    // later POST) passes through untouched so a background request can't
+    // consume the delay meant for the optimistic window.
+    if (route.request().method() !== 'POST' || commentPostHeld) {
       await route.continue()
-    },
-    { times: 1 },
-  )
+      return
+    }
+    commentPostHeld = true
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+    await route.continue()
+  })
   await q.locator('.milkdown .ProseMirror p').first().dblclick({ position: { x: 12, y: 10 } })
   await q.locator('.selection-toolbar.is-placed').waitFor({ timeout: 5000 })
   await q.locator('.selection-toolbar button', { hasText: 'Comment' }).first().click()
@@ -657,7 +662,7 @@ try {
   )
   await q.reload()
   await q.waitForSelector('.doc-status--live', { timeout: 15000 })
-  await q.waitForTimeout(800)
+  await q.waitForTimeout(800) // post-reload comment list settle
   const resolvedCameBack = await q
     .locator('.comment-card:not(.is-resolved)', { hasText: persistComment })
     .count()

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -575,6 +575,126 @@ try {
   ok('comment posted from the anchored composer landed in the rail')
   await p.close()
 
+  // --- Resolve persistence: accept/reject/resolve must survive a refresh ---
+  // (regression for the optimistic-id resolve 404 and silent non-persistence)
+  const persistDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Persistence check',
+        markdown: 'Persistence paragraph alpha bravo charlie delta echo foxtrot golf hotel.',
+      }),
+    })
+  ).json()
+  const seedSuggestion = (anchor) =>
+    fetch(`${BASE}/api/docs/${persistDoc.slug}/suggestions`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'persistence rewrite', intent: 'check', anchor_text: anchor }),
+    })
+  await seedSuggestion('alpha')
+  await seedSuggestion('bravo')
+
+  const q = await makePage('a')
+  await q.goto(`${BASE}/d/${persistDoc.slug}`)
+  await q.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await q.waitForTimeout(800)
+
+  // Accept one, reject the other; both decisions must survive a reload.
+  await q.locator('.margin-card .btn-accept').first().click()
+  await q.waitForFunction(() => document.querySelectorAll('.margin-card').length === 1, undefined, {
+    timeout: 10000,
+  })
+  await q.locator('.margin-card .btn-reject').first().click()
+  await q.waitForFunction(() => document.querySelectorAll('.margin-card').length === 0, undefined, {
+    timeout: 10000,
+  })
+  await q.reload()
+  await q.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await q.waitForTimeout(800)
+  const cardsBack = await q.locator('.margin-card').count()
+  if (cardsBack === 0) ok('accepted and rejected suggestions stayed resolved across reload')
+  else fail(`${cardsBack} resolved suggestion card(s) reappeared after reload`)
+
+  // A freshly posted (optimistic) comment must not offer Resolve until the
+  // server id arrives — hold the POST open to keep the optimistic window.
+  await q.route(
+    '**/comments',
+    async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1500))
+      await route.continue()
+    },
+    { times: 1 },
+  )
+  await q.locator('.milkdown .ProseMirror p').first().dblclick({ position: { x: 12, y: 10 } })
+  await q.locator('.selection-toolbar.is-placed').waitFor({ timeout: 5000 })
+  await q.locator('.selection-toolbar button', { hasText: 'Comment' }).first().click()
+  const persistComment = `Persistence comment ${Date.now()}`
+  await q.fill('.comment-composer--anchored .comment-input', persistComment)
+  await q.locator('.comment-composer--anchored .btn-accept').click()
+  await q.locator('.comment-card', { hasText: persistComment }).waitFor({ timeout: 2000 })
+  const resolveDuringWindow = await q
+    .locator('.comment-card', { hasText: persistComment })
+    .locator('.comment-resolve')
+    .count()
+  if (resolveDuringWindow === 0) ok('optimistic comment hides Resolve until the server id arrives')
+  else fail('Resolve offered on an optimistic comment (would PATCH a negative id)')
+
+  // After reconciliation the button appears; resolving must persist.
+  await q
+    .locator('.comment-card', { hasText: persistComment })
+    .locator('.comment-resolve')
+    .waitFor({ timeout: 10000 })
+  await q.locator('.comment-card', { hasText: persistComment }).locator('.comment-resolve').click()
+  await q.waitForFunction(
+    (text) =>
+      !Array.from(document.querySelectorAll('.comment-card:not(.is-resolved)')).some((card) =>
+        card.textContent?.includes(text),
+      ),
+    persistComment,
+    { timeout: 10000 },
+  )
+  await q.reload()
+  await q.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await q.waitForTimeout(800)
+  const resolvedCameBack = await q
+    .locator('.comment-card:not(.is-resolved)', { hasText: persistComment })
+    .count()
+  if (resolvedCameBack === 0) ok('resolved comment stayed resolved across reload')
+  else fail('resolved comment reappeared open after reload')
+
+  // Inline tracked edit: accept then reload immediately — the resolve syncs
+  // through Yjs and must already be on the server. (Boundary note: local
+  // updates made while the cable is disconnected are only re-sent at the
+  // next reconnect handshake — a refresh inside that window loses them.
+  // Not simulated here; see docs/plans/2026-06-07-001 R3.)
+  await q.click('.mode-control-trigger')
+  await q.locator('.mode-control-option', { hasText: 'Suggest' }).click()
+  await q.click('.milkdown .ProseMirror')
+  await q.keyboard.press('Meta+ArrowDown')
+  await q.keyboard.press('End')
+  const trackedSentinel = `persist-${Date.now()}`
+  await q.keyboard.type(` ${trackedSentinel}`)
+  await q.locator('.milkdown ins.sug-ins', { hasText: trackedSentinel }).first().waitFor({ timeout: 5000 })
+  await q.waitForTimeout(1200) // let the insertion itself persist first
+  await q.locator('.margin-card--inline .btn-accept').first().click()
+  await q.reload()
+  await q.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await q.waitForTimeout(1200)
+  const trackedStillMarked = await q
+    .locator('.milkdown ins.sug-ins', { hasText: trackedSentinel })
+    .count()
+  const trackedTextKept = await q
+    .locator('.milkdown .ProseMirror', { hasText: trackedSentinel })
+    .count()
+  if (trackedStillMarked === 0 && trackedTextKept > 0) {
+    ok('inline tracked-edit accept persisted across an immediate reload')
+  } else {
+    fail(`inline accept did not persist: marks=${trackedStillMarked} text=${trackedTextKept}`)
+  }
+  await q.close()
+
   for (const [label, errs] of Object.entries(errors)) {
     const fatal = errs.filter(
       (e) =>

--- a/test/integration/comment_flow_test.rb
+++ b/test/integration/comment_flow_test.rb
@@ -52,15 +52,21 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     assert_equal "agent", comment.as_props[:author_kind]
   end
 
-  test "resolving a nonexistent comment redirects back instead of 404ing" do
+  test "resolving a nonexistent comment redirects back with an error instead of 404ing" do
     # An optimistic (not-yet-reconciled) client id or a deleted comment must
     # not raise a 404 modal over the editor.
     patch resolve_comment_path(-42), params: { by: "Quiet Falcon" }
 
-    assert_response :see_other
+    # 302, not 303: error-bag redirects carry no explicit status so the
+    # InertiaRails middleware preserves the staged errors (it deletes them on
+    # anything but 301/302, and upgrades Inertia non-GET redirects itself).
+    assert_response :redirect
+    # The errors bag must carry the message — the client's onError path (and
+    # optimistic revert) depends on it being present on the follow-up render.
+    assert_equal "is no longer available", session[:inertia_errors][:comment]
   end
 
-  test "resolving twice is idempotent" do
+  test "resolving an already-resolved comment re-stamps but does not reopen it" do
     comment = @document.comments.create!(author_name: "A", author_kind: "human", body: "Fix this")
 
     patch resolve_comment_path(comment), params: { by: "B" }

--- a/test/integration/comment_flow_test.rb
+++ b/test/integration/comment_flow_test.rb
@@ -51,6 +51,28 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     comment = @document.comments.create!(author_name: "Scout", author_kind: "agent", body: "From the API")
     assert_equal "agent", comment.as_props[:author_kind]
   end
+
+  test "resolving a nonexistent comment redirects back instead of 404ing" do
+    # An optimistic (not-yet-reconciled) client id or a deleted comment must
+    # not raise a 404 modal over the editor.
+    patch resolve_comment_path(-42), params: { by: "Quiet Falcon" }
+
+    assert_response :see_other
+  end
+
+  test "resolving twice is idempotent" do
+    comment = @document.comments.create!(author_name: "A", author_kind: "human", body: "Fix this")
+
+    patch resolve_comment_path(comment), params: { by: "B" }
+    first_resolved_at = comment.reload.resolved_at
+    patch resolve_comment_path(comment), params: { by: "C" }
+
+    assert_response :see_other
+    assert comment.reload.resolved_at.present?
+    assert_empty @document.comments.open
+    # The second resolve re-stamps but never un-resolves; both are accepted.
+    assert_operator comment.resolved_at, :>=, first_resolved_at
+  end
 end
 
 class ThemePersistenceTest < ActionDispatch::IntegrationTest

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -39,6 +39,9 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     patch accept_suggestion_path(@suggestion)
     assert_response :redirect
     assert_equal "rejected", @suggestion.reload.status
+    # The errors bag must actually survive to the follow-up render — staging
+    # is silently discarded by the middleware when the redirect is 303.
+    assert_equal "is no longer pending", session[:inertia_errors][:suggestion]
   end
 
   test "ask AI endpoint creates a pending ai suggestion" do
@@ -116,7 +119,11 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
         body: "a" * (Suggestion::MAX_BODY_BYTES + 1)
       }
     end
-    assert_response :see_other
+    # 302, not 303: error-bag redirects carry no explicit status so the
+    # InertiaRails middleware preserves the staged errors (it only keeps
+    # them across 301/302 and upgrades Inertia non-GET redirects itself).
+    assert_response :redirect
+    assert_includes session[:inertia_errors][:suggestion], "Body is too long"
   end
 
   test "oversized replaces and anchor_text are rejected" do
@@ -142,7 +149,7 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     assert_no_difference -> { @document.suggestions.count } do
       post document_suggestions_path(@document.slug), params: { body: "" }
     end
-    assert_response :see_other
+    assert_response :redirect
   end
 
   test "browser POST to an unknown doc redirects home without a 500" do


### PR DESCRIPTION
## What this fixes

**Bug report:** accepting/rejecting/resolving a card makes it disappear, but refreshing the page brings it back — the UI claims success while the server never persisted anything.

Two real defects found and fixed, one of them hiding a third:

1. **Resolve on a freshly posted comment 404'd silently.** A new comment renders optimistically with a negative id (`-Date.now()`) until the server reload delivers the real id. Suggestion cards gate their Accept/Reject buttons on `id > 0`; the comments panel didn't — clicking Resolve in that window fired `PATCH /comments/-1780…/resolve` → 404 → never persisted → reappeared on refresh. Reproduced live with a held-POST probe. The Resolve button now appears only after reconciliation (same gate as suggestion cards), with a belt-and-suspenders guard in the handler.

2. **`comments#resolve` raised a raw 404** for missing rows (stale cards, deleted docs). It now rescues `RecordNotFound` and redirects back with an Inertia error, mirroring the suggestions controller.

3. **Found while pinning #2 with a test: every error-bag redirect in the app was silently dropping its errors.** InertiaRails' middleware only preserves staged `inertia: { errors: }` session data across 301/302 responses — it upgrades Inertia PATCH/PUT/DELETE redirects to 303 itself. Our rescues passed `status: :see_other` explicitly, so the middleware deleted the errors on the same response that staged them (bisected with a scratch-controller experiment: 303 → errors gone, 302 → errors survive). All four suggestion-controller rescue sites had this latent bug; the client's `onError` path never saw those messages. Fixed by dropping the explicit status on error-bag redirects and pinning the behavior with session-level assertions.

**Verified not broken:** Inertia v3's optimistic layer reverts mutations on failure (`shouldRestore`/`replayOptimistics`, confirmed from installed source + a forced-abort probe) and re-baselines concurrent background reloads (`preserveOptimisticProps`) — so no reconciliation handlers were needed, and a failed action visibly restores the card.

## Testing

- `bin/rails test`: 175 runs, 556 assertions, 0 failures (4 new tests: 404-path with errors-bag assertion, double-resolve semantics, suggestion errors-bag survival, oversized-body errors-bag).
- New refresh-persistence section in `script/browser_check.mjs`: accept + reject survive reload; optimistic comments hide Resolve until the server id arrives (held-POST window); resolved comments stay resolved; inline tracked-edit accept persists across an immediate reload. All passing locally.
- Live agent-browser pass: resolve via UI → reload → stays resolved, DB confirmed.
- Plan: `docs/plans/2026-06-07-001-fix-resolve-persistence-plan.md` (R1–R7 verified).

## Residual notes (advisory, from code review)

- Inertia's revert-on-failure is an implementation detail of `@inertiajs/core` 3.3.1 — re-verify on upgrades (no browser-side forced-failure regression test).
- Inline tracked-edit *reject* persistence is untested (accept is covered).
- The disconnected-Yjs drop window (refresh while the cable is down or the main thread is wedged) is documented, not fixed — plan scope boundary.
- Pre-existing, unchanged: agents can propose suggestions/comments but cannot accept/reject/resolve via the API (acknowledged in AgentGuide); `browser_check.mjs` is ~11 sections in one flat script and worth splitting next time it grows.

## Post-Deploy Monitoring & Validation

- Watch for `PATCH /comments/*/resolve` 404s in logs (should drop to zero) and `ActiveRecord::RecordNotFound` from CommentsController.
- Healthy signal: comment resolve rate unchanged; `resolved_comment` activities continue to log.
- Failure signal: comments stuck unresolved after users report resolving → revert is safe (frontend + controller-rescue change only, no schema).
- Validation window: first day of normal use; owner: @kieranklaassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
