### PR TITLE
fix(editor): render soft line breaks instead of collapsing metadata blocks

### DIFF
--- a/app/frontend/editor/line_breaks.ts
+++ b/app/frontend/editor/line_breaks.ts
@@ -1,0 +1,30 @@
+import type { Ctx } from '@milkdown/kit/ctx'
+import { hardbreakAttr, hardbreakSchema } from '@milkdown/kit/preset/commonmark'
+
+/**
+ * Soft breaks (single newlines in markdown source) parse into `hardbreak`
+ * nodes flagged `isInline: true` — Milkdown's commonmark preset keeps them
+ * in the document so they round-trip back to "\n", but renders them as a
+ * span containing a single space. That collapses agent-authored metadata
+ * blocks like `**Date:** …\n**Source:** …` into one run-on paragraph.
+ *
+ * Render them as a real `<br>` instead. Serialization is untouched:
+ * `isInline` breaks still emit "\n" and explicit hard breaks still emit
+ * `\`, so document sources never change shape — only the display does.
+ */
+export const renderSoftBreaks = (ctx: Ctx): void => {
+  ctx.update(hardbreakSchema.key, (prev) => (innerCtx) => {
+    const spec = prev(innerCtx)
+    return {
+      ...spec,
+      toDOM: (node) => ['br', innerCtx.get(hardbreakAttr.key)(node)],
+      parseDOM: [
+        {
+          tag: 'br[data-is-inline="true"]',
+          getAttrs: () => ({ isInline: true }),
+        },
+        ...(spec.parseDOM ?? []),
+      ],
+    }
+  })
+}

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -48,6 +48,7 @@ import {
   trashIcon,
 } from './table_icons'
 import { agentCursors } from './agent_cursors'
+import { renderSoftBreaks } from './line_breaks'
 import { selectionCallbackCtx, selectionWatcher } from './selection_watcher'
 import { postJSON } from '../lib/csrf'
 
@@ -276,6 +277,7 @@ function CollabEditor({
             uploader: imageUploader,
             enableHtmlFileUploader: true,
           }))
+          renderSoftBreaks(ctx)
           // The defaults are bare text ('+', 'left', …) — real icons required.
           ctx.update(tableBlockConfig.key, (prev) => ({
             ...prev,

--- a/docs/plans/2026-06-07-002-fix-soft-break-line-collapse-plan.md
+++ b/docs/plans/2026-06-07-002-fix-soft-break-line-collapse-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Preserve soft line breaks so metadata blocks render as separate lines"
 type: fix
-status: active
+status: completed
 date: 2026-06-07
 ---
 

--- a/docs/plans/2026-06-07-002-fix-soft-break-line-collapse-plan.md
+++ b/docs/plans/2026-06-07-002-fix-soft-break-line-collapse-plan.md
@@ -1,0 +1,148 @@
+---
+title: "fix: Preserve soft line breaks so metadata blocks render as separate lines"
+type: fix
+status: active
+date: 2026-06-07
+---
+
+# fix: Preserve soft line breaks so metadata blocks render as separate lines
+
+## Summary
+
+The document at https://pruf.kieranklaassen.com/d/1KytrvTXNj opens with a metadata block — `**Date:** …`, `**Source:** …`, `**Goal:** …` on consecutive lines — that renders as one run-on paragraph in the editor. The lines are separated by single newlines (CommonMark soft breaks), and Milkdown's mdast→ProseMirror conversion collapses them to spaces. Agent-authored markdown uses single newlines deliberately (this metadata-block shape tops nearly every plan/brainstorm doc agents share to Pruf), so Pruf should preserve them as visible line breaks — the behavior users know from Notion, Slack, Obsidian, and GitHub comments.
+
+Fix: a small remark transformer (mirroring the repo's existing `$remark` plugins) that converts in-paragraph newlines in mdast `text` values into mdast `break` nodes, which the commonmark preset already renders as `hardbreak`. Then repair the already-damaged live document via the agent suggestion API.
+
+---
+
+## Problem Frame
+
+**Observed:** On `/d/1KytrvTXNj`, the three metadata lines render as a single jumbled paragraph: "Date: 2026-06-07 Source: Analysis of all local agent transcripts … Goal: Reduce, sharpen…". Verified in a live browser session; the rendered `<p>` contains no `<br>` and no newline characters.
+
+**Root cause (verified locally):**
+- `remark` keeps soft breaks as literal `\n` inside mdast `text` node values (verified against the repo's installed remark: `'**Date:** x\n**Source:** y'` parses to text values ending in `"\n"`).
+- Milkdown's mdast→ProseMirror conversion collapses those newlines to spaces when creating PM text nodes. The collapse happens at parse time, so it is baked into the Yjs CRDT state of every document seeded with soft-break markdown.
+- No custom remark plugin currently runs that could intercept this (`provenanceParse` and `suggestParse` only handle HTML spans).
+
+**Hard breaks already work:** the commonmark preset includes a `hardbreak` node schema mapped to mdast `break`. Verified round-trip against the installed remark: a `break` node stringifies as `\` + newline, and `a\` + newline + `b` re-parses to `[text, break, text]`. So converting soft breaks → `break` nodes at the mdast stage rides entirely on existing, working machinery.
+
+**Two layers of damage:**
+1. Code: every future parse (document seeding, suggestion acceptance — both use the same Milkdown parser context) collapses soft breaks.
+2. Content: the live document's Yjs state already has the collapsed text persisted. A code fix cannot retroactively repair it; the content needs an edit.
+
+---
+
+## Requirements
+
+- R1: Markdown with single-newline-separated lines inside a paragraph renders each line on its own visible line in the editor (seeding path).
+- R2: The same preservation applies when a suggestion is accepted (suggestion-acceptance parse path shares the parser).
+- R3: Round-trip stability — serializing the document (snapshot push, agent API reads) emits hard breaks as `\`-terminated lines that re-parse to the identical structure; no drift on repeated open/serialize cycles.
+- R4: Code blocks, inline code, and other literal contexts are untouched (they hold content in `value` fields, not phrasing `text` children — the transformer must only touch phrasing text).
+- R5: The live document `/d/1KytrvTXNj` gets a proposed repair of its metadata block via the agent suggestion API (`anchor_text` + `replaces` + hard-break body), reviewable by the owner in the editor.
+
+---
+
+## Key Technical Decisions
+
+**KTD1 — Convert soft breaks to hard breaks globally at the mdast stage, via a custom `$remark` transformer.**
+Alternatives considered:
+- *CSS `white-space` fix*: dead end — the newlines are already gone from the PM doc (verified: rendered text contains no `\n`).
+- *`remark-breaks` npm package*: does exactly this, but Milkdown bundles its own unified/remark versions; a custom ~25-line transformer following the existing `provenanceParse` pattern (`app/frontend/editor/provenance/remark.ts`) avoids any version-compat risk, matches repo conventions, and keeps the dependency surface flat.
+- *Heuristic scoping (only "metadata-looking" blocks)*: rejected — magic-pattern detection is fragile, and global newline-preservation is the established product behavior of comparable editors. Agent-generated markdown does not hard-wrap prose, so the global rule has no practical downside in this corpus.
+
+**KTD2 — Repair the live document through the designed agent flow (suggestion with `anchor_text`/`replaces`), not by mutating CRDT state server-side.** `Suggestion.propose!` is the single sanctioned entry point; acceptance keeps provenance marks correct and keeps a human in the loop. The proposal body uses explicit `\` hard breaks so it renders correctly even before the code fix deploys.
+
+**KTD3 — No data migration for other existing documents.** The collapse is baked into per-document Yjs state; rewriting CRDT history server-side is high-risk and out of proportion. Existing docs heal only if their owners re-edit them; new docs are correct from seed.
+
+---
+
+## Implementation Units
+
+### U1. Soft-break preservation remark transformer
+
+**Goal:** Single newlines inside paragraphs survive parsing as `hardbreak` nodes.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** none.
+
+**Files:**
+- `app/frontend/editor/line_breaks.ts` (new) — the `$remark` transformer
+- `app/frontend/editor/milkdown_editor.tsx` — register it in the plugin chain (alongside `provenance` / `suggestChangesMarks`, before the editor parses any content)
+
+**Approach:** Walk the mdast tree visiting phrasing `text` nodes (children arrays only — never `value`-bearing literal nodes like `code`/`inlineCode`, which have no text children and are naturally skipped). For each text value containing `\n`, split and splice `{type: 'break'}` nodes between the segments, dropping a trailing newline at the end of a paragraph rather than emitting a dangling break. Mirror the structure and typing style of `provenanceParse` in `app/frontend/editor/provenance/remark.ts`. No serializer half is needed: the commonmark preset already stringifies `break` → `\` + newline.
+
+**Patterns to follow:** `app/frontend/editor/provenance/remark.ts` ($remark transformer shape, MdastNode interface, visit recursion); registration order conventions in `app/frontend/editor/milkdown_editor.tsx` (plugin chain around lines 303–322).
+
+**Test scenarios:** (covered via U2's browser checks plus the script-level cases below — the repo has no JS unit-test runner, and adding one is out of scope)
+- Happy path: seeding `**Date:** a\n**Source:** b\n**Goal:** c` renders three visual lines (two `<br>` in the paragraph).
+- Round-trip: after seeding, the pushed snapshot markdown contains `\`-terminated lines; reloading the doc renders identically (no drift, no duplicated breaks).
+- Edge: paragraph-final newline produces no trailing empty line.
+- Edge: fenced code block content containing newlines is unchanged (still one `code_block`, newlines literal).
+- Edge: blank-line-separated paragraphs still parse as separate paragraphs (transformer must not eat paragraph boundaries — those never reach text values, but assert it anyway).
+- Integration: accepting a suggestion whose body contains soft breaks inserts hard-break-separated lines (R2).
+
+**Verification:** On a locally seeded document with the exact metadata block from the live doc, the editor shows Date/Source/Goal on three lines; the API's `markdown` snapshot round-trips stably.
+
+### U2. Browser-check coverage for soft-break rendering
+
+**Goal:** Regression coverage in the repo's E2E harness.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** U1.
+
+**Files:**
+- `script/browser_check.mjs` — add a check (or extend the seeding check) that creates a doc via `POST /api/docs` with a soft-break metadata block, opens it, and asserts the paragraph contains two `<br>` elements / three lines; then asserts the serialized snapshot keeps the lines separate.
+
+**Patterns to follow:** existing checks in `script/browser_check.mjs` (33 sequential checks, Playwright, agent-API doc creation already exercised there).
+
+**Test scenarios:** this unit *is* test coverage; the scenario list lives in U1.
+
+**Verification:** `BASE_URL=http://localhost:3000 node script/browser_check.mjs` passes including the new check; full suite stays green (`bin/rails test` unaffected — no server code changes).
+
+### U3. Repair the live document's metadata block
+
+**Goal:** `/d/1KytrvTXNj` metadata renders as three lines after the owner accepts a proposed edit.
+
+**Requirements:** R5.
+
+**Dependencies:** none (deploy-independent: the proposal body uses explicit `\` hard breaks, which parse correctly in the current production build).
+
+**Files:** none in-repo — this is an outward action against the production agent API (`POST /api/docs/1KytrvTXNj/suggestions` with `X-Agent-Name`, `anchor_text` matching the run-on metadata paragraph, `replaces` set, and a body where Date/Source/Goal lines end in `\`).
+
+**Approach:** Propose, don't mutate: the suggestion lands in the review panel for Kieran to accept in the editor. Include an `intent` line explaining the reformat. This is reversible (rejectable) and uses the platform's designed agent loop.
+
+**Test expectation: none** — content action, verified by observing the pending suggestion on the live doc (API `suggestions` array) and visually after acceptance.
+
+**Verification:** `GET /api/docs/1KytrvTXNj` shows the pending suggestion with the hard-break body; after acceptance the rendered paragraph shows three lines.
+
+---
+
+## Scope Boundaries
+
+**In scope:** soft-break preservation in the Milkdown parse pipeline; E2E regression check; suggestion-based repair of the one live document the user pointed at.
+
+**Out of scope / non-goals:**
+- YAML frontmatter (`---` delimited) parsing or styled metadata cards — the target document has none; nothing in the current corpus needs it.
+- Server-side rewriting of existing documents' Yjs state (KTD3).
+- Adding a JS unit-test framework (vitest etc.) — the repo's established harness is `script/browser_check.mjs`.
+
+**Deferred to follow-up work:**
+- A styled "document metadata" presentation (e.g., rendering a leading key-value block as a visually distinct card) if the plain three-line rendering proves insufficient.
+
+---
+
+## Assumptions
+
+- Global soft-break→hard-break conversion is the desired product behavior (Notion/Slack-style), not a metadata-only special case. Grounded in: the user's ask, the agent-authored corpus (no hard-wrapped prose), and comparable products.
+- "Metadata frontmatter" in the request refers to the visible `**Date:/Source:/Goal:**` block on the linked doc (it has no YAML frontmatter — verified via the API).
+- Proposing a suggestion on the live production doc is within the autonomous mandate, since it is the platform's reviewable, rejectable agent flow and the user pointed at that doc explicitly.
+
+---
+
+## Risks & Dependencies
+
+- **Round-trip drift:** if Milkdown's stringifier emitted something other than `\` line endings, snapshots could mutate on every open. Mitigated: round-trip verified against the installed remark; U2 asserts stability.
+- **Existing docs re-serialize differently:** docs whose Yjs state already contains collapsed spaces are untouched by the transformer (no newlines left to convert) — no behavior change for them.
+- **Suggest-changes / provenance interaction:** new `hardbreak` nodes flow through y-prosemirror and the provenance mark plugin like any inline node; the browser check with provenance-seeded content guards this.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -71,51 +71,88 @@ try {
 
   // Soft breaks: single newlines in seeded markdown must render as visible
   // line breaks (metadata blocks like **Date:** / **Source:** / **Goal:**),
-  // and the snapshot must round-trip them back to plain newlines unchanged.
+  // the snapshot must round-trip them back to plain newlines unchanged, and
+  // literal contexts (fenced code) must keep their newlines untouched.
   const softDoc = await (
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Soft break check',
-        markdown: '# Soft breaks\n\n**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin\n',
+        markdown:
+          '# Soft breaks\n\n**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin\n\n```\ncode line one\ncode line two\n```\n',
       }),
     })
   ).json()
+  // br[data-type="hardbreak"] comes from Milkdown's hardbreakAttr; update the
+  // selector if a Milkdown upgrade renames it.
+  const inspectSoftBreaks = () => {
+    const p = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) =>
+      el.textContent?.includes('Date:'),
+    )
+    const code = document.querySelectorAll('.milkdown .ProseMirror pre')
+    return {
+      brs: p ? p.querySelectorAll('br[data-type="hardbreak"]').length : -1,
+      lines: p ? p.innerText.split('\n') : [],
+      html: p ? p.innerHTML.slice(0, 200) : '(no metadata paragraph found)',
+      codeBlocks: code.length,
+      codeText: code[0]?.textContent ?? '',
+    }
+  }
+  const assertSoftBreakRender = async (page, label) => {
+    await page
+      .waitForFunction(
+        () => {
+          const p = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) =>
+            el.textContent?.includes('Date:'),
+          )
+          return p && p.querySelectorAll('br[data-type="hardbreak"]').length === 2
+        },
+        { timeout: 10000 },
+      )
+      .catch(() => null)
+    const state = await page.evaluate(inspectSoftBreaks)
+    if (
+      state.brs === 2 &&
+      state.lines.length === 3 &&
+      state.lines[0].endsWith('2026-06-07') &&
+      state.lines[2].startsWith('Goal:')
+    ) {
+      ok(`soft-break metadata block renders as three separate lines (${label})`)
+    } else {
+      fail(`soft breaks collapsed (${label}): brs=${state.brs} lines=${JSON.stringify(state.lines)} html=${state.html}`)
+    }
+    if (state.codeBlocks === 1 && state.codeText.includes('code line one') && state.codeText.includes('code line two')) {
+      ok(`fenced code block kept literal newlines (${label})`)
+    } else {
+      fail(`code block mangled (${label}): blocks=${state.codeBlocks} text=${JSON.stringify(state.codeText.slice(0, 80))}`)
+    }
+  }
   const sb = await browser.newPage()
   await sb.goto(`${BASE}/d/${softDoc.slug}`)
   await sb.waitForSelector('.doc-status--live', { timeout: 15000 })
-  const metaLines = await sb
-    .waitForFunction(
-      () => {
-        const p = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) =>
-          el.textContent?.includes('Date:'),
-        )
-        if (!p) return null
-        const brs = p.querySelectorAll('br[data-type="hardbreak"]').length
-        return brs === 2 ? p.innerText.split('\n') : null
-      },
-      { timeout: 10000 },
-    )
-    .then((handle) => handle.jsonValue())
-    .catch(() => null)
-  if (
-    metaLines?.length === 3 &&
-    metaLines[0].endsWith('2026-06-07') &&
-    metaLines[2].startsWith('Goal:')
-  ) {
-    ok('soft-break metadata block renders as three separate lines')
-  } else {
-    fail(`soft breaks collapsed: ${JSON.stringify(metaLines)}`)
+  await assertSoftBreakRender(sb, 'initial render')
+  // The 900ms snapshot debounce resets on every update — poll the API until
+  // the snapshot lands instead of gambling on a fixed sleep.
+  const stripMarkup = (md) => (md ?? '').replace(/<\/?(?:span|ins|del)[^>]*>/g, '')
+  const expectedMeta = '**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin'
+  let softPlain = ''
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const softState = await (await fetch(`${BASE}/api/docs/${softDoc.slug}`)).json()
+    softPlain = stripMarkup(softState.markdown)
+    if (softPlain.includes(expectedMeta)) break
+    await sb.waitForTimeout(300)
   }
-  await sb.waitForTimeout(1500) // snapshot debounce (900ms) + margin
-  const softState = await (await fetch(`${BASE}/api/docs/${softDoc.slug}`)).json()
-  const softPlain = (softState.markdown ?? '').replace(/<\/?span[^>]*>/g, '')
-  if (softPlain.includes('**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin')) {
+  if (softPlain.includes(expectedMeta)) {
     ok('soft breaks round-trip to plain newlines in the snapshot')
   } else {
     fail(`soft-break serialization drifted: ${JSON.stringify(softPlain.slice(0, 160))}`)
   }
+  // Reload exercises the persisted-state reparse path (no drift on repeated
+  // open/serialize cycles).
+  await sb.reload()
+  await sb.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await assertSoftBreakRender(sb, 'after reload')
   await sb.close()
 
   // Type a unique sentinel at the start of the doc in A
@@ -323,7 +360,9 @@ try {
     method: 'POST',
     headers: agentHeaders,
     body: JSON.stringify({
-      body: 'An agent-proposed closing paragraph.',
+      // Soft break in the body: acceptance parses through the same Milkdown
+      // parser as seeding, so the two lines must render with a <br> between.
+      body: 'An agent-proposed closing paragraph.\nWith a second proposed line.',
       intent: 'Add a closing',
       anchor_text: 'provenance',
     }),
@@ -356,6 +395,26 @@ try {
     { timeout: 10000 },
   )
   ok('accepted agent text carries agent attribution in the document')
+
+  const acceptedSoftBreakOk = await a
+    .waitForFunction(
+      () => {
+        const p = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) =>
+          el.textContent?.includes('An agent-proposed closing paragraph.'),
+        )
+        return (
+          p &&
+          p.querySelectorAll('br[data-type="hardbreak"]').length >= 1 &&
+          p.innerText.split('\n').some((line) => line.startsWith('With a second proposed line.'))
+        )
+      },
+      undefined,
+      { timeout: 10000 },
+    )
+    .then(() => true)
+    .catch(() => false)
+  if (acceptedSoftBreakOk) ok('accepted suggestion soft break renders as a separate line')
+  else fail('soft break in accepted suggestion body collapsed into one line')
 
   // Agent reacts to the human: poll + ack events
   const events = await (await fetch(`${api}/events/pending`, { headers: agentHeaders })).json()

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -69,6 +69,55 @@ try {
   else fail('## input rule did not produce a heading')
   await c.close()
 
+  // Soft breaks: single newlines in seeded markdown must render as visible
+  // line breaks (metadata blocks like **Date:** / **Source:** / **Goal:**),
+  // and the snapshot must round-trip them back to plain newlines unchanged.
+  const softDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Soft break check',
+        markdown: '# Soft breaks\n\n**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin\n',
+      }),
+    })
+  ).json()
+  const sb = await browser.newPage()
+  await sb.goto(`${BASE}/d/${softDoc.slug}`)
+  await sb.waitForSelector('.doc-status--live', { timeout: 15000 })
+  const metaLines = await sb
+    .waitForFunction(
+      () => {
+        const p = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) =>
+          el.textContent?.includes('Date:'),
+        )
+        if (!p) return null
+        const brs = p.querySelectorAll('br[data-type="hardbreak"]').length
+        return brs === 2 ? p.innerText.split('\n') : null
+      },
+      { timeout: 10000 },
+    )
+    .then((handle) => handle.jsonValue())
+    .catch(() => null)
+  if (
+    metaLines?.length === 3 &&
+    metaLines[0].endsWith('2026-06-07') &&
+    metaLines[2].startsWith('Goal:')
+  ) {
+    ok('soft-break metadata block renders as three separate lines')
+  } else {
+    fail(`soft breaks collapsed: ${JSON.stringify(metaLines)}`)
+  }
+  await sb.waitForTimeout(1500) // snapshot debounce (900ms) + margin
+  const softState = await (await fetch(`${BASE}/api/docs/${softDoc.slug}`)).json()
+  const softPlain = (softState.markdown ?? '').replace(/<\/?span[^>]*>/g, '')
+  if (softPlain.includes('**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin')) {
+    ok('soft breaks round-trip to plain newlines in the snapshot')
+  } else {
+    fail(`soft-break serialization drifted: ${JSON.stringify(softPlain.slice(0, 160))}`)
+  }
+  await sb.close()
+
   // Type a unique sentinel at the start of the doc in A
   const sentinel = `sync-${Date.now()}`
   await a.click('.milkdown .ProseMirror')


### PR DESCRIPTION
## Summary

Documents that open with an agent-authored metadata block —

```
**Date:** 2026-06-07
**Source:** Analysis of all local agent transcripts…
**Goal:** Reduce, sharpen, and de-bloat the plugin…
```

— rendered as one run-on paragraph ("Date: 2026-06-07 Source: Analysis… Goal: Reduce…"), because soft line breaks (single newlines) displayed as a space. Now each line renders on its own line, matching what the author wrote and what every comparable editor (Notion, Slack, GitHub comments) shows.

The root cause was presentational, not parse loss: Milkdown already preserves soft breaks as `hardbreak` nodes flagged `isInline: true`, but its commonmark preset renders those as a `<span>` containing a single space. The fix overrides the hardbreak schema's `toDOM` to emit a real `<br>` (plus a `parseDOM` rule so editor-generated HTML round-trips the flag on paste).

Two consequences fall out of fixing it at the render layer:

- **Serialization is untouched** — soft breaks still round-trip to plain `\n` (verified byte-identical), so the markdown agents read via the API never changes shape.
- **Existing documents heal on deploy** — the break nodes were always in their CRDT state; they were just rendered as spaces. No content repair or migration needed (the originally planned live-doc repair was dropped as unnecessary).

## Test plan

- `script/browser_check.mjs` gains soft-break coverage: seeded metadata block renders as three lines (initial render and after reload), fenced code blocks keep literal newlines, the snapshot round-trips to plain newlines (polled past the 900 ms debounce), and a suggestion body containing a soft break renders as a separate line after acceptance.
- Full suite: `bin/rails test` (175 runs, 0 failures) and `BASE_URL=… node script/browser_check.mjs` green; the only console noise is the pre-existing SharePopover dev-mode React warning, untouched by this branch.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
