### PR TITLE
fix: suggestion replace duplication + atomic one-round-trip Accept all

### DIFF
--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -32,6 +32,31 @@ class SuggestionsController < InertiaController
     redirect_to root_path, status: :see_other
   end
 
+  # Bulk accept for the Accept-all button. JSON in/out rather than the
+  # Inertia redirect dance: the accepting client needs the authoritative
+  # winner list synchronously to merge each body into the CRDT locally.
+  # One activity entry and one broadcast for the whole batch — eleven
+  # "accepted X" rows would be noise, and the broadcast triggers every
+  # client's debounced props reload anyway.
+  def accept_all
+    document = Document.find_by!(slug: params[:slug])
+    by = preferred_name(params[:by], fallback: "human")
+    accepted = Suggestion.accept_all!(document:, by:)
+
+    if accepted.any?
+      Activity.log!(
+        document:,
+        actor_name: preferred_name(params[:by], fallback: "Someone"),
+        actor_kind: "human",
+        action: "accepted_suggestion",
+        detail: "accepted #{accepted.size} suggestions in one batch"
+      )
+      DocumentMetaChannel.broadcast_event(document, :suggestions)
+    end
+
+    render json: { accepted: accepted.map(&:as_props) }
+  end
+
   def accept
     @suggestion.accept!(by: preferred_name(params[:by], fallback: "human"))
     log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -40,13 +40,15 @@ class SuggestionsController < InertiaController
   # client's debounced props reload anyway.
   def accept_all
     document = Document.find_by!(slug: params[:slug])
-    by = preferred_name(params[:by], fallback: "human")
+    # One name for both resolved_by and the activity row — two lookups with
+    # different fallbacks silently diverge when no session name is set.
+    by = preferred_name(params[:by], fallback: "Someone")
     accepted = Suggestion.accept_all!(document:, by:)
 
     if accepted.any?
       Activity.log!(
         document:,
-        actor_name: preferred_name(params[:by], fallback: "Someone"),
+        actor_name: by,
         actor_kind: "human",
         action: "accepted_suggestion",
         detail: "accepted #{accepted.size} suggestions in one batch"
@@ -55,6 +57,9 @@ class SuggestionsController < InertiaController
     end
 
     render json: { accepted: accepted.map(&:as_props) }
+  rescue ActiveRecord::RecordNotFound
+    # JSON in, JSON out — an HTML 404 page here is unparseable to the client.
+    render json: { error: "No document with that slug." }, status: :not_found
   end
 
   def accept

--- a/app/frontend/components/margin_suggestions.tsx
+++ b/app/frontend/components/margin_suggestions.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { editorViewCtx } from '@milkdown/kit/core'
+import { editorViewCtx, parserCtx } from '@milkdown/kit/core'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import type { EditorHandle } from '../editor/milkdown_editor'
 import type { ProvenanceSpan } from '../editor/provenance'
-import { findTextRange, type SuggestionPayload } from '../editor/suggestions'
+import { findSuggestionTarget, type SuggestionPayload } from '../editor/suggestions'
 import { truncate } from '../lib/truncate'
 import { clearHighlight, domRange, setHighlight, supportsHighlights } from '../lib/highlights'
 
@@ -91,8 +91,12 @@ export function MarginSuggestions({
     if (!container || !handle) return
 
     let view: EditorView
+    let parser: Parameters<typeof findSuggestionTarget>[1]
     try {
-      view = handle.editor.action((ctx) => ctx.get(editorViewCtx))
+      ;({ view, parser } = handle.editor.action((ctx) => ({
+        view: ctx.get(editorViewCtx),
+        parser: ctx.get(parserCtx),
+      })))
     } catch {
       return // editor torn down mid-navigation
     }
@@ -102,7 +106,7 @@ export function MarginSuggestions({
     rangesRef.current = new Map()
 
     const entries = suggestions.map((s) => {
-      const range = findTextRange(view.state.doc, anchorOf(s))
+      const range = findSuggestionTarget(view.state.doc, parser, anchorOf(s))
       if (range) {
         const dom = domRange(view, range.from, range.to)
         if (dom) rangesRef.current.set(s.id, dom)
@@ -166,7 +170,7 @@ export function MarginSuggestions({
       try {
         handle.editor.action((ctx) => {
           const view = ctx.get(editorViewCtx)
-          const range = findTextRange(view.state.doc, anchorOf(suggestion))
+          const range = findSuggestionTarget(view.state.doc, ctx.get(parserCtx), anchorOf(suggestion))
           if (!range) return
           const tr = view.state.tr.setSelection(
             TextSelection.create(view.state.doc, range.from, range.to),

--- a/app/frontend/editor/suggestions.ts
+++ b/app/frontend/editor/suggestions.ts
@@ -113,6 +113,31 @@ interface MatchedRange {
   kind: 'inline' | 'block'
 }
 
+// Parsing a quote is deterministic for a given source string, and the margin
+// measure pass re-matches every suggestion on each document change — caching
+// makes the per-keystroke cost a Map lookup instead of a markdown parse.
+// Cached nodes are only read for textContent/shape, so a cache entry from a
+// torn-down editor's schema is still valid data.
+const PARSE_CACHE_MAX = 200
+const parseCache = new Map<string, Node | null>()
+
+const parseQuote = (parser: MarkdownParser, search: string): Node | null => {
+  const cached = parseCache.get(search)
+  if (cached !== undefined) return cached
+  let parsed: Node | null = null
+  try {
+    parsed = parser(search) ?? null
+  } catch {
+    parsed = null
+  }
+  if (parseCache.size >= PARSE_CACHE_MAX) {
+    const oldest = parseCache.keys().next().value
+    if (oldest !== undefined) parseCache.delete(oldest)
+  }
+  parseCache.set(search, parsed)
+  return parsed
+}
+
 /**
  * Locate suggestion-quoted text in the document. Agents quote the markdown
  * SOURCE they read from the API (`### Heading`, `**bold**`, `\~` escapes),
@@ -133,12 +158,7 @@ function matchQuotedText(
   const raw = findTextRange(doc, search)
   if (raw) return { ...raw, kind: 'inline' }
 
-  let parsed: Node | undefined
-  try {
-    parsed = parser(search)
-  } catch {
-    return null
-  }
+  const parsed = parseQuote(parser, search)
   if (!parsed || parsed.content.size === 0) return null
 
   const block = findBlockRange(doc, blockTexts(parsed))

--- a/app/frontend/editor/suggestions.ts
+++ b/app/frontend/editor/suggestions.ts
@@ -1,7 +1,10 @@
 import { editorViewCtx, parserCtx, type Editor } from '@milkdown/kit/core'
-import type { MarkType, Node } from '@milkdown/kit/prose/model'
+import { Slice, type MarkType, type Node } from '@milkdown/kit/prose/model'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import { SKIP_PROVENANCE } from './provenance'
+
+/** The Milkdown parser's call shape — markdown source in, doc node out. */
+type MarkdownParser = (markdown: string) => Node | undefined
 
 export interface SuggestionPayload {
   id: number
@@ -64,6 +67,107 @@ export function findTextRange(
   return result
 }
 
+const normalizeBlockText = (text: string): string => text.replace(/\s+/g, ' ').trim()
+
+/** Normalized plain text of each top-level block in a parsed fragment. */
+const blockTexts = (parsed: Node): string[] => {
+  const texts: string[] = []
+  parsed.forEach((child) => texts.push(normalizeBlockText(child.textContent)))
+  return texts
+}
+
+/**
+ * First contiguous window of top-level doc blocks whose rendered text
+ * matches `searchTexts` block-for-block (whitespace-normalized, full-block
+ * equality). Returns the doc range spanning the window.
+ */
+function findBlockRange(doc: Node, searchTexts: string[]): { from: number; to: number } | null {
+  if (searchTexts.length === 0 || searchTexts.every((t) => t === '')) return null
+  const blocks: { text: string; from: number; to: number }[] = []
+  doc.forEach((child, offset) => {
+    blocks.push({
+      text: normalizeBlockText(child.textContent),
+      from: offset,
+      to: offset + child.nodeSize,
+    })
+  })
+  for (let i = 0; i + searchTexts.length <= blocks.length; i += 1) {
+    let matched = true
+    for (let j = 0; j < searchTexts.length; j += 1) {
+      if (blocks[i + j].text !== searchTexts[j]) {
+        matched = false
+        break
+      }
+    }
+    if (matched) {
+      return { from: blocks[i].from, to: blocks[i + searchTexts.length - 1].to }
+    }
+  }
+  return null
+}
+
+interface MatchedRange {
+  from: number
+  to: number
+  /** 'inline' = within one textblock; 'block' = a window of whole blocks. */
+  kind: 'inline' | 'block'
+}
+
+/**
+ * Locate suggestion-quoted text in the document. Agents quote the markdown
+ * SOURCE they read from the API (`### Heading`, `**bold**`, `\~` escapes),
+ * but the document only contains rendered text — so a raw string search is
+ * tried first (fast path for plain-text quotes), then the quote is parsed
+ * through the same Milkdown parser as the body and matched by rendered
+ * text: block-sequence-wise for blocky quotes, inline for short ones.
+ * Without this, "replace" silently degraded to "insert-after" and content
+ * duplicated (the J3YVc161mb double-outline incident).
+ */
+function matchQuotedText(
+  doc: Node,
+  parser: MarkdownParser,
+  search: string | null,
+): MatchedRange | null {
+  if (!search) return null
+
+  const raw = findTextRange(doc, search)
+  if (raw) return { ...raw, kind: 'inline' }
+
+  let parsed: Node | undefined
+  try {
+    parsed = parser(search)
+  } catch {
+    return null
+  }
+  if (!parsed || parsed.content.size === 0) return null
+
+  const block = findBlockRange(doc, blockTexts(parsed))
+  if (block) return { ...block, kind: 'block' }
+
+  // Markdown-styled inline quote (e.g. `**Date:** 2026`) inside a larger
+  // paragraph: match its rendered text within a single block.
+  if (parsed.childCount === 1 && parsed.firstChild?.isTextblock) {
+    const inline = findTextRange(doc, normalizeBlockText(parsed.firstChild.textContent))
+    if (inline) return { ...inline, kind: 'inline' }
+  }
+  return null
+}
+
+/**
+ * Where a suggestion's quoted text (replaces, else anchor) lives in the
+ * doc — for margin-card placement and jump-to-anchor. Same matcher accept
+ * uses, so cards anchor correctly for markdown-quoting suggestions instead
+ * of stacking at the document top.
+ */
+export function findSuggestionTarget(
+  doc: Node,
+  parser: MarkdownParser,
+  search: string | null,
+): { from: number; to: number } | null {
+  const match = matchQuotedText(doc, parser, search)
+  return match ? { from: match.from, to: match.to } : null
+}
+
 /**
  * Merge an accepted suggestion into the live document. The inserted text
  * carries provenance matching its author kind: machine authors (ai/agent)
@@ -73,9 +177,15 @@ export function findTextRange(
  * verbatim`) — human prose must never inflate the AI percentages or enter
  * the AI review-state machinery (which keys on kind === 'ai').
  *
- * - `replaces` present and found → the matched range is replaced
- * - `anchor_text` present and found → content inserted after that block
- * - otherwise → appended at the end of the document
+ * - `replaces` matched inline + single-textblock body → inline replacement
+ *   (keeps the surrounding paragraph intact — the typo-fix path)
+ * - `replaces` matched as a block window → the whole window is replaced by
+ *   the parsed body (section rewrites)
+ * - `replaces` matched inline + multi-block body → replaceRange fits the
+ *   block content around the matched text
+ * - no `replaces` match → inserted after `anchor_text`'s block, else
+ *   appended at the end of the document. The old content is only ever left
+ *   in place when `replaces` genuinely matched nothing.
  *
  * Returns the inserted range so callers can spotlight the merge.
  */
@@ -94,35 +204,46 @@ export function applySuggestion(
 
     const parsed = parser(suggestion.body)
     if (!parsed || parsed.content.size === 0) return
+    const bodyIsInline = parsed.childCount === 1 && Boolean(parsed.firstChild?.isTextblock)
 
     let tr = state.tr
     let insertFrom: number
-    let insertSize: number
+    let insertTo: number
 
-    const replaceRange = findTextRange(state.doc, suggestion.replaces)
-    if (replaceRange && parsed.childCount === 1 && parsed.firstChild?.isTextblock) {
-      // Inline replacement keeps the surrounding paragraph intact.
-      const inline = parsed.firstChild.content
-      tr = tr.replaceWith(replaceRange.from, replaceRange.to, inline)
-      insertFrom = replaceRange.from
-      insertSize = inline.size
+    const target = matchQuotedText(state.doc, parser, suggestion.replaces)
+    if (target && target.kind === 'inline' && bodyIsInline) {
+      const inline = parsed.firstChild!.content
+      tr = tr.replaceWith(target.from, target.to, inline)
+      insertFrom = target.from
+      insertTo = target.from + inline.size
+    } else if (target && target.kind === 'block') {
+      tr = tr.replaceWith(target.from, target.to, parsed.content)
+      insertFrom = target.from
+      insertTo = target.from + parsed.content.size
+    } else if (target) {
+      // Inline match, block-shaped body: let replaceRange grow the cut to
+      // fit block content (covers-whole-block matches replace the block).
+      tr = tr.replaceRange(target.from, target.to, new Slice(parsed.content, 0, 0))
+      insertFrom = tr.mapping.map(target.from, -1)
+      insertTo = tr.mapping.map(target.to, 1)
     } else {
-      const anchorRange =
-        replaceRange ?? findTextRange(state.doc, suggestion.anchor_text)
+      const anchorRange = matchQuotedText(state.doc, parser, suggestion.anchor_text)
       let insertPos = state.doc.content.size
       if (anchorRange) {
+        // Block matches already end at a top-level boundary; inline matches
+        // resolve to the end of their enclosing top-level block.
         const $anchor = state.doc.resolve(anchorRange.to)
-        insertPos = $anchor.after($anchor.depth >= 1 ? 1 : 0)
+        insertPos = $anchor.depth >= 1 ? $anchor.after(1) : anchorRange.to
       }
       tr = tr.insert(insertPos, parsed.content)
       insertFrom = insertPos
-      insertSize = parsed.content.size
+      insertTo = insertPos + parsed.content.size
     }
 
     const human = suggestion.author_kind === 'human'
     tr = tr.addMark(
       insertFrom,
-      insertFrom + insertSize,
+      insertTo,
       markType.create(
         human
           ? { kind: 'human', author: suggestion.author_name, state: 'verbatim' }
@@ -130,10 +251,10 @@ export function applySuggestion(
       ),
     )
     tr.setMeta(SKIP_PROVENANCE, true)
-    tr.setSelection(TextSelection.near(tr.doc.resolve(insertFrom + insertSize)))
+    tr.setSelection(TextSelection.near(tr.doc.resolve(insertTo)))
     tr.scrollIntoView()
     view.dispatch(tr)
-    applied = { from: insertFrom, to: insertFrom + insertSize }
+    applied = { from: insertFrom, to: insertTo }
   })
 
   return applied

--- a/app/frontend/lib/csrf.ts
+++ b/app/frontend/lib/csrf.ts
@@ -4,10 +4,18 @@ export function csrfToken(): string {
   )
 }
 
-/** fetch wrapper for non-Inertia JSON endpoints (snapshots, activity pings). */
+/** fetch wrappers for non-Inertia JSON endpoints (snapshots, bulk accept). */
 export async function postJSON(url: string, body: unknown): Promise<Response> {
+  return jsonRequest('POST', url, body)
+}
+
+export async function patchJSON(url: string, body: unknown): Promise<Response> {
+  return jsonRequest('PATCH', url, body)
+}
+
+async function jsonRequest(method: string, url: string, body: unknown): Promise<Response> {
   return fetch(url, {
-    method: 'POST',
+    method,
     headers: {
       'Content-Type': 'application/json',
       'X-CSRF-Token': csrfToken(),

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -53,6 +53,7 @@ import { useMetaChannel } from '../../lib/use_meta_channel'
 import { useMediaQuery } from '../../lib/use_media_query'
 import { useAnchoredPopover } from '../../lib/use_anchored_popover'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
+import { patchJSON } from '../../lib/csrf'
 import {
   getStoredFlag,
   getStoredString,
@@ -435,22 +436,43 @@ export default function DocumentShow({
     [acceptOne],
   )
 
-  // Accept every pending server-backed suggestion, strictly in sequence:
-  // each merge re-anchors against the post-merge document, exactly as if
-  // the cards were clicked one by one. Suggestions resolved elsewhere
-  // mid-loop 422 and are skipped.
+  // Accept all pending suggestions in ONE round trip: the server flips the
+  // batch atomically and returns the winners, then the bodies merge into
+  // the CRDT locally in id order — each merge re-anchors against the
+  // post-merge document, exactly as if the cards were clicked one by one,
+  // minus the per-card network wait. Cards hide optimistically while the
+  // request is in flight; the broadcast-driven props reload makes the
+  // clearing durable, and a failed request lets the cards reappear.
   const [acceptingAll, setAcceptingAll] = useState(false)
   const acceptAllSuggestions = useCallback(async () => {
-    if (acceptingAll) return
-    const pending = suggestionsRef.current.filter((s) => s.id > 0)
-    if (pending.length === 0) return
+    if (acceptingAll || !handle) return
+    if (suggestionsRef.current.filter((s) => s.id > 0).length === 0) return
     setAcceptingAll(true)
     try {
-      for (const suggestion of pending) await acceptOne(suggestion)
+      const response = await patchJSON(`/d/${doc.slug}/suggestions/accept_all`, {
+        by: identity.name,
+      })
+      if (!response.ok) return
+      const { accepted } = (await response.json()) as { accepted: SuggestionPayload[] }
+      for (const suggestion of accepted) {
+        const merged = applySuggestion(handle.editor, suggestion)
+        if (merged) flashMergedRange(handle.editor, merged)
+      }
+      // The broadcast already schedules every client's debounced reload;
+      // this explicit one guarantees the acceptor's own cards clear even
+      // with the cable momentarily down.
+      router.reload({ only: ['suggestions', 'activities'], async: true })
     } finally {
       setAcceptingAll(false)
     }
-  }, [acceptingAll, acceptOne])
+  }, [acceptingAll, handle, doc.slug, identity.name])
+
+  // Optimistic clearing for the bulk path: server-backed cards vanish the
+  // moment Accept all is clicked; optimistic placeholders (negative ids,
+  // not part of the batch) stay visible.
+  const visibleSuggestions = acceptingAll
+    ? suggestions.filter((s) => s.id < 0)
+    : suggestions
 
   const rejectSuggestion = useCallback(
     (suggestion: SuggestionPayload) => {
@@ -776,7 +798,7 @@ export default function DocumentShow({
                 focusMode={focusMode || isMobile}
               />
               <MarginSuggestions
-                suggestions={suggestions}
+                suggestions={visibleSuggestions}
                 handle={handle}
                 spans={spans}
                 focusMode={focusMode || isMobile}
@@ -859,7 +881,7 @@ export default function DocumentShow({
         )}
         {isMobile && (
           <MobileDock
-            suggestionCount={suggestions.length + inlineSuggestions.length}
+            suggestionCount={visibleSuggestions.length + inlineSuggestions.length}
             commentCount={comments.filter((c) => !c.resolved).length}
             active={activeSheet}
             onOpen={(kind) => setActiveSheet((current) => (current === kind ? null : kind))}
@@ -867,7 +889,7 @@ export default function DocumentShow({
         )}
         {isMobile && activeSheet === 'suggestions' && (
           <MobileSheet
-            title={`Suggestions${suggestions.length + inlineSuggestions.length > 0 ? ` · ${suggestions.length + inlineSuggestions.length}` : ''}`}
+            title={`Suggestions${visibleSuggestions.length + inlineSuggestions.length > 0 ? ` · ${visibleSuggestions.length + inlineSuggestions.length}` : ''}`}
             onClose={() => {
               setActiveSheet(null)
               setSheetFocusId(null)
@@ -875,7 +897,7 @@ export default function DocumentShow({
           >
             <InlineSuggestionSheetList inline={inlineSuggestions} handle={handle} />
             <SuggestionSheetList
-              suggestions={suggestions}
+              suggestions={visibleSuggestions}
               focusId={sheetFocusId}
               onAccept={acceptSuggestion}
               onReject={rejectSuggestion}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -18,12 +18,13 @@ import {
 } from '../../editor/provenance'
 import {
   applySuggestion,
+  findSuggestionTarget,
   findTextRange,
   flashMergedRange,
   type SuggestionPayload,
 } from '../../editor/suggestions'
 import { refreshAgentCursors } from '../../editor/agent_cursors'
-import { editorViewCtx } from '@milkdown/kit/core'
+import { editorViewCtx, parserCtx } from '@milkdown/kit/core'
 import { collectInlineSuggestions } from '../../editor/suggest_changes'
 import {
   MarginInlineSuggestions,
@@ -156,6 +157,10 @@ export default function DocumentShow({
   const [commentTarget, setCommentTarget] = useState<CommentTarget | null>(null)
   const [composerAnchor, setComposerAnchor] = useState<string | null>(null)
   const viewRef = useRef<EditorView | null>(null)
+  // Live handle for code that runs after awaits or inside stable callbacks —
+  // a closure-captured handle goes stale when the editor remounts mid-flight.
+  const handleRef = useRef<EditorHandle | null>(null)
+  handleRef.current = handle
   const [panelOpen, setPanelOpen] = useState(() => getStoredFlag('pruf:panel', true))
   const [focusMode, setFocusMode] = useState(() => getStoredFlag('pruf:focus', false))
   // Demo doc always opens in Edit and stays locked there.
@@ -320,13 +325,20 @@ export default function DocumentShow({
     setSelectionTarget(null)
 
     // Mobile: tapping inside a pending suggestion's tinted anchor opens its
-    // sheet card — the touch equivalent of glancing at the margin.
+    // sheet card — the touch equivalent of glancing at the margin. Same
+    // parser-aware matcher the cards anchor with, so markdown-quoting
+    // suggestions hit-test at their real ranges.
     if (isMobileRef.current && empty) {
       const pos = view.state.selection.head
-      const hit = suggestionsRef.current.find((s) => {
-        const range = findTextRange(view.state.doc, s.replaces ?? s.anchor_text)
-        return range !== null && pos >= range.from && pos <= range.to
-      })
+      const parser = handleRef.current
+        ? handleRef.current.editor.action((ctx) => ctx.get(parserCtx))
+        : null
+      const hit = parser
+        ? suggestionsRef.current.find((s) => {
+            const range = findSuggestionTarget(view.state.doc, parser, s.replaces ?? s.anchor_text)
+            return range !== null && pos >= range.from && pos <= range.to
+          })
+        : undefined
       if (hit) {
         setSheetFocusId(hit.id)
         setActiveSheet('suggestions')
@@ -445,27 +457,52 @@ export default function DocumentShow({
   // clearing durable, and a failed request lets the cards reappear.
   const [acceptingAll, setAcceptingAll] = useState(false)
   const acceptAllSuggestions = useCallback(async () => {
-    if (acceptingAll || !handle) return
+    if (acceptingAll || !handleRef.current) return
     if (suggestionsRef.current.filter((s) => s.id > 0).length === 0) return
     setAcceptingAll(true)
+    let succeeded = false
     try {
       const response = await patchJSON(`/d/${doc.slug}/suggestions/accept_all`, {
         by: identity.name,
       })
-      if (!response.ok) return
-      const { accepted } = (await response.json()) as { accepted: SuggestionPayload[] }
-      for (const suggestion of accepted) {
-        const merged = applySuggestion(handle.editor, suggestion)
-        if (merged) flashMergedRange(handle.editor, merged)
+      if (response.ok) {
+        const { accepted } = (await response.json()) as { accepted: SuggestionPayload[] }
+        for (const suggestion of accepted) {
+          // Live handle: the editor can remount during the awaits above.
+          const live = handleRef.current
+          if (!live) break
+          // One failing merge must not strand the rest of the batch — every
+          // winner is already accepted server-side.
+          try {
+            const merged = applySuggestion(live.editor, suggestion)
+            if (merged) flashMergedRange(live.editor, merged)
+          } catch (error) {
+            console.warn('pruf: bulk merge failed for suggestion', suggestion.id, error)
+          }
+        }
+        succeeded = true
+      } else {
+        console.warn('pruf: accept all rejected', response.status)
       }
-      // The broadcast already schedules every client's debounced reload;
-      // this explicit one guarantees the acceptor's own cards clear even
-      // with the cable momentarily down.
-      router.reload({ only: ['suggestions', 'activities'], async: true })
+    } catch (error) {
+      console.warn('pruf: accept all failed', error)
     } finally {
-      setAcceptingAll(false)
+      if (succeeded) {
+        // Hold the optimistic clearing until fresh props land — releasing
+        // before the reload finishes flashes the accepted cards (and the
+        // header button) back for a full round trip. The broadcast-driven
+        // debounced reload still covers every other client.
+        router.reload({
+          only: ['suggestions', 'activities'],
+          async: true,
+          onFinish: () => setAcceptingAll(false),
+        })
+      } else {
+        // Failure: release immediately so the cards reappear (rollback).
+        setAcceptingAll(false)
+      }
     }
-  }, [acceptingAll, handle, doc.slug, identity.name])
+  }, [acceptingAll, doc.slug, identity.name])
 
   // Optimistic clearing for the bulk path: server-backed cards vanish the
   // moment Accept all is clicked; optimistic placeholders (negative ids,

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -47,6 +47,24 @@ class Suggestion < ApplicationRecord
     transition!("accepted", by:)
   end
 
+  # Batch accept for the Accept-all button: flips every pending suggestion
+  # in one transaction (one fsync instead of N round-trips) and returns the
+  # rows that actually transitioned, in id order. A suggestion resolved
+  # concurrently by a single accept loses its pending status and is simply
+  # excluded — the caller only merges winners, so no text applies twice.
+  def self.accept_all!(document:, by: nil)
+    winners = []
+    document.transaction do
+      document.suggestions.pending.order(:id).each do |suggestion|
+        suggestion.accept!(by:)
+        winners << suggestion
+      rescue ActiveRecord::RecordInvalid
+        # lost to a concurrent resolve between the scope read and this row
+      end
+    end
+    winners
+  end
+
   def reject!(by: nil)
     transition!("rejected", by:)
   end

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -83,9 +83,17 @@ class Suggestion < ApplicationRecord
     errors.add(:intent, "is too long") if intent.to_s.bytesize > MAX_INTENT_BYTES
   end
 
+  # Compare-and-set at the DB, mirroring Document#claim!: only a row still
+  # pending transitions, so two concurrent accepts (single-vs-single,
+  # single-vs-bulk, bulk-vs-bulk across Puma threads) produce exactly one
+  # winner — the loser raises and its client never merges, which is the
+  # guarantee the whole accept flow's no-duplicate promise rests on. An
+  # in-memory status check would pass in BOTH racing requests.
   def transition!(new_status, by:)
-    raise ActiveRecord::RecordInvalid.new(self), "already #{status}" unless status == "pending"
+    updated = self.class.where(id:, status: "pending")
+                  .update_all(status: new_status, resolved_by: by, updated_at: Time.current)
+    raise ActiveRecord::RecordInvalid.new(self), "already #{status}" if updated.zero?
 
-    update!(status: new_status, resolved_by: by)
+    reload
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   delete "d/:slug", to: "documents#destroy", as: :destroy_document
   post "d/:slug/snapshot", to: "documents#snapshot", as: :document_snapshot
   post "d/:slug/suggestions", to: "suggestions#create", as: :document_suggestions
+  patch "d/:slug/suggestions/accept_all", to: "suggestions#accept_all", as: :accept_all_document_suggestions
 
   patch "suggestions/:id/accept", to: "suggestions#accept", as: :accept_suggestion
   patch "suggestions/:id/reject", to: "suggestions#reject", as: :reject_suggestion

--- a/docs/plans/2026-06-08-001-fix-suggestion-replace-duplication-plan.md
+++ b/docs/plans/2026-06-08-001-fix-suggestion-replace-duplication-plan.md
@@ -1,0 +1,243 @@
+---
+title: "fix: Suggestion replace duplication + fast bulk accept"
+type: fix
+status: active
+date: 2026-06-08
+---
+
+# fix: Suggestion replace duplication + fast bulk accept
+
+## Summary
+
+Accepting agent suggestions that *replace* existing text can duplicate content instead of replacing it, and Accept all is slow (N sequential PATCH round-trips with an Inertia partial reload each). Production doc `J3YVc161mb` now contains its entire talk outline twice: the original 60-minute outline untouched, followed by the accepted 30-minute rewrite appended at the end.
+
+Two deliverables: (1) markdown-aware, block-level suggestion matching so `replaces` actually replaces, and (2) a server-side bulk-accept endpoint so Accept all is one round trip with optimistic card clearing. Plus a one-time repair of the damaged production doc.
+
+---
+
+## Problem Frame
+
+### Bug: duplication on accept (root cause, confirmed)
+
+Production evidence (doc `J3YVc161mb`, all 11 suggestions accepted):
+
+- `plain_markdown` contains the full original outline (60-min, sections 1–10 + Q&A) at lines 0–118, then a complete second outline (30-min) at lines 120–175.
+- The stored suggestion rows quote **markdown source** in `replaces`: e.g. `## Talk outline - Blastoff Ruby, June 12 (\~60 minutes: 45 talk + Q\&A)` and `### 1. Cold open (3 min)` — including heading markers and backslash escapes.
+- The two plain-text suggestions (no markdown syntax in `replaces`) matched and replaced correctly; every markdown-quoting suggestion duplicated.
+
+Code-level mechanism in `app/frontend/editor/suggestions.ts`:
+
+1. `findTextRange` searches the **rendered plain text** of single textblocks (`text.indexOf(search)`). A `replaces` string containing `## `, `**`, or `\~` can never match — markdown syntax does not exist in textContent. Multi-block `replaces` (anything containing a blank line) can also never match, since matching is per-textblock.
+2. `applySuggestion` only performs a replacement when `replaces` matched AND the parsed body is a **single textblock**. In every other case it falls through to the insert-after-anchor path (or doc-end append), which **inserts the new content without deleting the old** — that is the duplication.
+
+So: agents naturally quote the markdown they read from the API; the editor matches against rendered text; the mismatch silently degrades "replace" into "append", and the old content survives.
+
+### Performance: Accept all is slow
+
+`acceptAllSuggestions` (added earlier today, `app/frontend/pages/documents/show.tsx`) loops the per-card flow: one PATCH per suggestion, each awaiting an Inertia partial reload of `suggestions` + `activities`. 11 suggestions ≈ 11 sequential round-trips to the Hetzner server — many seconds of "Accepting…".
+
+### Scope boundary
+
+The seed-claim consumed-without-applying anomaly observed on doc `u3MwGn64VN` (claim burned, no Yjs state persisted, self-healed by stale-claim reclaim) is a **separate latent issue** — different mechanism, no user-visible damage. Out of scope here; recorded under Deferred.
+
+---
+
+## Requirements
+
+- R1: Accepting a suggestion whose `replaces` quotes markdown source (headings, bold, escapes) replaces the matching document content — no duplication. (Bug report: "we have the document twice")
+- R2: Accepting a suggestion whose `replaces` spans multiple blocks replaces the whole matched block range.
+- R3: A suggestion body that parses to multiple blocks still replaces (block-level) when `replaces` matched, instead of degrading to insert-after.
+- R4: Accept all completes in approximately one server round trip, with cards clearing optimistically on click. (Request: "make it server-side or instant optimistic")
+- R5: Per-card accept and reject behavior, provenance marking of merged text, and concurrent-acceptor safety are preserved.
+- R6: Production doc `J3YVc161mb` is repaired: the stale original outline removed, the accepted 30-min outline and the user's edits kept.
+
+---
+
+## Key Technical Decisions
+
+1. **Match by parsed text, not raw string.** Parse `replaces` (and `anchor_text` on the fallback path) through the same Milkdown parser used for the body, then match the document by comparing per-block plain text (with whitespace normalization) against the parsed search blocks, block-sequence-wise. This makes matching agnostic to markdown syntax and escaping — the agent quotes markdown, the parser normalizes both sides to the same plain-text space. Rationale: any string-level normalization (stripping `#`, unescaping) is a losing game of edge cases; the parser is already in context and is the single source of truth for markdown → text.
+2. **Block-level replacement.** When the parsed `replaces` matches a sequence of blocks, replace the entire block range with the entire parsed body (`tr.replaceWith` over node boundaries). Keep the existing inline path (replace inside one paragraph) when both the matched range and the body are single-textblock inline content — it preserves surrounding text in mixed paragraphs.
+3. **Bulk accept is a server endpoint + client-side merge.** `PATCH /d/:slug/suggestions/accept_all` atomically transitions all pending suggestions (`where(status: "pending").update_all`-style, returning the winners), logs **one** activity entry ("accepted N suggestions"), broadcasts once, and returns the accepted suggestions as JSON. The accepting client then applies each body to the CRDT locally in id order — content application must stay client-side because only clients hold a ProseMirror/Milkdown parser; the server has no Yjs content writer. Rationale: one round trip replaces N; the editor merge is local and fast; the existing per-suggestion concurrency story (server confirms the winner before any CRDT insert) carries over wholesale to the batch.
+4. **Optimistic UX.** On click, all pending cards clear optimistically via the bulk PATCH's `router.optimistic`; merges apply on success. A failed request restores the cards (Inertia rolls back optimistic state on error).
+5. **Repair by content surgery, not seed reset.** Doc `J3YVc161mb` has human edits and a comment; resetting Yjs state to the seed would lose them. Repair = remove the stale original-outline block via an agent-grade edit (the same suggestion machinery, now fixed, or direct snapshot surgery via the editor), verified against the heading structure.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+    participant U as User (browser)
+    participant S as Rails server
+    participant E as Editor (CRDT)
+
+    U->>S: PATCH /d/:slug/suggestions/accept_all {by}
+    Note over S: atomic: pending → accepted (winners only)<br/>1 activity entry, 1 broadcast
+    S-->>U: { accepted: [suggestion, ...] }
+    Note over U: cards already cleared optimistically
+    loop each accepted suggestion (id order)
+        U->>E: applySuggestion (parser-aware match → block replace)
+    end
+    E-->>S: Yjs sync + debounced snapshot
+```
+
+Matching pipeline inside `applySuggestion` (directional, not implementation spec):
+
+```text
+parse(replaces) → searchBlocks[]            # plain text per block, via Milkdown parser
+scan doc top-level blocks for a window where
+    normalize(docBlock[i..i+k].text) == normalize(searchBlocks[0..k].text)
+matched?
+  ├─ yes, single inline ↔ single inline → existing inline replace (string offsets)
+  ├─ yes, otherwise → tr.replaceWith(blockRange.from, blockRange.to, parsedBody)
+  └─ no → fall back to anchor_text (same parsed matching) → insert after; else append
+```
+
+---
+
+## Implementation Units
+
+### U1. Markdown-aware matching and block-level replacement
+
+**Goal:** `replaces` that quotes markdown source — single- or multi-block — matches and truly replaces; no silent degrade to append when a body is multi-block.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** none
+
+**Files:**
+- `app/frontend/editor/suggestions.ts` (modify: `applySuggestion`, add parsed-block matching; keep `findTextRange` for plain-text inline cases and other callers — `show.tsx` uses it for comment anchors and margin cards)
+- `script/browser_check.mjs` (test scenarios live in U4)
+
+**Approach:**
+- Add a matcher that takes the parsed `replaces` fragment and walks the doc's top-level block sequence comparing whitespace-normalized textContent per block; returns the doc position range spanning the matched blocks.
+- In `applySuggestion`: try parsed-block matching for `replaces` first. Preserve the existing inline-replace path when the match is a single textblock's inner text and the body is single-textblock (current behavior, good for typo fixes like ids 22/24). Otherwise replace the full block range with the parsed body.
+- Apply the same parsed matching to `anchor_text` on the fallback path so markdown-quoting anchors keep working as insert-after targets.
+- Provenance marking (`addMark` over the inserted range) and `SKIP_PROVENANCE` meta stay exactly as today.
+- Margin card positioning (`findTextRange(anchorOf(s))` in `margin_suggestions.tsx`) currently fails to place cards for markdown-quoting suggestions (they stack at doc top, observed as `top: 0` fallback). Export the parsed matcher so the card-anchoring call sites can use it too — same fix, second consumer.
+
+**Patterns to follow:** `applySuggestion`'s existing parser usage (`ctx.get(parserCtx)`); whitespace normalization mirrors `findTextRange`'s segment-table caution about leaf nodes.
+
+**Test scenarios:**
+- Happy path: suggestion with `replaces: "### Heading (3 min)"` against a doc containing that heading → heading replaced by the body, exactly one occurrence of the new text, zero of the old (Covers R1).
+- Multi-block: `replaces` quoting a heading plus its paragraph (blank-line separated) → both blocks replaced by a multi-block body (Covers R2, R3).
+- Escapes: `replaces` containing `\~` and `\&` (as production data does) → matches the rendered `~`/`&` text (Covers R1).
+- Inline preservation: plain-text `replaces` of a few words inside a paragraph with a single-paragraph body → surrounding sentence text intact (regression guard for ids 22/24 behavior, R5).
+- No match: `replaces` text absent from the doc → body inserted after `anchor_text` block (existing fallback), original doc text untouched and not deleted.
+- Provenance: merged text carries `kind: ai, state: pending` marks for agent authors (R5).
+
+**Verification:** browser check assertions in U4 pass; accepting a markdown-quoting replace suggestion in a live editor leaves exactly one copy of the content.
+
+### U2. Bulk accept endpoint
+
+**Goal:** One PATCH transitions every pending suggestion atomically and returns the winners.
+
+**Requirements:** R4, R5
+
+**Dependencies:** none (parallel with U1)
+
+**Files:**
+- `config/routes.rb` (add `patch "d/:slug/suggestions/accept_all"`)
+- `app/controllers/suggestions_controller.rb` (add `accept_all` action)
+- `app/models/suggestion.rb` (add class method for the atomic batch transition)
+- `test/integration/suggestion_flow_test.rb` (scenarios below)
+
+**Approach:**
+- Model: a class method that, within the document scope, atomically flips `pending → accepted` (single UPDATE with status guard, `resolved_by` stamped) and returns the suggestions that actually transitioned — concurrent per-card accepts that already won are naturally excluded.
+- Controller: finds the document by slug, runs the batch, logs **one** activity entry ("accepted N suggestions"), broadcasts `:suggestions` once via `DocumentMetaChannel`, responds with JSON `{ accepted: [as_props, ...] }` ordered by id. Zero pending → `{ accepted: [] }`, still 200.
+- This is a JSON endpoint (the client needs the authoritative winner list synchronously), not an Inertia redirect — mirror the `postJSON`/CSRF pattern used by `documents#snapshot`.
+
+**Patterns to follow:** `Suggestion.propose!` (single entry point + activity + broadcast), `documents#snapshot` for the JSON-response controller shape, `transition!`'s `resolved_by` semantics.
+
+**Test scenarios:**
+- Happy path: 3 pending suggestions → PATCH accept_all → all accepted, response lists all 3 in id order, one activity row with detail mentioning the count (Covers R4).
+- Atomicity/concurrency: one suggestion already accepted before the call → response lists only the 2 winners; the pre-accepted one is untouched.
+- Empty: no pending suggestions → 200 with empty list, no activity row.
+- Missing doc: unknown slug → 404.
+- `by` param: `resolved_by` stamped with the provided name on every transitioned row.
+
+**Verification:** integration tests green; `bin/rails test` passes.
+
+### U3. Rewire Accept all to the bulk endpoint
+
+**Goal:** One round trip, instant optimistic card clearing, merges applied locally in order.
+
+**Requirements:** R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `app/frontend/pages/documents/show.tsx` (modify `acceptAllSuggestions`; per-card `acceptOne` stays as-is)
+
+**Approach:**
+- Replace the sequential `acceptOne` loop: optimistically clear all pending cards, send one request to `accept_all`, then apply each returned suggestion via `applySuggestion` in response order (each merge re-anchors against the post-merge doc — same semantics as today's loop, minus the network). Refresh `suggestions`/`activities` props once at the end (single partial reload or rely on the broadcast-driven reload).
+- On request failure: restore cards (optimistic rollback) and clear the `acceptingAll` flag.
+- Keep `flashMergedRange` per merge; keep the button's disabled "Accepting…" state (it will now last well under a second).
+
+**Test scenarios:** (behavioral coverage lives in the U4 browser checks — unit-level JS tests are not part of this repo's harness)
+- Covered in U4: one click → all bodies merged, cards cleared, button retires, merges persist across reload.
+- Covered in U4: duplication regression — accept-all over markdown-quoting replace suggestions leaves no duplicated sections.
+
+**Verification:** Accept all on a 10-suggestion doc completes in ~1s locally; browser checks in U4 pass.
+
+### U4. Test coverage: duplication regression + fast bulk accept
+
+**Goal:** Permanent guards against the exact production failure and the slow path.
+
+**Requirements:** R1–R5
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- `script/browser_check.mjs` (modify the existing Accept-all section; add replace-duplication scenarios)
+- `test/integration/suggestion_flow_test.rb` (U2 scenarios)
+
+**Approach:** Extend the existing "Accept all" browser-check section: seed a doc with headed sections, post agent suggestions whose `replaces` quotes markdown source (heading markers + escapes, mirroring the Tuin payloads), accept all, assert each original section text appears exactly once (replaced, not duplicated), assert ordering, assert persistence across reload. Keep the existing button-presence/retire assertions.
+
+**Test scenarios:**
+- Markdown-quoting replace via Accept all → old section text count is 0, new text count is 1, per section (Covers R1, R4).
+- Multi-block replace via per-card accept → same exactly-once assertion (Covers R2 on the single-accept path).
+- Plain-text inline replace still works (ids 22/24 regression guard, R5).
+- Reload → merged state persists, no cards return.
+
+**Verification:** full `script/browser_check.mjs` suite green (modulo the known pre-existing SharePopover dev warning).
+
+### U5. Repair production doc J3YVc161mb
+
+**Goal:** Remove the stale 60-minute outline; keep the accepted 30-minute outline, the user's typo edits, and the open comment.
+
+**Requirements:** R6
+
+**Dependencies:** U1–U4 deployed (the fix must be live before touching the doc, or new accepts could re-damage it)
+
+**Files:** none (operational; uses the live editor/API against production)
+
+**Approach:** After deploy, surgically delete the duplicated original-outline block (lines spanning the old `## Talk outline … (\~60 minutes …)` section through the old `### Q\&A (10-15 min)` section) from the live document — via the now-fixed suggestion machinery (a replace suggestion covering the stale block, accepted in-browser) or equivalent direct edit. Verify the heading structure afterward: exactly one `## Talk outline` heading, the 30-min variant.
+
+**Test scenarios:** Test expectation: none — operational data repair, verified by inspection.
+
+**Verification:** `plain_markdown` for the doc contains exactly one outline; the user's comment remains open; ownership unchanged.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the suggestion matching/replacement fix, bulk accept endpoint and client rewiring, regression coverage, the one-doc production repair.
+
+**Out of scope (true non-goals):**
+- Server-side rendering/merging of suggestion content into Yjs (server has no ProseMirror parser; architecture keeps content application client-side).
+- Reject all (not requested; trivially added later on the same endpoint pattern).
+
+### Deferred to Follow-Up Work
+- Seed-claim burn anomaly (claim consumed without template application, observed on `u3MwGn64VN`): self-heals via stale-claim reclaim, but the first open after a reset shows an empty doc until the next visit. Worth its own investigation.
+- `Suggestion#transition!` single-row race (read-check-write, not atomic compare-and-set). The bulk path in U2 is atomic; aligning the single-row path can follow.
+- Margin cards for unmatched anchors stack at the document top (`top: 0` fallback) — U1's exported matcher fixes placement for markdown anchors, but a visible "anchor not found" treatment is a design question for later.
+
+---
+
+## Risks & Dependencies
+
+- **Behavior change radius:** `applySuggestion` also serves per-card accept and the browser-check agent-loop assertions. Mitigation: preserve the inline path for plain-text cases; run the full browser suite (U4) before merge.
+- **Whitespace normalization too loose/strict:** over-normalizing could match the wrong section (e.g., repeated identical headings). Mitigation: match the longest block sequence, require full-block equality (not substring), and take the first match — same first-match semantics as today's `findTextRange`.
+- **Bulk endpoint exposure:** `accept_all` is unauthenticated like every accept surface in this app (claim model is open by design). It only transitions suggestion status — no content injection beyond what `propose!` already allows.
+- **Production repair is irreversible:** take the doc's current markdown snapshot (already captured in this plan's research) before surgery.

--- a/docs/residual-review-findings/fix-suggestion-replace-duplication.md
+++ b/docs/residual-review-findings/fix-suggestion-replace-duplication.md
@@ -1,0 +1,12 @@
+# Residual Review Findings — fix/suggestion-replace-duplication
+
+Source: ce-code-review run `20260608-090630-e732cef8` (LFG pipeline, 2026-06-08).
+Verdict: Ready with fixes — P1 and six P2 findings applied in-branch (`fix(review): apply review findings`); the three residual actionable findings below were filed to GitHub Issues.
+
+## Residual Review Findings
+
+- **P2** `app/models/suggestion.rb:55` — Cap the accept_all batch size (unbounded N×128KB response inside one SQLite write transaction) — [#21](https://github.com/kieranklaassen/pruf/issues/21)
+- **P2** `app/frontend/editor/suggestions.ts:97` — Block matching should require node-type equality, not just text equality (paragraph text can satisfy a heading quote and be destructively replaced) — [#22](https://github.com/kieranklaassen/pruf/issues/22)
+- **P2** `app/frontend/pages/documents/show.tsx:412` — Gate per-card acceptOne while Accept all is in flight (redundant overlapping request; CAS makes it harmless but noisy) — [#23](https://github.com/kieranklaassen/pruf/issues/23)
+
+Report-only items (owner: human) retained in the review artifact at `/tmp/compound-engineering/ce-code-review/20260608-090630-e732cef8/`: replaceRange-branch test coverage, matcher wrapper indirection, confirm-then-merge orphan window (architectural, pre-existing trade-off), double partial reload (deliberate belt-and-braces), AgentGuide doc notes on `replaces` quoting and bulk-accept events.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -844,52 +844,101 @@ try {
   }
   await q.close()
 
-  // --- Accept all: an agent suggestion batch merges with one click ---
+  // --- Accept all + replace semantics ---
+  // Mirrors the J3YVc161mb double-outline incident: agents quote markdown
+  // SOURCE in `replaces` (heading markers, backslash escapes), and accepted
+  // replacements must actually replace — never leave the old text behind.
   const bulkDoc = await (
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Accept all check',
-        markdown: 'Alpha paragraph here.\n\nBravo paragraph here.\n\nCharlie paragraph here.\n',
+        markdown:
+          '# Bulk doc\n\n## Talk outline (~60 minutes: 45 talk + Q&A)\n\nIntro paragraph stays.\n\n### 1. Cold open (3 min)\n\nOriginal cold open copy.\n\n### 2. Receipts (5 min)\n\nOriginal receipts copy.\n',
       }),
     })
   ).json()
-  const bulkBodies = ['First proposed line.', 'Second proposed line.', 'Third proposed line.']
-  const bulkAnchors = ['Alpha paragraph here.', 'Bravo paragraph here.', 'Charlie paragraph here.']
-  for (let i = 0; i < 3; i += 1) {
-    await fetch(`${BASE}/api/docs/${bulkDoc.slug}/suggestions`, {
+  const bulkSuggest = (payload) =>
+    fetch(`${BASE}/api/docs/${bulkDoc.slug}/suggestions`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'Scout', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ body: bulkBodies[i], intent: 'bulk', anchor_text: bulkAnchors[i] }),
+      body: JSON.stringify(payload),
     })
-  }
+  // (a) heading quoted as markdown source with escapes — the exact
+  //     production payload shape that used to silently append
+  await bulkSuggest({
+    body: '## Talk outline (30 min talk + Q\\&A separate)',
+    intent: 'retime',
+    replaces: '## Talk outline (\\~60 minutes: 45 talk + Q\\&A)',
+  })
+  // (b) multi-block replaces (heading + paragraph) with a multi-block body
+  await bulkSuggest({
+    body: '### 1. Cold open (2 min)\n\nTighter cold open copy.',
+    intent: 'tighten',
+    replaces: '### 1. Cold open (3 min)\n\nOriginal cold open copy.',
+  })
+  // (c) plain-text inline replace — the path that always worked
+  await bulkSuggest({
+    body: 'Sharper receipts copy.',
+    intent: 'sharpen',
+    replaces: 'Original receipts copy.',
+  })
   const bulk = await makePage('a')
   await bulk.goto(`${BASE}/d/${bulkDoc.slug}`)
   await bulk.waitForSelector('.doc-status--live', { timeout: 15000 })
   await bulk.waitForTimeout(1000)
-  const bulkBtnText = (await bulk.locator('.accept-all-button').textContent().catch(() => null))?.trim()
-  if (bulkBtnText === 'Accept all 3') ok('Accept all button appears in the header with the count')
-  else fail(`Accept all button wrong or missing: "${bulkBtnText}"`)
-  await bulk.locator('.accept-all-button').click()
-  // Cards clear optimistically per accept; the merged text lands on each
-  // PATCH's success — wait for BOTH before judging.
-  const bulkMerged = await bulk
+
+  // Per-card accept of the multi-block suggestion first — exercises the
+  // single-accept path and accept_all's already-resolved exclusion.
+  const multiBlockCard = bulk.locator('.margin-card', { hasText: 'tighten' })
+  await multiBlockCard.locator('.btn-accept').click()
+  const perCardReplaced = await bulk
     .waitForFunction(
-      (bodies) => {
+      () => {
         const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
         return (
-          document.querySelectorAll('.margin-card').length === 0 &&
-          bodies.every((b) => text.includes(b))
+          text.includes('Tighter cold open copy.') &&
+          !text.includes('Original cold open copy.') &&
+          text.includes('Cold open (2 min)') &&
+          !text.includes('Cold open (3 min)')
         )
       },
-      bulkBodies,
-      { timeout: 15000 },
+      undefined,
+      { timeout: 10000 },
     )
     .then(() => true)
     .catch(() => false)
-  if (bulkMerged) ok('Accept all merged every suggestion and cleared the cards')
-  else fail('Accept all left cards or unmerged text behind')
+  if (perCardReplaced) ok('per-card accept replaced a multi-block markdown-quoted section exactly')
+  else fail('multi-block replace left old text behind or did not merge')
+
+  const bulkBtnText = (await bulk.locator('.accept-all-button').textContent().catch(() => null))?.trim()
+  if (bulkBtnText === 'Accept all 2') ok('Accept all button shows the remaining pending count')
+  else fail(`Accept all button wrong or missing: "${bulkBtnText}"`)
+  await bulk.locator('.accept-all-button').click()
+  const assertBulkDocState = () => {
+    const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
+    const once = (s) => text.split(s).length === 2
+    const never = (s) => !text.includes(s)
+    return (
+      document.querySelectorAll('.margin-card').length === 0 &&
+      once('Talk outline (30 min talk + Q&A separate)') &&
+      never('60 minutes') &&
+      once('Sharper receipts copy.') &&
+      never('Original receipts copy.') &&
+      once('Intro paragraph stays.') &&
+      once('Tighter cold open copy.')
+    )
+  }
+  const bulkMerged = await bulk
+    .waitForFunction(assertBulkDocState, undefined, { timeout: 15000 })
+    .then(() => true)
+    .catch(() => false)
+  if (bulkMerged) ok('Accept all replaced every quoted section exactly once (no duplication)')
+  else {
+    const debugText = await bulk.locator('.milkdown .ProseMirror').innerText()
+    fail(`Accept all duplicated or dropped content:\n${debugText.slice(0, 400)}`)
+  }
   if ((await bulk.locator('.accept-all-button').count()) === 0) {
     ok('Accept all button retired itself once nothing is pending')
   } else {
@@ -899,13 +948,12 @@ try {
   await bulk.reload()
   await bulk.waitForSelector('.doc-status--live', { timeout: 15000 })
   await bulk.waitForTimeout(800)
-  const bulkAfter = await bulk.locator('.milkdown .ProseMirror').innerText()
-  const bulkCardsBack = await bulk.locator('.margin-card').count()
-  if (bulkBodies.every((b) => bulkAfter.includes(b)) && bulkCardsBack === 0) {
-    ok('bulk-accepted suggestions persisted across reload')
-  } else {
-    fail(`bulk accept did not persist: cards=${bulkCardsBack}`)
-  }
+  const bulkPersisted = await bulk
+    .waitForFunction(assertBulkDocState, undefined, { timeout: 10000 })
+    .then(() => true)
+    .catch(() => false)
+  if (bulkPersisted) ok('bulk-accepted replacements persisted across reload')
+  else fail('bulk accept state drifted after reload')
   await bulk.close()
 
   for (const [label, errs] of Object.entries(errors)) {

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -152,4 +152,61 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     assert_equal "accepted", suggestion.reload.status
     assert_includes @document.activities.last.detail, "Quiet Falcon"
   end
+
+  # --- Bulk accept (Accept all) ---
+
+  test "accept_all transitions every pending suggestion and returns winners in id order" do
+    second = @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "b")
+    third = @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "c")
+
+    assert_difference -> { @document.activities.count }, 1 do
+      patch accept_all_document_suggestions_path(@document.slug),
+            params: { by: "Quiet Falcon" }, as: :json
+    end
+
+    assert_response :success
+    accepted = response.parsed_body["accepted"]
+    assert_equal [ @suggestion.id, second.id, third.id ], accepted.map { |s| s["id"] }
+    assert_equal %w[accepted accepted accepted],
+                 [ @suggestion, second, third ].map { |s| s.reload.status }
+    assert_equal "Quiet Falcon", @suggestion.reload.resolved_by
+    assert_includes @document.activities.last.detail, "3 suggestions"
+  end
+
+  test "accept_all excludes suggestions already resolved before the call" do
+    second = @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "b")
+    @suggestion.accept!(by: "Earlier Window")
+
+    patch accept_all_document_suggestions_path(@document.slug), as: :json
+
+    accepted = response.parsed_body["accepted"]
+    assert_equal [ second.id ], accepted.map { |s| s["id"] }
+    assert_equal "Earlier Window", @suggestion.reload.resolved_by
+  end
+
+  test "accept_all with nothing pending returns an empty list and logs no activity" do
+    @suggestion.reject!
+
+    assert_no_difference -> { @document.activities.count } do
+      patch accept_all_document_suggestions_path(@document.slug), as: :json
+    end
+
+    assert_response :success
+    assert_empty response.parsed_body["accepted"]
+  end
+
+  test "accept_all broadcasts one suggestions event for the whole batch" do
+    @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "b")
+
+    # one :activities event from Activity.log!, one :suggestions event —
+    # regardless of how many suggestions transitioned
+    assert_broadcasts(DocumentMetaChannel.broadcasting_for(@document), 2) do
+      patch accept_all_document_suggestions_path(@document.slug), as: :json
+    end
+  end
+
+  test "accept_all on an unknown doc returns 404" do
+    patch accept_all_document_suggestions_path("gone-doc"), as: :json
+    assert_response :not_found
+  end
 end

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -170,7 +170,28 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     assert_equal %w[accepted accepted accepted],
                  [ @suggestion, second, third ].map { |s| s.reload.status }
     assert_equal "Quiet Falcon", @suggestion.reload.resolved_by
+    assert_equal "Quiet Falcon", @document.activities.last.actor_name
     assert_includes @document.activities.last.detail, "3 suggestions"
+  end
+
+  test "accept_all without a name uses one fallback for resolver and actor alike" do
+    patch accept_all_document_suggestions_path(@document.slug), as: :json
+
+    assert_equal "Someone", @suggestion.reload.resolved_by
+    assert_equal "Someone", @document.activities.last.actor_name
+  end
+
+  test "transition! is compare-and-set: a stale in-memory record cannot double-accept" do
+    fresh = Suggestion.find(@suggestion.id)
+    stale = Suggestion.find(@suggestion.id)
+
+    fresh.accept!(by: "First Window")
+    # The stale copy still believes it is pending — the DB must be the arbiter,
+    # or both windows would merge the same body into the shared document.
+    assert_raises(ActiveRecord::RecordInvalid) { stale.accept!(by: "Second Window") }
+
+    assert_equal "First Window", @suggestion.reload.resolved_by
+    assert_equal "accepted", @suggestion.status
   end
 
   test "accept_all excludes suggestions already resolved before the call" do
@@ -205,8 +226,10 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "accept_all on an unknown doc returns 404" do
+  test "accept_all on an unknown doc returns a JSON 404, not an HTML error page" do
     patch accept_all_document_suggestions_path("gone-doc"), as: :json
     assert_response :not_found
+    assert_includes response.content_type, "application/json"
+    assert_equal "No document with that slug.", response.parsed_body["error"]
   end
 end


### PR DESCRIPTION
## What was broken

Accepting an agent suggestion that *replaces* text could duplicate the document instead. Production doc `J3YVc161mb` ended up with its entire talk outline twice: the original 60-minute version untouched, followed by the accepted 30-minute rewrite appended at the end.

The cause: agents quote the **markdown source** they read from the API in `replaces` (`## Talk outline (\~60 minutes...)`, `### 1. Cold open (3 min)`), but the editor matched against **rendered plain text** within single textblocks — `## ` and `\~` never appear there, multi-block quotes can never match at all. Every failed match silently degraded "replace" into "insert-after," leaving the old content in place. (The two plain-text suggestions on that doc replaced correctly, confirming the mechanism.)

Accept all was also slow: N suggestions = N sequential PATCH round-trips, each awaiting an Inertia partial reload — many seconds of "Accepting…" for an 11-suggestion batch.

## What this changes

- **Matching is now parser-aware.** A quote is tried as a raw string first (typo-fix fast path, unchanged behavior), then parsed through the same Milkdown parser as the body and matched block-sequence-wise by rendered text. Heading markers, escapes, and multi-block quotes all match; matched block windows are **truly replaced** (`tr.replaceWith` over the window) instead of inserted after. Margin cards and the mobile tap hit-test anchor with the same matcher, so markdown-quoting suggestions no longer stack at the document top.
- **Accept all is one round trip.** New `PATCH /d/:slug/suggestions/accept_all` flips the batch atomically (one transaction, one activity entry, one broadcast) and returns the winners; the client merges each body locally in id order — same semantics as clicking the cards one by one, minus the per-card network wait. Cards hide optimistically on click and stay hidden until fresh props land.
- **Accepts are concurrency-safe at the DB.** `transition!` is now a compare-and-set (`WHERE status = 'pending'`), so two windows racing an accept — single vs single, single vs bulk, bulk vs bulk — produce exactly one winner. The loser 422s and never merges. Review caught that the previous in-memory guard would let both windows win and double-merge, recreating the duplication bug by another path.

## Review hardening (applied in-branch)

JSON 404 contract on the bulk endpoint, per-merge failure isolation (one bad suggestion no longer strands the batch), live editor ref across awaits, unified actor attribution, and memoized quote parsing so the margin measure pass stops re-parsing markdown per keystroke. Residual P2s filed as #21, #22, #23 (see `docs/residual-review-findings/`).

## Verification

- 177 Rails tests green (new: CAS stale-record test, bulk winners/exclusion/empty/404-shape/broadcast tests)
- Full Playwright suite green, including new exactly-once regression checks mirroring the production payloads (markdown-escaped heading replace, multi-block replace via per-card accept, plain inline replace, reload persistence)
- agent-browser spot check: two markdown-quoting suggestions, one Accept-all click → both sections replaced exactly once in the editor and the API markdown round-trip

## After merge

Deploy, then repair `J3YVc161mb` (plan U5): delete the stale duplicated outline; the clean original is preserved in `seed_markdown`, the user's typo edits and open comment stay.

Plan: `docs/plans/2026-06-08-001-fix-suggestion-replace-duplication-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
