### PR TITLE
Fix mobile agent cursor overflow

### DIFF
--- a/app/frontend/editor/agent_cursors.ts
+++ b/app/frontend/editor/agent_cursors.ts
@@ -15,6 +15,77 @@ export const agentCursorsCtx = $ctx<{ list: AgentCursor[] }, 'agentCursors'>(
 )
 
 const agentCursorKey = new PluginKey('AGENT_CURSORS')
+const cursorCleanup = new WeakMap<Node, () => void>()
+const cursorLabels = new Set<HTMLElement>()
+let cursorClampFrame: number | null = null
+let cursorResizeObserver: ResizeObserver | null = null
+let cursorIntersectionObserver: IntersectionObserver | null = null
+let cursorMutationObserver: MutationObserver | null = null
+
+const clampCursorLabels = () => {
+  cursorClampFrame = null
+  cursorLabels.forEach((label) => {
+    const gutter = 8
+    label.style.removeProperty('--agent-cursor-shift')
+    const rect = label.getBoundingClientRect()
+    let shift = 0
+    if (rect.right > window.innerWidth - gutter) shift = window.innerWidth - gutter - rect.right
+    if (rect.left + shift < gutter) shift += gutter - (rect.left + shift)
+    label.style.setProperty('--agent-cursor-shift', `${Math.round(shift)}px`)
+  })
+}
+
+const scheduleCursorClamp = () => {
+  if (cursorClampFrame !== null) return
+  cursorClampFrame = requestAnimationFrame(clampCursorLabels)
+}
+
+const startCursorClampManager = () => {
+  if (cursorResizeObserver) return
+  cursorResizeObserver = new ResizeObserver(scheduleCursorClamp)
+  cursorIntersectionObserver = new IntersectionObserver(scheduleCursorClamp, {
+    rootMargin: '0px -8px',
+    threshold: 1,
+  })
+  cursorMutationObserver = new MutationObserver(scheduleCursorClamp)
+  cursorMutationObserver.observe(document.getElementById('app') ?? document.body, {
+    attributes: true,
+    subtree: true,
+    attributeFilter: ['class'],
+  })
+  window.addEventListener('resize', scheduleCursorClamp)
+  document.addEventListener('scroll', scheduleCursorClamp, { capture: true, passive: true })
+  document.addEventListener('transitionend', scheduleCursorClamp, true)
+}
+
+const stopCursorClampManager = () => {
+  if (cursorClampFrame !== null) cancelAnimationFrame(cursorClampFrame)
+  cursorClampFrame = null
+  cursorResizeObserver?.disconnect()
+  cursorIntersectionObserver?.disconnect()
+  cursorMutationObserver?.disconnect()
+  cursorResizeObserver = null
+  cursorIntersectionObserver = null
+  cursorMutationObserver = null
+  window.removeEventListener('resize', scheduleCursorClamp)
+  document.removeEventListener('scroll', scheduleCursorClamp, true)
+  document.removeEventListener('transitionend', scheduleCursorClamp, true)
+}
+
+const registerCursorLabel = (label: HTMLElement) => {
+  startCursorClampManager()
+  cursorLabels.add(label)
+  cursorResizeObserver?.observe(label)
+  cursorIntersectionObserver?.observe(label)
+  scheduleCursorClamp()
+}
+
+const unregisterCursorLabel = (label: HTMLElement) => {
+  if (!cursorLabels.delete(label)) return
+  cursorResizeObserver?.unobserve(label)
+  cursorIntersectionObserver?.unobserve(label)
+  if (cursorLabels.size === 0) stopCursorClampManager()
+}
 
 const buildCursorDOM = (agent: AgentCursor): HTMLElement => {
   const cursor = document.createElement('span')
@@ -23,6 +94,17 @@ const buildCursorDOM = (agent: AgentCursor): HTMLElement => {
   label.className = 'agent-cursor-label'
   label.textContent = `✦ ${agent.name}`
   cursor.appendChild(label)
+
+  let destroyed = false
+  const setupFrame = requestAnimationFrame(() => {
+    if (!destroyed) registerCursorLabel(label)
+  })
+  cursorCleanup.set(cursor, () => {
+    destroyed = true
+    cancelAnimationFrame(setupFrame)
+    unregisterCursorLabel(label)
+  })
+
   return cursor
 }
 
@@ -45,7 +127,11 @@ const agentCursorProse = $prose((ctx) => {
           const pos = range ? range.to : Math.max(0, state.doc.content.size - 1)
           return Decoration.widget(pos, () => buildCursorDOM(agent), {
             side: 1,
-            key: `agent-${agent.name}`,
+            key: `agent-${agent.name}-${pos}`,
+            destroy: (node) => {
+              cursorCleanup.get(node)?.()
+              cursorCleanup.delete(node)
+            },
           })
         })
         return DecorationSet.create(state.doc, decorations)

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2053,6 +2053,10 @@ a:focus-visible {
   background: var(--prov-pending-line);
   color: #fff;
   white-space: nowrap;
+  max-width: calc(100vw - 1rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  translate: var(--agent-cursor-shift, 0) 0;
   user-select: none;
   box-shadow: 0 0 0 2px var(--surface), 0 2px 6px rgb(0 0 0 / 0.12);
   animation: card-in 200ms ease;

--- a/docs/dogfood-reports/2026-06-08-feat-agent-rich-html-api-dogfood.md
+++ b/docs/dogfood-reports/2026-06-08-feat-agent-rich-html-api-dogfood.md
@@ -74,12 +74,19 @@ flowchart TD
 | 7 | Review | Create and resolve a comment; create and accept an HTML replacement suggestion | Pass | - | - | - |
 | 8 | Safety | Reject direct uploads, missing identity, malformed data, oversized bodies, and burst traffic | Pass | - | - | - |
 | 9 | Normalization | Remove scripts, remote images, event handlers, classes, and unsupported CSS with warning | Pass | - | - | - |
-| 10 | Responsive | Desktop and 390px mobile layouts render without overflow or console errors | Pass | - | - | - |
+| 10 | Responsive | Desktop and 390px mobile layouts render without overflow or console errors | Fixed | A long live-agent cursor label added 35px of horizontal overflow on the production document | Clamp cursor labels to viewport gutters, truncate oversized names, and cover the case in the browser smoke test | Hotfix |
 | 11 | Regression | Landing page and Markdown creation remain usable after uploader replacement | Pass | - | - | - |
 
 ## What Was Fixed
 
-None. The review hardening held through the full browser matrix without an additional code fix.
+- **Mobile agent cursor overflow:** Production verification found that a long
+  live-agent name could extend beyond a 390px viewport even though the rich
+  document content and images were responsive. Cursor labels now cap their
+  width, translate back inside 8px viewport gutters after editor resize, scroll,
+  or cursor movement, and remove their observers and listeners when ProseMirror
+  destroys the widget. The browser smoke test creates an intentionally oversized
+  agent name, moves it between document positions, toggles the side-panel
+  layout, and asserts both the label bounds and page scroll width.
 
 ## Console Errors
 
@@ -108,7 +115,9 @@ None.
 
 The matrix is green. A substantial HTML research document rendered three
 production-scale figures and one browser-pasted image, persisted browser edits,
-accepted an agent HTML replacement, resolved an anchored comment, survived
-reload, and fit a 390px viewport without overflow. Invalid uploads, disabled
-direct uploads, normalization, and throttling returned the documented errors.
-The landing page and Markdown creation/edit/reload journey also remained green.
+accepted an agent HTML replacement, resolved an anchored comment, and survived
+reload. Production testing exposed and fixed a mobile overflow caused by a long
+live-agent cursor label; the final 390px regression now keeps the label and page
+inside the viewport. Invalid uploads, disabled direct uploads, normalization,
+and throttling returned the documented errors. The landing page and Markdown
+creation/edit/reload journey also remained green.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -391,6 +391,96 @@ try {
   ok('share popover shows the agent-active signal')
   await a.locator('.agent-cursor-label', { hasText: 'Scout' }).first().waitFor({ timeout: 5000 })
   ok('agent pseudo-cursor rendered at its work location')
+  const overflowAgentName = 'Extremely Long Production Review Agent Name For Mobile Overflow'
+  const overflowAgentHeaders = {
+    'X-Agent-Name': overflowAgentName,
+    'Content-Type': 'application/json',
+  }
+  await fetch(`${api}/presence`, {
+    method: 'POST',
+    headers: overflowAgentHeaders,
+    body: JSON.stringify({ status: 'active', location: 'provenance' }),
+  })
+  await a.locator('.agent-cursor-label', { hasText: overflowAgentName }).first().waitFor({ timeout: 5000 })
+  await a.setViewportSize({ width: 390, height: 844 })
+  await a
+    .waitForFunction(
+      (agentName) => {
+        const label = Array.from(document.querySelectorAll('.agent-cursor-label')).find((el) =>
+          el.textContent?.includes(agentName),
+        )
+        if (!label) return false
+        const rect = label.getBoundingClientRect()
+        return rect.left >= 8 && rect.right <= 382 && document.documentElement.scrollWidth <= 390
+      },
+      overflowAgentName,
+      { timeout: 5000 },
+    )
+    .catch(() => null)
+  const cursorBox = await a.locator('.agent-cursor-label', { hasText: overflowAgentName }).first().boundingBox()
+  const pageWidth = await a.evaluate(() => document.documentElement.scrollWidth)
+  if (cursorBox && cursorBox.x >= 8 && cursorBox.x + cursorBox.width <= 382 && pageWidth <= 390) {
+    ok('agent pseudo-cursor label stays inside the mobile viewport')
+  } else {
+    fail(`agent pseudo-cursor label escapes mobile viewport: box=${JSON.stringify(cursorBox)} pageWidth=${pageWidth}`)
+  }
+  const cursorMoveAnchor = await a.locator('.milkdown .ProseMirror h1').first().innerText()
+  await fetch(`${api}/presence`, {
+    method: 'POST',
+    headers: overflowAgentHeaders,
+    body: JSON.stringify({ status: 'active', location: cursorMoveAnchor }),
+  })
+  await a
+    .waitForFunction(
+      (agentName) => {
+        const label = Array.from(document.querySelectorAll('.agent-cursor-label')).find((el) =>
+          el.textContent?.includes(agentName),
+        )
+        if (!label || !label.closest('h1')) return false
+        const rect = label.getBoundingClientRect()
+        return rect.left >= 8 && rect.right <= 382 && document.documentElement.scrollWidth <= 390
+      },
+      overflowAgentName,
+      { timeout: 5000 },
+    )
+  ok('agent pseudo-cursor stays clamped after moving without a viewport resize')
+  await a.setViewportSize({ width: 1280, height: 900 })
+  const panelWasHidden = await a.locator('.doc-page').evaluate((page) => page.classList.contains('is-panel-hidden'))
+  await a.keyboard.press('Meta+\\')
+  await a.waitForFunction(
+    (wasHidden) => document.querySelector('.doc-page')?.classList.contains('is-panel-hidden') !== wasHidden,
+    panelWasHidden,
+    { timeout: 5000 },
+  )
+  await a.waitForTimeout(250)
+  const shiftedCursorBox = await a
+    .locator('.agent-cursor-label', { hasText: overflowAgentName })
+    .first()
+    .boundingBox()
+  const shiftedPageWidth = await a.evaluate(() => document.documentElement.scrollWidth)
+  if (
+    shiftedCursorBox &&
+    shiftedCursorBox.x >= 8 &&
+    shiftedCursorBox.x + shiftedCursorBox.width <= 1272 &&
+    shiftedPageWidth <= 1280
+  ) {
+    ok('agent pseudo-cursor stays clamped after the side panel changes layout')
+  } else {
+    fail(
+      `agent pseudo-cursor escaped after panel layout: box=${JSON.stringify(shiftedCursorBox)} pageWidth=${shiftedPageWidth}`,
+    )
+  }
+  await a.keyboard.press('Meta+\\')
+  await a.waitForFunction(
+    (wasHidden) => document.querySelector('.doc-page')?.classList.contains('is-panel-hidden') === wasHidden,
+    panelWasHidden,
+    { timeout: 5000 },
+  )
+  await fetch(`${api}/presence`, {
+    method: 'POST',
+    headers: overflowAgentHeaders,
+    body: JSON.stringify({ status: 'done' }),
+  })
 
   const suggestRes = await fetch(`${api}/suggestions`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- clamp long live-agent cursor labels inside viewport gutters
- centralize layout, scroll, resize, and lifecycle handling for all cursor labels
- add browser regressions for mobile width, cursor movement, and side-panel layout changes
- update the rich HTML dogfood report with the production finding

## Verification
- `npm run check`
- `bin/rails test` (232 runs, 905 assertions)
- `bin/rubocop`
- `bin/rails zeitwerk:check`
- `bin/brakeman --no-pager`
- `bundle exec bundler-audit check --update`
- `BASE_URL=http://localhost:3100 node script/browser_check.mjs`

## Context
Production verification of PR #26 found 35px of horizontal overflow at a 390px viewport when a long agent presence label was rendered. The rich HTML document and images themselves were responsive.