### PR TITLE
feat: Accept all button for agent suggestion batches

### DIFF
--- a/app/frontend/components/mobile_dock.tsx
+++ b/app/frontend/components/mobile_dock.tsx
@@ -82,6 +82,9 @@ interface SuggestionSheetProps {
   focusId: number | null
   onAccept: (suggestion: SuggestionPayload) => void
   onReject: (suggestion: SuggestionPayload) => void
+  /** Present only when several server-backed suggestions are pending. */
+  onAcceptAll?: () => Promise<void>
+  acceptingAll?: boolean
 }
 
 /** The suggestion review surface on mobile — full cards in a scrollable
@@ -91,6 +94,8 @@ export function SuggestionSheetList({
   focusId,
   onAccept,
   onReject,
+  onAcceptAll,
+  acceptingAll = false,
 }: SuggestionSheetProps) {
   const listRef = useRef<HTMLUListElement>(null)
   const [resolving, setResolving] = useState<Set<number>>(new Set())
@@ -127,7 +132,17 @@ export function SuggestionSheetList({
   }
 
   return (
-    <ul className="sheet-suggestions" ref={listRef}>
+    <>
+      {onAcceptAll && (
+        <button
+          className="accept-all-button accept-all-button--sheet"
+          disabled={acceptingAll}
+          onClick={() => void onAcceptAll()}
+        >
+          {acceptingAll ? 'Accepting…' : `Accept all ${suggestions.filter((s) => s.id > 0).length}`}
+        </button>
+      )}
+      <ul className="sheet-suggestions" ref={listRef}>
       {suggestions.map((suggestion) => {
         const machine = suggestion.author_kind !== 'human'
         return (
@@ -168,6 +183,7 @@ export function SuggestionSheetList({
           </li>
         )
       })}
-    </ul>
+      </ul>
+    </>
   )
 }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1550,6 +1550,40 @@ a:focus-visible {
   gap: 0.625rem;
 }
 
+/* Bulk accept for agent suggestion batches — appears beside the mode
+   control only while two or more server-backed suggestions are pending. */
+.accept-all-button {
+  border: 1px solid var(--sug-ins-line);
+  background: var(--sug-ins-bg);
+  color: var(--ink);
+  font-size: 0.74rem;
+  font-weight: 550;
+  border-radius: 7px;
+  padding: 0.28rem 0.8rem;
+  min-height: 1.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.accept-all-button:hover:not(:disabled) {
+  background: var(--sug-ins-line);
+  color: var(--surface);
+}
+
+.accept-all-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.accept-all-button--sheet {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
 .header-menu-trigger {
   font-size: 0.9rem;
   line-height: 1;

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -389,37 +389,68 @@ export default function DocumentShow({
     applyReviewState(view, span, state)
   }, [])
 
-  const acceptSuggestion = useCallback(
-    (suggestion: SuggestionPayload) => {
-      if (!handle) return
-      // Optimistic placeholders (negative id) have no server row yet —
-      // a PATCH against them would 404.
-      if (suggestion.id < 0) return
-      // The card clears optimistically, but the CRDT insert waits for the
-      // server to confirm THIS client won the accept — otherwise two windows
-      // accepting concurrently would each insert the text (the loser's PATCH
-      // 422s, but a local-first insert could not be rolled back).
-      router
-        .optimistic((props: Partial<DocumentProps>) => ({
-          suggestions: (props.suggestions ?? []).filter((s) => s.id !== suggestion.id),
-        }))
-        .patch(
-          `/suggestions/${suggestion.id}/accept`,
-          { by: identity.name },
-          {
-            preserveScroll: true,
-            only: ['suggestions', 'activities'],
-            async: true,
-            onSuccess: () => {
-              const merged = applySuggestion(handle.editor, suggestion)
-              // A one-beat pulse on the merged text — the reward for review.
-              if (merged) flashMergedRange(handle.editor, merged)
+  // Promise-based single accept, shared by the per-card button and Accept
+  // all. The card clears optimistically, but the CRDT insert waits for the
+  // server to confirm THIS client won the accept — otherwise two windows
+  // accepting concurrently would each insert the text (the loser's PATCH
+  // 422s, but a local-first insert could not be rolled back). The promise
+  // settles on finish regardless of outcome so a bulk loop never stalls on
+  // a suggestion someone else resolved first.
+  const acceptOne = useCallback(
+    (suggestion: SuggestionPayload) =>
+      new Promise<void>((resolve) => {
+        // Optimistic placeholders (negative id) have no server row yet —
+        // a PATCH against them would 404.
+        if (!handle || suggestion.id < 0) {
+          resolve()
+          return
+        }
+        router
+          .optimistic((props: Partial<DocumentProps>) => ({
+            suggestions: (props.suggestions ?? []).filter((s) => s.id !== suggestion.id),
+          }))
+          .patch(
+            `/suggestions/${suggestion.id}/accept`,
+            { by: identity.name },
+            {
+              preserveScroll: true,
+              only: ['suggestions', 'activities'],
+              async: true,
+              onSuccess: () => {
+                const merged = applySuggestion(handle.editor, suggestion)
+                // A one-beat pulse on the merged text — the reward for review.
+                if (merged) flashMergedRange(handle.editor, merged)
+              },
+              onFinish: () => resolve(),
             },
-          },
-        )
-    },
+          )
+      }),
     [handle, identity.name],
   )
+
+  const acceptSuggestion = useCallback(
+    (suggestion: SuggestionPayload) => {
+      void acceptOne(suggestion)
+    },
+    [acceptOne],
+  )
+
+  // Accept every pending server-backed suggestion, strictly in sequence:
+  // each merge re-anchors against the post-merge document, exactly as if
+  // the cards were clicked one by one. Suggestions resolved elsewhere
+  // mid-loop 422 and are skipped.
+  const [acceptingAll, setAcceptingAll] = useState(false)
+  const acceptAllSuggestions = useCallback(async () => {
+    if (acceptingAll) return
+    const pending = suggestionsRef.current.filter((s) => s.id > 0)
+    if (pending.length === 0) return
+    setAcceptingAll(true)
+    try {
+      for (const suggestion of pending) await acceptOne(suggestion)
+    } finally {
+      setAcceptingAll(false)
+    }
+  }, [acceptingAll, acceptOne])
 
   const rejectSuggestion = useCallback(
     (suggestion: SuggestionPayload) => {
@@ -657,6 +688,9 @@ export default function DocumentShow({
     [submitComment, composerAnchor],
   )
 
+  // Server-backed pending suggestions — the population Accept all covers.
+  const pendingSuggestionCount = suggestions.filter((s) => s.id > 0).length
+
   const jumpToAnchor = useCallback((anchorText: string) => {
     const view = viewRef.current
     if (!view) return
@@ -692,6 +726,15 @@ export default function DocumentShow({
               <ProvenanceSummaryChip spans={spans} />
               <PresenceBar humans={peers} agents={presences} compact={isMobile} />
             </div>
+            {pendingSuggestionCount > 1 && (
+              <button
+                className="accept-all-button"
+                disabled={acceptingAll}
+                onClick={() => void acceptAllSuggestions()}
+              >
+                {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
+              </button>
+            )}
             <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
             <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
             <HeaderMenu
@@ -836,6 +879,8 @@ export default function DocumentShow({
               focusId={sheetFocusId}
               onAccept={acceptSuggestion}
               onReject={rejectSuggestion}
+              onAcceptAll={pendingSuggestionCount > 1 ? acceptAllSuggestions : undefined}
+              acceptingAll={acceptingAll}
             />
           </MobileSheet>
         )}

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -844,6 +844,70 @@ try {
   }
   await q.close()
 
+  // --- Accept all: an agent suggestion batch merges with one click ---
+  const bulkDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Accept all check',
+        markdown: 'Alpha paragraph here.\n\nBravo paragraph here.\n\nCharlie paragraph here.\n',
+      }),
+    })
+  ).json()
+  const bulkBodies = ['First proposed line.', 'Second proposed line.', 'Third proposed line.']
+  const bulkAnchors = ['Alpha paragraph here.', 'Bravo paragraph here.', 'Charlie paragraph here.']
+  for (let i = 0; i < 3; i += 1) {
+    await fetch(`${BASE}/api/docs/${bulkDoc.slug}/suggestions`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'Scout', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: bulkBodies[i], intent: 'bulk', anchor_text: bulkAnchors[i] }),
+    })
+  }
+  const bulk = await makePage('a')
+  await bulk.goto(`${BASE}/d/${bulkDoc.slug}`)
+  await bulk.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await bulk.waitForTimeout(1000)
+  const bulkBtnText = (await bulk.locator('.accept-all-button').textContent().catch(() => null))?.trim()
+  if (bulkBtnText === 'Accept all 3') ok('Accept all button appears in the header with the count')
+  else fail(`Accept all button wrong or missing: "${bulkBtnText}"`)
+  await bulk.locator('.accept-all-button').click()
+  // Cards clear optimistically per accept; the merged text lands on each
+  // PATCH's success — wait for BOTH before judging.
+  const bulkMerged = await bulk
+    .waitForFunction(
+      (bodies) => {
+        const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
+        return (
+          document.querySelectorAll('.margin-card').length === 0 &&
+          bodies.every((b) => text.includes(b))
+        )
+      },
+      bulkBodies,
+      { timeout: 15000 },
+    )
+    .then(() => true)
+    .catch(() => false)
+  if (bulkMerged) ok('Accept all merged every suggestion and cleared the cards')
+  else fail('Accept all left cards or unmerged text behind')
+  if ((await bulk.locator('.accept-all-button').count()) === 0) {
+    ok('Accept all button retired itself once nothing is pending')
+  } else {
+    fail('Accept all button still visible with no pending suggestions')
+  }
+  await bulk.waitForTimeout(1500) // let the snapshot debounce flush
+  await bulk.reload()
+  await bulk.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await bulk.waitForTimeout(800)
+  const bulkAfter = await bulk.locator('.milkdown .ProseMirror').innerText()
+  const bulkCardsBack = await bulk.locator('.margin-card').count()
+  if (bulkBodies.every((b) => bulkAfter.includes(b)) && bulkCardsBack === 0) {
+    ok('bulk-accepted suggestions persisted across reload')
+  } else {
+    fail(`bulk accept did not persist: cards=${bulkCardsBack}`)
+  }
+  await bulk.close()
+
   for (const [label, errs] of Object.entries(errors)) {
     const fatal = errs.filter(
       (e) =>


### PR DESCRIPTION
## What

An **Accept all · N** pill in the document header (and at the top of the mobile suggestions sheet) whenever two or more server-backed suggestions are pending — one click merges an entire agent batch instead of clicking N cards.

## How

- The existing per-card accept flow is refactored into a promise-based `acceptOne` (settles via `onFinish`, so a bulk loop never stalls on a suggestion someone else resolved first — the loser's PATCH 422s and the loop continues). The per-card button uses the same helper, so behavior there is unchanged.
- `acceptAllSuggestions` runs the accepts **strictly in sequence**: each merge re-anchors against the post-merge document, exactly equivalent to clicking the cards one by one. The concurrency guarantee (CRDT insert only after the server confirms this client won the accept) is preserved per suggestion.
- The button renders only with ≥2 pending server-backed suggestions, disables itself while running ("Accepting…"), and disappears when nothing is pending.
- Styled in the suggestion-insertion green so it reads as the bulk form of the per-card Accept.

## Verification

- `npm run check` clean
- Full `script/browser_check.mjs` passes with four new permanent checks: button appears with count, one click merges all three seeded agent suggestions and clears the cards, the button retires itself, merges persist across reload. Only failure is the pre-existing `SharePopover` setState-in-render dev warning (also fails on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)