### PR TITLE
feat(editor): add inline Excalidraw sketches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Inspired by [Proof](https://proofeditor.ai) from Dan Shipper.
 - Human and AI authorship provenance
 - Read, edit, comment, and suggest modes
 - Reviewable suggestions, anchored comments, and task checkboxes
+- Inline Excalidraw sketches with touch, Apple Pencil, and SVG export
 - Agent presence, activity, and a discoverable HTTP API
 - Local-first Yjs state synchronized through Action Cable
 

--- a/app/frontend/editor/document_format.ts
+++ b/app/frontend/editor/document_format.ts
@@ -6,6 +6,7 @@ import {
   type Node,
   type Schema,
 } from '@milkdown/kit/prose/model'
+import { normalizeSketchData } from './sketch/scene'
 
 export type DocumentFormat = 'markdown' | 'html'
 export type HtmlTrust = 'external' | 'snapshot'
@@ -43,6 +44,8 @@ const ALLOWED_TAGS = [
   'td',
   'span',
   'ins',
+  'figure',
+  'figcaption',
 ]
 
 const ALLOWED_ATTR = [
@@ -67,6 +70,11 @@ const ALLOWED_ATTR = [
   'data-author',
   'data-state',
   'data-suggestion-id',
+  'data-thinkroom-sketch',
+  'data-sketch-id',
+  'data-scene',
+  'data-description',
+  'data-format-version',
 ]
 
 const ACTIVE_STORAGE_PATH =
@@ -77,7 +85,16 @@ const PROVENANCE_STATES = new Set(['verbatim', 'pending', 'reviewed', 'endorsed'
 const MAX_METADATA_LENGTH = 255
 const PROVENANCE_ATTRS = ['data-provenance', 'data-kind', 'data-author', 'data-state']
 const SUGGESTION_ATTRS = ['data-suggestion-id', 'data-author']
-const THINKROOM_ATTRS = Array.from(new Set([...PROVENANCE_ATTRS, ...SUGGESTION_ATTRS]))
+const SKETCH_ATTRS = [
+  'data-thinkroom-sketch',
+  'data-sketch-id',
+  'data-scene',
+  'data-description',
+  'data-format-version',
+]
+const THINKROOM_ATTRS = Array.from(
+  new Set([...PROVENANCE_ATTRS, ...SUGGESTION_ATTRS, ...SKETCH_ATTRS]),
+)
 
 const removeAttrs = (element: Element, attrs: string[]) => {
   attrs.forEach((attr) => element.removeAttribute(attr))
@@ -137,6 +154,22 @@ const sanitizeMetadata = (element: HTMLElement, trust: HtmlTrust) => {
   if (validSuggestion) {
     element.setAttribute('data-suggestion-id', suggestionId)
     element.setAttribute('data-author', author)
+  }
+
+  if (element.tagName === 'FIGURE' && metadata['data-thinkroom-sketch'] !== null) {
+    try {
+      const validSketch = normalizeSketchData({
+        id: metadata['data-sketch-id'],
+        formatVersion: Number(metadata['data-format-version']),
+        description: metadata['data-description'],
+        scene: JSON.parse(metadata['data-scene'] ?? ''),
+      })
+      if (validSketch) {
+        for (const attr of SKETCH_ATTRS) element.setAttribute(attr, metadata[attr] ?? '')
+      }
+    } catch {
+      // Invalid trusted metadata stays stripped.
+    }
   }
 }
 

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import * as Y from 'yjs'
 import type { Ctx } from '@milkdown/kit/ctx'
 import {
@@ -42,12 +42,21 @@ import {
   type ProvenanceSpan,
 } from './provenance'
 import { frontmatter } from './frontmatter'
+import {
+  attrsFromSketchData,
+  sketchControlsCtx,
+  sketchNodeViewPlugins,
+  sketchSchemaPlugins,
+  type SketchData,
+} from './sketch'
+import { SketchModal } from './sketch/sketch_modal'
 import { suggestChangesMarks } from './suggest_changes'
 import { suggestState, suggestDispatch } from './suggest_changes/intercept'
 import { suggestGuard } from './suggest_changes/normalize'
 import {
   enableSuggestChanges,
   disableSuggestChanges,
+  suggestChangesKey,
 } from '@handlewithcare/prosemirror-suggest-changes'
 import {
   alignCenterIcon,
@@ -74,6 +83,7 @@ export interface EditorHandle {
   editor: Editor
   ydoc: Y.Doc
   provider: CableProvider
+  openSketch: () => void
 }
 
 export type ConnectionStatus = 'connecting' | 'live'
@@ -324,6 +334,7 @@ function CollabEditor({
   onSelection,
   onTitleChange,
 }: EditorProps) {
+  const [sketchDraft, setSketchDraft] = useState<SketchData | null | undefined>(undefined)
   const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection, onTitleChange })
   callbacksRef.current = { onReady, onStatus, onSpans, onSelection, onTitleChange }
   // Ref so the editable() closure always reads the live value; the effect
@@ -344,6 +355,10 @@ function CollabEditor({
         .config((ctx) => {
           ctx.set(rootCtx, root)
           ctx.set(provenanceIdentityCtx.key, { name: identity.name })
+          ctx.set(sketchControlsCtx.key, {
+            edit: (data) => setSketchDraft(data),
+            enabled: () => editableRef.current && !suggestingRef.current,
+          })
           // Read-only modes gate USER input only — ProseMirror still accepts
           // programmatic transactions (Yjs sync, seeding, suggestion accept).
           // dispatchTransaction is the suggest-changes wrapper: a pass-through
@@ -409,6 +424,8 @@ function CollabEditor({
         .use(upload)
         .use(provenance)
         .use(frontmatter)
+        .use(sketchSchemaPlugins)
+        .use(sketchNodeViewPlugins)
         .use(suggestChangesMarks)
         // Order matters: provenanceWriter (inside provenance) runs its
         // appendTransaction before suggestGuard's — the guard observes
@@ -525,7 +542,7 @@ function CollabEditor({
         if (title) callbacksRef.current.onTitleChange?.(title)
       })
 
-      const handle = { editor, ydoc, provider }
+      const handle = { editor, ydoc, provider, openSketch: () => setSketchDraft(null) }
       startedRef.current = true
       // Seed/initial sync ran with suggesting off; apply a pre-stored
       // suggest mode only now that the document content is settled.
@@ -604,7 +621,84 @@ function CollabEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [suggesting, loading])
 
-  return <Milkdown />
+  const saveSketch = (data: SketchData) => {
+    if (!editableRef.current || suggestingRef.current) return
+    const editor = get()
+    if (!editor) return
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const type = view.state.schema.nodes.thinkroomSketch
+      if (!type) return
+
+      let existingPos: number | null = null
+      view.state.doc.descendants((node, pos) => {
+        if (node.type === type && node.attrs.id === data.id) {
+          existingPos = pos
+          return false
+        }
+        return existingPos === null
+      })
+
+      const attrs = attrsFromSketchData(data)
+      const tr =
+        existingPos === null
+          ? view.state.tr.replaceSelectionWith(type.create(attrs)).scrollIntoView()
+          : view.state.tr.setNodeMarkup(existingPos, type, attrs)
+      tr.setMeta(SKIP_PROVENANCE, true)
+      tr.setMeta(suggestChangesKey, { skip: true })
+      view.dispatch(tr)
+
+      const session = sessions.get(slug)
+      if (session) void session.provider.persistCurrentState(buildSnapshotPayload(ctx, session.ydoc, contentFormat))
+    })
+    setSketchDraft(undefined)
+  }
+
+  const deleteSketch = (id: string) => {
+    if (!editableRef.current || suggestingRef.current) return
+    const editor = get()
+    if (!editor) return
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const type = view.state.schema.nodes.thinkroomSketch
+      if (!type) return
+
+      let targetPos = -1
+      let targetSize = 0
+      view.state.doc.descendants((node, pos) => {
+        if (node.type === type && node.attrs.id === id) {
+          targetPos = pos
+          targetSize = node.nodeSize
+          return false
+        }
+        return targetPos < 0
+      })
+      if (targetPos < 0) return
+
+      const tr = view.state.tr.delete(targetPos, targetPos + targetSize).scrollIntoView()
+      tr.setMeta(SKIP_PROVENANCE, true)
+      tr.setMeta(suggestChangesKey, { skip: true })
+      view.dispatch(tr)
+
+      const session = sessions.get(slug)
+      if (session) void session.provider.persistCurrentState(buildSnapshotPayload(ctx, session.ydoc, contentFormat))
+    })
+    setSketchDraft(undefined)
+  }
+
+  return (
+    <>
+      <Milkdown />
+      {sketchDraft !== undefined && (
+        <SketchModal
+          initialData={sketchDraft}
+          onCancel={() => setSketchDraft(undefined)}
+          onDelete={sketchDraft ? () => deleteSketch(sketchDraft.id) : undefined}
+          onSave={saveSketch}
+        />
+      )}
+    </>
+  )
 }
 
 export function DocumentEditor(props: EditorProps) {

--- a/app/frontend/editor/sketch/excalidraw_canvas.tsx
+++ b/app/frontend/editor/sketch/excalidraw_canvas.tsx
@@ -1,0 +1,48 @@
+import { Excalidraw } from '@excalidraw/excalidraw'
+import '@excalidraw/excalidraw/index.css'
+import { memo, useCallback, useMemo } from 'react'
+import type { SketchScene } from './scene'
+
+interface ExcalidrawCanvasProps {
+  scene: SketchScene
+  onSceneChange: (scene: unknown) => void
+}
+
+const UI_OPTIONS = {
+  canvasActions: {
+    loadScene: false,
+    saveToActiveFile: false,
+    export: false,
+    saveAsImage: false,
+    toggleTheme: false,
+  },
+  tools: { image: false },
+} as const
+
+function ExcalidrawCanvas({ scene, onSceneChange }: ExcalidrawCanvasProps) {
+  const initialData = useMemo(
+    () => ({ elements: scene.elements, appState: scene.appState, files: {} }),
+    [scene],
+  )
+  const handleChange = useCallback(
+    (elements: Parameters<NonNullable<React.ComponentProps<typeof Excalidraw>['onChange']>>[0],
+      appState: Parameters<NonNullable<React.ComponentProps<typeof Excalidraw>['onChange']>>[1],
+      files: Parameters<NonNullable<React.ComponentProps<typeof Excalidraw>['onChange']>>[2]) => {
+      onSceneChange({ type: 'excalidraw', version: 2, elements, appState, files })
+    },
+    [onSceneChange],
+  )
+  return (
+    <Excalidraw
+      initialData={initialData as never}
+      onChange={handleChange}
+      UIOptions={UI_OPTIONS}
+      aiEnabled={false}
+      autoFocus
+      handleKeyboardGlobally={false}
+      validateEmbeddable={false}
+    />
+  )
+}
+
+export default memo(ExcalidrawCanvas)

--- a/app/frontend/editor/sketch/export.ts
+++ b/app/frontend/editor/sketch/export.ts
@@ -1,0 +1,38 @@
+import type { SketchScene } from './scene'
+
+export async function sketchToSvg(scene: SketchScene): Promise<SVGSVGElement> {
+  const { exportToSvg } = await import('@excalidraw/excalidraw')
+  return exportToSvg({
+    elements: scene.elements as never,
+    appState: {
+      ...scene.appState,
+      exportBackground: true,
+      exportEmbedScene: false,
+    } as never,
+    files: {},
+    exportPadding: 24,
+  })
+}
+
+export const svgMarkup = (svg: SVGSVGElement): string =>
+  new XMLSerializer().serializeToString(svg)
+
+export async function copySketchSvg(scene: SketchScene): Promise<void> {
+  const markup = svgMarkup(await sketchToSvg(scene))
+  const blob = new Blob([markup], { type: 'image/svg+xml' })
+  try {
+    await navigator.clipboard.write([new ClipboardItem({ 'image/svg+xml': blob })])
+  } catch {
+    await navigator.clipboard.writeText(markup)
+  }
+}
+
+export async function downloadSketchSvg(scene: SketchScene, name: string): Promise<void> {
+  const markup = svgMarkup(await sketchToSvg(scene))
+  const url = URL.createObjectURL(new Blob([markup], { type: 'image/svg+xml' }))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `${name.trim().replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'sketch'}.svg`
+  anchor.click()
+  URL.revokeObjectURL(url)
+}

--- a/app/frontend/editor/sketch/index.ts
+++ b/app/frontend/editor/sketch/index.ts
@@ -1,0 +1,8 @@
+export {
+  sketchSchemaPlugins,
+  sketchSchema,
+  dataFromSketchNode,
+  attrsFromSketchData,
+} from './schema'
+export { sketchNodeViewPlugins, sketchControlsCtx } from './node_view'
+export * from './scene'

--- a/app/frontend/editor/sketch/node_view.ts
+++ b/app/frontend/editor/sketch/node_view.ts
@@ -1,0 +1,141 @@
+import type { Node } from '@milkdown/kit/prose/model'
+import type { NodeView, NodeViewConstructor } from '@milkdown/kit/prose/view'
+import { $ctx, $prose, $view } from '@milkdown/kit/utils'
+import { Plugin } from '@milkdown/kit/prose/state'
+import { dataFromSketchNode, sketchSchema } from './schema'
+import { renderSketchPreview } from './preview'
+import { sketchAccessibleLabel, type SketchData } from './scene'
+
+interface SketchControls {
+  edit: (data: SketchData) => void
+  enabled: () => boolean
+}
+
+export const sketchControlsCtx = $ctx<SketchControls, 'sketchControls'>(
+  { edit: () => undefined, enabled: () => false },
+  'sketchControls',
+)
+
+const buildSketchView = (
+  initialNode: Node,
+  edit: (data: SketchData) => void,
+  enabled: () => boolean,
+): NodeView => {
+  const dom = document.createElement('figure')
+  const preview = document.createElement('div')
+  const caption = document.createElement('figcaption')
+  let currentData = dataFromSketchNode(initialNode)
+  let renderedScene = ''
+  let renderedDescription = ''
+
+  dom.className = 'thinkroom-sketch'
+  dom.contentEditable = 'false'
+  preview.className = 'thinkroom-sketch-preview'
+  caption.className = 'thinkroom-sketch-caption'
+  dom.append(preview, caption)
+
+  const syncInteractivity = () => {
+    const interactive = enabled()
+    dom.classList.toggle('is-editable', interactive)
+    if (interactive) {
+      dom.setAttribute('role', 'button')
+      dom.tabIndex = 0
+      dom.title = 'Edit sketch'
+    } else {
+      dom.removeAttribute('role')
+      dom.removeAttribute('tabindex')
+      dom.removeAttribute('title')
+    }
+  }
+
+  const render = (node: Node) => {
+    currentData = dataFromSketchNode(node)
+    if (!currentData) {
+      preview.replaceChildren()
+      caption.textContent = 'Invalid sketch'
+      return
+    }
+    const scene = node.attrs.scene as string
+    const description = currentData.description
+    if (scene !== renderedScene || description !== renderedDescription) {
+      preview.replaceChildren(renderSketchPreview(currentData.scene))
+      caption.textContent = description || 'Sketch'
+      renderedScene = scene
+      renderedDescription = description
+    }
+    dom.setAttribute('aria-label', sketchAccessibleLabel(currentData))
+    dom.dataset.sketchId = currentData.id
+    syncInteractivity()
+  }
+
+  const open = () => {
+    if (currentData && enabled()) edit(currentData)
+  }
+  const onClick = (event: MouseEvent) => {
+    if (event.button !== 0) return
+    open()
+  }
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    open()
+  }
+
+  dom.addEventListener('click', onClick)
+  dom.addEventListener('keydown', onKeyDown)
+  render(initialNode)
+
+  return {
+    dom,
+    update: (node) => {
+      if (node.type !== initialNode.type) return false
+      render(node)
+      return true
+    },
+    selectNode: () => dom.classList.add('is-selected'),
+    deselectNode: () => dom.classList.remove('is-selected'),
+    stopEvent: (event) => event.target instanceof globalThis.Node && dom.contains(event.target),
+    ignoreMutation: () => true,
+    destroy: () => {
+      dom.removeEventListener('click', onClick)
+      dom.removeEventListener('keydown', onKeyDown)
+    },
+  }
+}
+
+const sketchNodeView = $view(
+  sketchSchema.node,
+  (ctx): NodeViewConstructor => (node) =>
+    buildSketchView(
+      node,
+      (data) => ctx.get(sketchControlsCtx.key).edit(data),
+      () => ctx.get(sketchControlsCtx.key).enabled(),
+    ),
+)
+
+const sketchInteractivity = $prose(
+  (ctx) =>
+    new Plugin({
+      view: (view) => {
+        const sync = () => {
+          const enabled = ctx.get(sketchControlsCtx.key).enabled()
+          view.dom.querySelectorAll<HTMLElement>('.thinkroom-sketch').forEach((node) => {
+            node.classList.toggle('is-editable', enabled)
+            if (enabled) {
+              node.setAttribute('role', 'button')
+              node.tabIndex = 0
+              node.title = 'Edit sketch'
+            } else {
+              node.removeAttribute('role')
+              node.removeAttribute('tabindex')
+              node.removeAttribute('title')
+            }
+          })
+        }
+        sync()
+        return { update: sync }
+      },
+    }),
+)
+
+export const sketchNodeViewPlugins = [sketchControlsCtx, sketchNodeView, sketchInteractivity].flat()

--- a/app/frontend/editor/sketch/preview.ts
+++ b/app/frontend/editor/sketch/preview.ts
@@ -1,0 +1,146 @@
+import type { SketchScene } from './scene'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+const number = (value: unknown, fallback = 0): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback
+
+const string = (value: unknown, fallback: string): string =>
+  typeof value === 'string' ? value : fallback
+
+const svgElement = <K extends keyof SVGElementTagNameMap>(
+  name: K,
+  attrs: Record<string, string | number>,
+): SVGElementTagNameMap[K] => {
+  const element = document.createElementNS(SVG_NS, name)
+  for (const [key, value] of Object.entries(attrs)) element.setAttribute(key, String(value))
+  return element
+}
+
+/** Lightweight document preview. The full Excalidraw renderer stays lazy and
+ * is used for editing/export; this renderer keeps initial document load small. */
+export function renderSketchPreview(scene: SketchScene): SVGSVGElement {
+  const live = scene.elements.filter((element) => element.isDeleted !== true)
+  const bounds = live.reduce<{ minX: number; minY: number; maxX: number; maxY: number }>(
+    (box, element) => {
+      const x = number(element.x)
+      const y = number(element.y)
+      const width = Math.abs(number(element.width))
+      const height = Math.abs(number(element.height))
+      return {
+        minX: Math.min(box.minX, x),
+        minY: Math.min(box.minY, y),
+        maxX: Math.max(box.maxX, x + width),
+        maxY: Math.max(box.maxY, y + height),
+      }
+    },
+    { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+  )
+  const empty = !Number.isFinite(bounds.minX)
+  const padding = 24
+  const minX = empty ? 0 : bounds.minX - padding
+  const minY = empty ? 0 : bounds.minY - padding
+  const width = empty ? 640 : Math.max(240, bounds.maxX - bounds.minX + padding * 2)
+  const height = empty ? 320 : Math.max(140, bounds.maxY - bounds.minY + padding * 2)
+  const svg = svgElement('svg', {
+    viewBox: `${minX} ${minY} ${width} ${height}`,
+    role: 'img',
+    preserveAspectRatio: 'xMidYMid meet',
+  })
+  svg.classList.add('sketch-preview-svg')
+  svg.appendChild(
+    svgElement('rect', {
+      x: minX,
+      y: minY,
+      width,
+      height,
+      fill: string(scene.appState.viewBackgroundColor, '#ffffff'),
+    }),
+  )
+
+  for (const element of live) {
+    const x = number(element.x)
+    const y = number(element.y)
+    const w = number(element.width)
+    const h = number(element.height)
+    const stroke = string(element.strokeColor, '#1b1b1f')
+    const fill = string(element.backgroundColor, 'transparent')
+    const strokeWidth = number(element.strokeWidth, 2)
+    const opacity = number(element.opacity, 100) / 100
+    const group = svgElement('g', {
+      opacity,
+      transform: `rotate(${(number(element.angle) * 180) / Math.PI} ${x + w / 2} ${y + h / 2})`,
+    })
+    const common = { stroke, 'stroke-width': strokeWidth, fill, 'stroke-linecap': 'round' }
+
+    if (element.type === 'rectangle' || element.type === 'frame') {
+      group.appendChild(svgElement('rect', { x, y, width: w, height: h, rx: 4, ...common }))
+    } else if (element.type === 'ellipse') {
+      group.appendChild(
+        svgElement('ellipse', { cx: x + w / 2, cy: y + h / 2, rx: Math.abs(w / 2), ry: Math.abs(h / 2), ...common }),
+      )
+    } else if (element.type === 'diamond') {
+      group.appendChild(
+        svgElement('polygon', {
+          points: `${x + w / 2},${y} ${x + w},${y + h / 2} ${x + w / 2},${y + h} ${x},${y + h / 2}`,
+          ...common,
+        }),
+      )
+    } else if (element.type === 'line' || element.type === 'arrow' || element.type === 'freedraw') {
+      const rawPoints = Array.isArray(element.points) ? element.points : []
+      const points = rawPoints
+        .filter((point): point is unknown[] => Array.isArray(point) && point.length >= 2)
+        .map((point) => `${x + number(point[0])},${y + number(point[1])}`)
+        .join(' ')
+      group.appendChild(svgElement('polyline', { points, ...common, fill: 'none' }))
+      if (element.type === 'arrow' && rawPoints.length >= 2) {
+        const end = rawPoints[rawPoints.length - 1] as unknown[]
+        const before = rawPoints[rawPoints.length - 2] as unknown[]
+        const ex = x + number(end[0])
+        const ey = y + number(end[1])
+        const angle = Math.atan2(ey - (y + number(before[1])), ex - (x + number(before[0])))
+        const size = Math.max(8, strokeWidth * 4)
+        group.appendChild(
+          svgElement('polyline', {
+            points: `${ex - Math.cos(angle - 0.55) * size},${ey - Math.sin(angle - 0.55) * size} ${ex},${ey} ${ex - Math.cos(angle + 0.55) * size},${ey - Math.sin(angle + 0.55) * size}`,
+            stroke,
+            'stroke-width': strokeWidth,
+            fill: 'none',
+            'stroke-linecap': 'round',
+          }),
+        )
+      }
+    } else if (element.type === 'text') {
+      const fontSize = number(element.fontSize, 20)
+      const text = svgElement('text', {
+        x,
+        y: y + fontSize,
+        fill: stroke,
+        stroke: 'none',
+        'font-size': fontSize,
+        'font-family': 'system-ui, sans-serif',
+      })
+      string(element.text, '').split('\n').forEach((line, index) => {
+        const tspan = svgElement('tspan', { x, dy: index === 0 ? 0 : fontSize * 1.25 })
+        tspan.textContent = line
+        text.appendChild(tspan)
+      })
+      group.appendChild(text)
+    }
+    svg.appendChild(group)
+  }
+
+  if (empty) {
+    const label = svgElement('text', {
+      x: width / 2,
+      y: height / 2,
+      'text-anchor': 'middle',
+      fill: '#8b867f',
+      'font-size': 18,
+      'font-family': 'system-ui, sans-serif',
+    })
+    label.textContent = 'Empty sketch'
+    svg.appendChild(label)
+  }
+  return svg
+}

--- a/app/frontend/editor/sketch/scene.ts
+++ b/app/frontend/editor/sketch/scene.ts
@@ -1,0 +1,162 @@
+export const SKETCH_FORMAT_VERSION = 1
+export const MAX_SKETCH_BYTES = 512 * 1024
+export const MAX_SKETCH_DESCRIPTION = 500
+export const MAX_SKETCH_ELEMENTS = 500
+export const MAX_SKETCH_POINTS = 20_000
+
+const ELEMENT_TYPES = new Set([
+  'rectangle',
+  'diamond',
+  'ellipse',
+  'line',
+  'arrow',
+  'freedraw',
+  'text',
+  'frame',
+])
+const SAFE_COLOR = /^(?:transparent|#[0-9a-f]{3,8})$/i
+
+type JsonRecord = Record<string, unknown>
+
+export interface SketchScene {
+  type: 'excalidraw'
+  version: number
+  elements: JsonRecord[]
+  appState: JsonRecord
+  files: Record<string, never>
+}
+
+export interface SketchData {
+  id: string
+  formatVersion: typeof SKETCH_FORMAT_VERSION
+  description: string
+  scene: SketchScene
+}
+
+export const EMPTY_SKETCH_SCENE: SketchScene = {
+  type: 'excalidraw',
+  version: 2,
+  elements: [],
+  appState: { viewBackgroundColor: '#ffffff' },
+  files: {},
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const byteLength = (value: string): number => new TextEncoder().encode(value).length
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+const isPoint = (value: unknown): value is [number, number, ...unknown[]] =>
+  Array.isArray(value) && value.length >= 2 && isFiniteNumber(value[0]) && isFiniteNumber(value[1])
+
+/**
+ * Normalize the editable source before it enters ProseMirror/Yjs. Excalidraw
+ * SVG is derived from this data; imported files and links are deliberately
+ * excluded so a sketch cannot become a remote-resource or document-size path.
+ */
+export function normalizeSketchScene(input: unknown): SketchScene | null {
+  if (!isRecord(input) || input.type !== 'excalidraw') return null
+  if (!Array.isArray(input.elements) || input.elements.length > MAX_SKETCH_ELEMENTS) return null
+  if (input.appState !== undefined && !isRecord(input.appState)) return null
+  if (input.files !== undefined && (!isRecord(input.files) || Object.keys(input.files).length > 0)) {
+    return null
+  }
+  const inputAppState = (input.appState as JsonRecord | undefined) ?? {}
+  if (
+    inputAppState.viewBackgroundColor !== undefined &&
+    (typeof inputAppState.viewBackgroundColor !== 'string' ||
+      !SAFE_COLOR.test(inputAppState.viewBackgroundColor))
+  ) {
+    return null
+  }
+
+  let pointCount = 0
+  const elements: JsonRecord[] = []
+  for (const rawElement of input.elements) {
+    if (!isRecord(rawElement) || typeof rawElement.type !== 'string') return null
+    if (!ELEMENT_TYPES.has(rawElement.type) || rawElement.fileId || rawElement.link) return null
+    for (const color of [rawElement.strokeColor, rawElement.backgroundColor]) {
+      if (color !== undefined && (typeof color !== 'string' || !SAFE_COLOR.test(color))) return null
+    }
+    if (rawElement.points !== undefined) {
+      if (!Array.isArray(rawElement.points) || !rawElement.points.every(isPoint)) return null
+      pointCount += rawElement.points.length
+      if (pointCount > MAX_SKETCH_POINTS) return null
+    }
+
+    const element = structuredClone(rawElement)
+    delete element.link
+    delete element.customData
+    delete element.fileId
+    elements.push(element)
+  }
+
+  const sourceAppState = inputAppState
+  const appState: JsonRecord = {}
+  const retainedAppState: Record<string, (value: unknown) => boolean> = {
+    viewBackgroundColor: (value) => typeof value === 'string' && SAFE_COLOR.test(value),
+    theme: (value) => value === 'light' || value === 'dark',
+    gridSize: (value) => value === null || isFiniteNumber(value),
+    gridStep: isFiniteNumber,
+    gridModeEnabled: (value) => typeof value === 'boolean',
+    objectsSnapModeEnabled: (value) => typeof value === 'boolean',
+    zenModeEnabled: (value) => typeof value === 'boolean',
+  }
+  for (const [key, valid] of Object.entries(retainedAppState)) {
+    const value = sourceAppState[key]
+    if (value === undefined) continue
+    if (!valid(value)) return null
+    appState[key] = structuredClone(value)
+  }
+
+  const scene: SketchScene = {
+    type: 'excalidraw',
+    version: typeof input.version === 'number' && input.version > 0 ? input.version : 2,
+    elements,
+    appState,
+    files: {},
+  }
+  return byteLength(JSON.stringify(scene)) <= MAX_SKETCH_BYTES ? scene : null
+}
+
+export function normalizeSketchData(input: unknown): SketchData | null {
+  if (!isRecord(input) || input.formatVersion !== SKETCH_FORMAT_VERSION) return null
+  if (typeof input.id !== 'string' || !/^[a-zA-Z0-9_-]{1,100}$/.test(input.id)) return null
+  const scene = normalizeSketchScene(input.scene)
+  if (!scene) return null
+  const description = typeof input.description === 'string' ? input.description.trim() : ''
+  if (Array.from(description).length > MAX_SKETCH_DESCRIPTION) return null
+  return { id: input.id, formatVersion: SKETCH_FORMAT_VERSION, description, scene }
+}
+
+export function parseSketchData(source: string): SketchData | null {
+  if (byteLength(source) > MAX_SKETCH_BYTES + 4096) return null
+  try {
+    return normalizeSketchData(JSON.parse(source))
+  } catch {
+    return null
+  }
+}
+
+export function serializeSketchData(data: SketchData): string {
+  return JSON.stringify(data)
+}
+
+export function sketchLabels(scene: SketchScene): string[] {
+  return Array.from(
+    new Set(
+      scene.elements
+        .filter((element) => element.type === 'text')
+        .map((element) => (typeof element.text === 'string' ? element.text.trim() : ''))
+        .filter(Boolean),
+    ),
+  ).slice(0, 50)
+}
+
+export function sketchAccessibleLabel(data: SketchData): string {
+  const labels = sketchLabels(data.scene)
+  return [data.description || 'Sketch', labels.length > 0 ? labels.join(', ') : '']
+    .filter(Boolean)
+    .join(': ')
+}

--- a/app/frontend/editor/sketch/schema.ts
+++ b/app/frontend/editor/sketch/schema.ts
@@ -1,0 +1,124 @@
+import type { Node as MarkdownNode } from '@milkdown/kit/transformer'
+import { $nodeSchema, $remark } from '@milkdown/kit/utils'
+import {
+  SKETCH_FORMAT_VERSION,
+  normalizeSketchData,
+  parseSketchData,
+  serializeSketchData,
+  sketchAccessibleLabel,
+  type SketchData,
+} from './scene'
+
+type MutableMarkdownNode = MarkdownNode & {
+  type: string
+  lang?: string | null
+  value?: string
+  children?: MutableMarkdownNode[]
+}
+
+const transformSketchFences = (node: MarkdownNode): void => {
+  const mutable = node as MutableMarkdownNode
+  if (
+    mutable.type === 'code' &&
+    mutable.lang?.toLowerCase() === 'excalidraw' &&
+    parseSketchData(mutable.value ?? '')
+  ) {
+    mutable.type = 'thinkroomSketch'
+  }
+  mutable.children?.forEach(transformSketchFences)
+}
+
+const remarkSketchPlugin = $remark('remarkSketch', () => () => transformSketchFences)
+
+export const attrsFromSketchData = (data: SketchData) => ({
+  id: data.id,
+  scene: JSON.stringify(data.scene),
+  description: data.description,
+  formatVersion: data.formatVersion,
+})
+
+export const dataFromSketchNode = (node: {
+  attrs: Record<string, unknown>
+}): SketchData | null =>
+  normalizeSketchData({
+    id: node.attrs.id,
+    formatVersion: node.attrs.formatVersion,
+    description: node.attrs.description,
+    scene:
+      typeof node.attrs.scene === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(node.attrs.scene)
+            } catch {
+              return null
+            }
+          })()
+        : null,
+  })
+
+export const sketchSchema = $nodeSchema('thinkroomSketch', () => ({
+  group: 'block',
+  atom: true,
+  selectable: true,
+  draggable: false,
+  marks: '',
+  attrs: {
+    id: { default: '' },
+    scene: { default: '' },
+    description: { default: '' },
+    formatVersion: { default: SKETCH_FORMAT_VERSION },
+  },
+  parseDOM: [
+    {
+      tag: 'figure[data-thinkroom-sketch]',
+      getAttrs: (dom) => {
+        const element = dom as HTMLElement
+        const data = normalizeSketchData({
+          id: element.dataset.sketchId,
+          formatVersion: Number(element.dataset.formatVersion),
+          description: element.dataset.description ?? '',
+          scene: (() => {
+            try {
+              return JSON.parse(element.dataset.scene ?? '')
+            } catch {
+              return null
+            }
+          })(),
+        })
+        return data ? attrsFromSketchData(data) : false
+      },
+    },
+  ],
+  toDOM: (node) => {
+    const data = dataFromSketchNode(node)
+    if (!data) return ['p', 'Invalid sketch']
+    return [
+      'figure',
+      {
+        'data-thinkroom-sketch': '',
+        'data-sketch-id': data.id,
+        'data-format-version': String(data.formatVersion),
+        'data-description': data.description,
+        'data-scene': JSON.stringify(data.scene),
+        'aria-label': sketchAccessibleLabel(data),
+      },
+      ['figcaption', data.description || 'Sketch'],
+    ]
+  },
+  parseMarkdown: {
+    match: ({ type }) => type === 'thinkroomSketch',
+    runner: (state, node, type) => {
+      const data = parseSketchData((node.value as string | undefined) ?? '')
+      if (data) state.addNode(type, attrsFromSketchData(data))
+    },
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === 'thinkroomSketch',
+    runner: (state, node) => {
+      const data = dataFromSketchNode(node)
+      if (data) state.addNode('code', undefined, serializeSketchData(data), { lang: 'excalidraw' })
+    },
+  },
+}))
+
+export const sketchSchemaPlugins = [remarkSketchPlugin, sketchSchema].flat()

--- a/app/frontend/editor/sketch/sketch_modal.tsx
+++ b/app/frontend/editor/sketch/sketch_modal.tsx
@@ -1,0 +1,204 @@
+import {
+  Component,
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ErrorInfo,
+  type ReactNode,
+} from 'react'
+import {
+  EMPTY_SKETCH_SCENE,
+  MAX_SKETCH_DESCRIPTION,
+  normalizeSketchData,
+  normalizeSketchScene,
+  type SketchData,
+  type SketchScene,
+} from './scene'
+import { copySketchSvg, downloadSketchSvg } from './export'
+
+const ExcalidrawCanvas = lazy(() => import('./excalidraw_canvas'))
+
+class SketchCanvasBoundary extends Component<
+  { children: ReactNode; onClose: () => void },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Thinkroom sketch canvas failed to load', error, info)
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children
+    return (
+      <div className="sketch-load-error" role="alert">
+        <strong>The sketch canvas could not load.</strong>
+        <span>Your document is still safe. Close this window and reload Thinkroom to try again.</span>
+        <button type="button" className="sketch-button" onClick={this.props.onClose}>
+          Close
+        </button>
+      </div>
+    )
+  }
+}
+
+interface SketchModalProps {
+  initialData?: SketchData | null
+  onCancel: () => void
+  onDelete?: () => void
+  onSave: (data: SketchData) => void
+}
+
+export function SketchModal({ initialData, onCancel, onDelete, onSave }: SketchModalProps) {
+  const [canvasInitialScene] = useState<SketchScene>(initialData?.scene ?? EMPTY_SKETCH_SCENE)
+  const sceneDraftRef = useRef<unknown>(canvasInitialScene)
+  const [description, setDescription] = useState(initialData?.description ?? '')
+  const [error, setError] = useState('')
+  const [exporting, setExporting] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null
+    document.body.classList.add('sketch-modal-open')
+    dialogRef.current?.focus()
+    return () => {
+      document.body.classList.remove('sketch-modal-open')
+      previous?.focus()
+    }
+  }, [])
+
+  const updateScene = useCallback((next: unknown) => {
+    sceneDraftRef.current = next
+  }, [])
+
+  const save = () => {
+    const scene = normalizeSketchScene(sceneDraftRef.current)
+    if (!scene) {
+      setError('This sketch is too large or contains unsupported image or link data.')
+      return
+    }
+    const data = normalizeSketchData({
+      id: initialData?.id ?? crypto.randomUUID(),
+      formatVersion: 1,
+      description,
+      scene,
+    })
+    if (!data) {
+      setError('This sketch is too large to save in the document.')
+      return
+    }
+    onSave(data)
+  }
+
+  const runExport = async (action: (scene: SketchScene) => Promise<void>) => {
+    const scene = normalizeSketchScene(sceneDraftRef.current)
+    if (!scene) {
+      setError('This sketch is too large or contains unsupported image or link data.')
+      return
+    }
+    setExporting(true)
+    setError('')
+    try {
+      await action(scene)
+    } catch {
+      setError('The SVG could not be exported. Try saving the sketch first.')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <div className="sketch-modal-backdrop" role="presentation">
+      <div
+        ref={dialogRef}
+        className="sketch-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sketch-modal-title"
+        tabIndex={-1}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') onCancel()
+          if (event.key === 'Tab') {
+            const focusable = Array.from(
+              dialogRef.current?.querySelectorAll<HTMLElement>(
+                'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])',
+              ) ?? [],
+            ).filter((element) => element.offsetParent !== null)
+            const first = focusable[0]
+            const last = focusable[focusable.length - 1]
+            if (event.shiftKey && document.activeElement === first) {
+              event.preventDefault()
+              last?.focus()
+            } else if (!event.shiftKey && document.activeElement === last) {
+              event.preventDefault()
+              first?.focus()
+            }
+          }
+        }}
+      >
+        <header className="sketch-modal-header">
+          <div>
+            <h2 id="sketch-modal-title">{initialData ? 'Edit sketch' : 'New sketch'}</h2>
+            <p>Draw with mouse, touch, or Apple Pencil.</p>
+          </div>
+          <div className="sketch-modal-actions">
+            {initialData && onDelete && (
+              <button type="button" className="sketch-button sketch-button-danger" onClick={onDelete}>
+                Delete
+              </button>
+            )}
+            <button type="button" className="sketch-button" onClick={onCancel}>Cancel</button>
+            <button type="button" className="sketch-button sketch-button-primary" onClick={save}>Save sketch</button>
+          </div>
+        </header>
+
+        <div className="sketch-canvas-shell">
+          <SketchCanvasBoundary onClose={onCancel}>
+            <Suspense fallback={<div className="sketch-loading">Loading canvas…</div>}>
+              <ExcalidrawCanvas scene={canvasInitialScene} onSceneChange={updateScene} />
+            </Suspense>
+          </SketchCanvasBoundary>
+        </div>
+
+        <footer className="sketch-modal-footer">
+          <label className="sketch-description">
+            <span>Description for people and agents</span>
+            <input
+              type="text"
+              value={description}
+              maxLength={MAX_SKETCH_DESCRIPTION}
+              placeholder="e.g. Signup approval flow"
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </label>
+          <div className="sketch-modal-footer-actions">
+            <button
+              type="button"
+              className="sketch-button"
+              disabled={exporting}
+              onClick={() => void runExport(copySketchSvg)}
+            >
+              Copy SVG
+            </button>
+            <button
+              type="button"
+              className="sketch-button"
+              disabled={exporting}
+              onClick={() => void runExport((scene) => downloadSketchSvg(scene, description))}
+            >
+              Download SVG
+            </button>
+          </div>
+          {error && <p className="sketch-error" role="alert">{error}</p>}
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2725,3 +2725,230 @@ a:focus-visible {
     padding: 0.28rem 0.5rem !important;
   }
 }
+/* Inline sketch editor ---------------------------------------------------- */
+.sketch-modal-open {
+  overflow: hidden;
+}
+
+.sketch-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgb(20 18 15 / 54%);
+  backdrop-filter: blur(4px);
+}
+
+.sketch-modal {
+  width: min(1180px, 100%);
+  height: min(820px, calc(100dvh - 40px));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface-raised);
+  box-shadow: 0 24px 80px rgb(20 18 15 / 26%);
+}
+
+.sketch-modal-header,
+.sketch-modal-footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+}
+
+.sketch-modal-header {
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+}
+
+.sketch-modal-header h2 {
+  margin: 0;
+  font: 600 16px/1.3 var(--font-ui);
+}
+
+.sketch-modal-header p {
+  margin: 2px 0 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.sketch-modal-actions,
+.sketch-modal-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sketch-canvas-shell {
+  min-height: 0;
+  position: relative;
+  background: #fff;
+  touch-action: none;
+}
+
+.sketch-canvas-shell > div,
+.sketch-canvas-shell .excalidraw {
+  width: 100%;
+  height: 100%;
+}
+
+.sketch-loading {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.sketch-load-error {
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 10px;
+  height: 100%;
+  padding: 24px;
+  color: var(--ink-soft);
+  text-align: center;
+}
+
+.sketch-load-error strong {
+  color: var(--ink);
+}
+
+.sketch-modal-footer {
+  flex-wrap: wrap;
+  border-top: 1px solid var(--line);
+}
+
+.sketch-description {
+  min-width: min(360px, 100%);
+  flex: 1;
+  display: grid;
+  gap: 5px;
+  color: var(--ink-soft);
+  font-size: 11px;
+}
+
+.sketch-description input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  padding: 8px 10px;
+  font-size: 13px;
+}
+
+.sketch-button {
+  min-height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  padding: 6px 11px;
+  font: 500 12px/1 var(--font-ui);
+  cursor: pointer;
+}
+
+.sketch-button:hover:not(:disabled) {
+  background: var(--surface);
+}
+
+.sketch-button-primary {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--surface-raised);
+}
+
+.sketch-button-danger {
+  border-color: rgb(161 55 44 / 35%);
+  color: #a1372c;
+}
+
+.sketch-error {
+  flex-basis: 100%;
+  margin: 0;
+  color: #a1372c;
+  font-size: 12px;
+}
+
+@media (max-width: 700px) {
+  .sketch-modal-backdrop { padding: 0; }
+  .sketch-modal { width: 100%; height: 100dvh; border: 0; border-radius: 0; }
+  .sketch-modal-header { align-items: flex-start; }
+  .sketch-modal-header p { display: none; }
+  .sketch-modal-footer-actions { width: 100%; }
+}
+
+.sketch-insert-button {
+  min-height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--ink);
+  padding: 5px 9px;
+  font: 500 12px/1 var(--font-ui);
+  cursor: pointer;
+}
+
+.sketch-insert-button:hover:not(:disabled) {
+  background: var(--surface);
+}
+
+.sketch-insert-button:disabled {
+  opacity: 0.45;
+}
+
+.thinkroom-sketch {
+  width: 100%;
+  margin: 24px 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(20 18 15 / 4%);
+}
+
+.thinkroom-sketch.is-editable {
+  cursor: pointer;
+}
+
+.thinkroom-sketch.is-editable:hover,
+.thinkroom-sketch.is-selected {
+  border-color: color-mix(in srgb, var(--ink) 42%, transparent);
+  box-shadow: 0 0 0 2px rgb(38 35 31 / 7%);
+}
+
+.thinkroom-sketch-preview {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  max-height: 520px;
+  overflow: hidden;
+}
+
+.sketch-preview-svg {
+  display: block;
+  width: 100%;
+  max-height: 520px;
+}
+
+.thinkroom-sketch-caption {
+  min-height: 34px;
+  margin: 0;
+  border-top: 1px solid var(--line);
+  padding: 9px 12px;
+  color: var(--ink-soft);
+  font: 500 12px/1.3 var(--font-ui);
+}
+
+@media (max-width: 700px) {
+  .sketch-insert-button { display: none; }
+  .thinkroom-sketch { margin: 18px 0; border-radius: 9px; }
+  .thinkroom-sketch-preview { min-height: 150px; }
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -962,6 +962,16 @@ export default function DocumentShow({
                 {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
               </button>
             )}
+            {mode === 'edit' && (
+              <button
+                type="button"
+                className="sketch-insert-button"
+                disabled={!handle}
+                onClick={() => handle?.openSketch()}
+              >
+                Sketch
+              </button>
+            )}
             <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
             <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
             <HeaderMenu

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -120,6 +120,21 @@ class AgentGuide
           response_field: "normalized",
           warning_field: "warning",
           meaning: "When normalized is true, unsupported or unsafe source was removed or rewritten."
+        },
+        sketches: {
+          purpose: "Inline Excalidraw sketches remain editable in the human UI and expose text semantics to agents.",
+          markdown_source: "A fenced excalidraw block containing versioned JSON with id, description, and scene.",
+          html_source: "A trusted figure[data-thinkroom-sketch] snapshot; external HTML cannot set reserved sketch attributes.",
+          rendered_context: "plain_text emits the sketch description and text labels instead of raw scene JSON.",
+          canonical: "The Excalidraw scene is canonical; SVG is generated in the browser for preview, copy, and download.",
+          supported_elements: ThinkroomSketch::ELEMENT_TYPES,
+          limits: {
+            scene_max_bytes: ThinkroomSketch::MAX_SCENE_BYTES,
+            description_max_characters: ThinkroomSketch::MAX_DESCRIPTION_LENGTH,
+            elements_max: ThinkroomSketch::MAX_ELEMENTS,
+            points_max: ThinkroomSketch::MAX_POINTS,
+            embedded_images: false
+          }
         }
       }
       return contract unless format == "html"
@@ -131,7 +146,7 @@ class AgentGuide
           dropped_with_content: HtmlDocumentSanitizer::DROP_WITH_CONTENT,
           attributes: {
             supported: HtmlDocumentSanitizer::EXTERNAL_ATTRIBUTES,
-            reserved: "Thinkroom provenance and suggestion data attributes may appear in trusted snapshots; external source cannot set them."
+            reserved: "Thinkroom provenance, suggestion, and sketch data attributes may appear in trusted snapshots; external source cannot set them."
           },
           css: {
             supported: "Only text-align: left|center|right on th and td.",
@@ -160,6 +175,7 @@ class AgentGuide
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
+        "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported.",
         "Suggestion targeting: use a unique quote from plain_text for replaces or anchor_text; source-formatted quotes are parsed too. A missing or ambiguous replaces target stays pending and changes nothing. A missing anchor_text falls back to appending if a human accepts it.",
         "Tracked changes use <ins data-suggestion-id> / <del data-suggestion-id> in the source snapshot. They are human-typed suggestions pending review, not your proposals, and are not resolvable through this API.",
         "Review is human-gated by design: accepting/rejecting suggestions and advancing review states happen in the editor, by humans. Your job is to propose well.",
@@ -211,6 +227,11 @@ class AgentGuide
         - rendered text in "plain_text"
         Humans edit the rendered document in the browser; ProseMirror/Yjs is
         internal — do not send editor JSON or CRDT data.
+
+        Inline Excalidraw sketches are versioned source blocks. Their editable
+        scene appears in content; plain_text gives you the human description
+        and text labels without raw scene JSON. SVG is a derived browser
+        preview/export, and embedded bitmap files are not supported.
 
         #{html_contract_text(document, base_url)}
         ## Participate

--- a/app/services/document_plain_text.rb
+++ b/app/services/document_plain_text.rb
@@ -13,12 +13,47 @@ class DocumentPlainText
         )
       end
 
-      Nokogiri::HTML5.fragment(html)
+      fragment = Nokogiri::HTML5.fragment(html)
+      replace_sketches(fragment, format:)
+
+      fragment
         .xpath(".//text()")
         .map(&:text)
         .join(BLOCK_SEPARATOR)
         .squish
         .gsub(/\s+([.,;:!?])/, '\1')
+    end
+
+    private
+
+    def replace_sketches(fragment, format:)
+      if format == "html"
+        fragment.css("figure[data-thinkroom-sketch]").each do |node|
+          replace_with_semantics(
+            node,
+            scene: node["data-scene"],
+            description: node["data-description"],
+            format_version: node["data-format-version"]
+          )
+        end
+      else
+        fragment.css('pre[lang="excalidraw"] > code').each do |node|
+          payload = JSON.parse(node.text)
+          replace_with_semantics(
+            node.parent,
+            scene: JSON.generate(payload.fetch("scene")),
+            description: payload["description"],
+            format_version: payload["formatVersion"]
+          )
+        rescue JSON::ParserError, KeyError
+          # Leave malformed source visible instead of hiding data.
+        end
+      end
+    end
+
+    def replace_with_semantics(node, scene:, description:, format_version:)
+      parsed = ThinkroomSketch.parse(scene, description:, format_version:)
+      node.replace(Nokogiri::XML::Text.new(parsed.semantic_text, node.document)) if parsed
     end
   end
 end

--- a/app/services/html_document_sanitizer.rb
+++ b/app/services/html_document_sanitizer.rb
@@ -6,13 +6,14 @@ class HtmlDocumentSanitizer
   TAGS = %w[
     p h1 h2 h3 h4 h5 h6 blockquote pre code br hr
     ul ol li strong b em i s del a img
-    table thead tbody tr th td span ins
+    table thead tbody tr th td span ins figure figcaption
   ].freeze
 
   ATTRIBUTES = %w[
     href title src alt start style colspan rowspan colwidth
     data-language data-item-type data-label data-list-type data-spread data-checked
     data-is-header data-provenance data-kind data-author data-state data-suggestion-id
+    data-thinkroom-sketch data-sketch-id data-scene data-description data-format-version
   ].freeze
 
   PROVENANCE_KINDS = %w[human ai].freeze
@@ -31,7 +32,10 @@ class HtmlDocumentSanitizer
   DROP_WITH_CONTENT = %w[script style iframe object embed template svg math].freeze
   PROVENANCE_ATTRIBUTES = %w[data-provenance data-kind data-author data-state].freeze
   SUGGESTION_ATTRIBUTES = %w[data-suggestion-id data-author].freeze
-  THINKROOM_ATTRIBUTES = (PROVENANCE_ATTRIBUTES + SUGGESTION_ATTRIBUTES).uniq.freeze
+  SKETCH_ATTRIBUTES = %w[
+    data-thinkroom-sketch data-sketch-id data-scene data-description data-format-version
+  ].freeze
+  THINKROOM_ATTRIBUTES = (PROVENANCE_ATTRIBUTES + SUGGESTION_ATTRIBUTES + SKETCH_ATTRIBUTES).uniq.freeze
   EXTERNAL_ATTRIBUTES = (ATTRIBUTES - THINKROOM_ATTRIBUTES).freeze
 
   class << self
@@ -92,6 +96,7 @@ class HtmlDocumentSanitizer
 
       restore_provenance(node, metadata) if valid_provenance?(node, metadata)
       restore_suggestion(node, metadata) if valid_suggestion?(node, metadata)
+      restore_sketch(node, metadata) if valid_sketch?(node, metadata)
     end
 
     def valid_active_storage_src?(source)
@@ -135,6 +140,25 @@ class HtmlDocumentSanitizer
     def restore_suggestion(node, metadata)
       node["data-suggestion-id"] = metadata["data-suggestion-id"]
       node["data-author"] = metadata["data-author"].to_s
+    end
+
+    def valid_sketch?(node, metadata)
+      return false unless node.name == "figure" && !metadata["data-thinkroom-sketch"].nil?
+      return false unless metadata["data-sketch-id"].to_s.match?(/\A[a-zA-Z0-9_-]{1,100}\z/)
+
+      ThinkroomSketch.parse(
+        metadata["data-scene"],
+        description: metadata["data-description"],
+        format_version: metadata["data-format-version"]
+      ).present?
+    end
+
+    def restore_sketch(node, metadata)
+      SKETCH_ATTRIBUTES.each do |attribute|
+        node[attribute] = metadata[attribute].to_s
+      end
+      node["data-thinkroom-sketch"] = ""
+      node["data-format-version"] = ThinkroomSketch::FORMAT_VERSION.to_s
     end
 
     def strip_thinkroom_metadata(node)

--- a/app/services/thinkroom_sketch.rb
+++ b/app/services/thinkroom_sketch.rb
@@ -1,0 +1,93 @@
+class ThinkroomSketch
+  FORMAT_VERSION = 1
+  MAX_SCENE_BYTES = 512.kilobytes
+  MAX_DESCRIPTION_LENGTH = 500
+  MAX_ELEMENTS = 500
+  MAX_POINTS = 20_000
+  ELEMENT_TYPES = %w[
+    rectangle diamond ellipse line arrow freedraw text frame
+  ].freeze
+  SAFE_COLOR = /\A(?:transparent|#[0-9a-f]{3,8})\z/i
+
+  Parsed = Data.define(:scene, :description, :labels, :shape_types) do
+    def semantic_text
+      parts = [ description.presence, labels.presence&.join(", ") ].compact
+      parts.empty? ? "Sketch" : "Sketch: #{parts.join(" — ")}"
+    end
+  end
+
+  class << self
+    def parse(scene_json, description: "", format_version: FORMAT_VERSION)
+      source = scene_json.to_s
+      return if source.blank? || source.bytesize > MAX_SCENE_BYTES
+      return unless format_version.to_i == FORMAT_VERSION
+
+      scene = JSON.parse(source)
+      return unless valid_scene?(scene)
+
+      description = description.to_s.strip
+      return if description.length > MAX_DESCRIPTION_LENGTH
+      labels = scene.fetch("elements").filter_map do |element|
+        next unless element["type"] == "text"
+
+        element["text"].to_s.squish.presence
+      end.uniq.first(50)
+      shape_types = scene.fetch("elements").filter_map { |element| element["type"] }.uniq
+
+      Parsed.new(scene:, description:, labels:, shape_types:)
+    rescue JSON::ParserError, JSON::NestingError
+      nil
+    end
+
+    private
+
+    def valid_scene?(scene)
+      return false unless scene.is_a?(Hash)
+      return false unless scene["type"] == "excalidraw" && scene["version"].to_i.positive?
+
+      elements = scene["elements"]
+      return false unless elements.is_a?(Array) && elements.length <= MAX_ELEMENTS
+      return false unless scene["appState"].nil? || scene["appState"].is_a?(Hash)
+      return false unless scene["files"].nil? || scene["files"] == {}
+      return false unless safe_color?(scene.dig("appState", "viewBackgroundColor"))
+      return false unless valid_app_state?(scene["appState"] || {})
+
+      point_count = 0
+      elements.all? do |element|
+        next false unless element.is_a?(Hash) && ELEMENT_TYPES.include?(element["type"])
+        next false if element["fileId"].present? || element["link"].present?
+        next false unless safe_color?(element["strokeColor"]) && safe_color?(element["backgroundColor"])
+
+        points = element["points"]
+        next false unless points.nil? || points.is_a?(Array)
+        next false unless points.nil? || points.all? { |point| valid_point?(point) }
+
+        point_count += points&.length.to_i
+        point_count <= MAX_POINTS
+      end
+    end
+
+    def safe_color?(value)
+      value.nil? || value.to_s.match?(SAFE_COLOR)
+    end
+
+    def valid_point?(point)
+      point.is_a?(Array) && point.length >= 2 &&
+        point.first(2).all? { |coordinate| coordinate.is_a?(Numeric) && coordinate.finite? }
+    end
+
+    def valid_app_state?(app_state)
+      return false unless [ nil, "light", "dark" ].include?(app_state["theme"])
+      return false unless app_state["gridSize"].nil? || finite_number?(app_state["gridSize"])
+      return false unless app_state["gridStep"].nil? || finite_number?(app_state["gridStep"])
+
+      %w[gridModeEnabled objectsSnapModeEnabled zenModeEnabled].all? do |key|
+        app_state[key].nil? || [ true, false ].include?(app_state[key])
+      end
+    end
+
+    def finite_number?(value)
+      value.is_a?(Numeric) && value.finite?
+    end
+  end
+end

--- a/docs/plans/2026-06-24-002-feat-inline-excalidraw-sketches-plan.md
+++ b/docs/plans/2026-06-24-002-feat-inline-excalidraw-sketches-plan.md
@@ -1,0 +1,150 @@
+---
+title: "feat: Add inline Excalidraw sketches"
+type: feat
+date: 2026-06-24
+origin: STRATEGY.md
+---
+
+# Add inline Excalidraw sketches
+
+## Summary
+
+Add a focused sketch workflow to Thinkroom: insert an Excalidraw canvas at the current document position, draw with mouse, touch, or Apple Pencil, save it as an inline SVG preview, and reopen it for editing. The editable Excalidraw scene remains part of the collaborative document, while a concise description and extracted labels make the sketch understandable to agents through the existing document API.
+
+## Problem frame
+
+Thinkroom currently supports prose, tables, tasks, links, and uploaded raster images, but visual thinking requires leaving the document for a separate canvas and then pasting a flattened result back. That breaks flow and gives agents little useful context. A useful first version must feel native to the editor, survive Yjs collaboration and snapshot reloads, work on iPad without a native app, and avoid turning arbitrary SVG uploads into a new security surface.
+
+## Requirements
+
+- R1. In Edit mode, a person can insert a new sketch at the current block position and reopen an existing sketch by clicking its inline preview.
+- R2. The sketch editor supports Excalidraw shapes, arrows, text, and freehand drawing with mouse, touch, and standards-based pen input, including Apple Pencil in iPad Safari.
+- R3. Saving a sketch updates the document optimistically, synchronizes the complete editable scene through the existing Yjs channel, persists in snapshots, and survives reload without flattening the scene.
+- R4. The document renders each saved sketch as a crisp inline SVG preview with an accessible caption; the full Excalidraw application is loaded only when a sketch is edited.
+- R5. A saved sketch exposes an editable description plus deterministically extracted text labels and shape types in the Markdown/HTML source and plain-text API so agents can understand the artifact without interpreting pixels.
+- R6. Read, Comment, and Suggest modes show the clean inline preview but do not open or mutate the sketch. Sketch insertion and editing are Edit-mode operations in this release.
+- R7. The modal supports explicit Save and Cancel. Unsaved canvas changes remain local, and saving one sketch produces one collaborative document transaction rather than broadcasting every pointer movement.
+- R8. Scene data is validated and size-bounded before insertion and at snapshot sanitization boundaries; arbitrary SVG markup, remote image URLs, scripts, and imported bitmap files cannot enter the document through the sketch contract.
+- R9. A person can copy or download the derived SVG from the sketch editor for use outside Thinkroom.
+- R10. Existing Markdown and HTML documents, clean-copy behavior, provenance tracking, task checkboxes, links, and collaboration continue to behave unchanged.
+
+## Key technical decisions
+
+- KTD1. **Use an atomic Milkdown block node:** Add a `thinkroomSketch` ProseMirror atom with `scene`, `description`, and format-version attributes. Atom semantics keep provenance and text-suggestion marks out of the scene payload while allowing Yjs to synchronize one intentional save.
+- KTD2. **Keep scene JSON canonical and SVG derived:** Store normalized Excalidraw scene JSON so the sketch remains editable. Generate the inline/copy/download SVG with Excalidraw's `exportToSvg`; never accept or persist arbitrary user-supplied SVG markup.
+- KTD3. **Open a modal instead of embedding a live canvas:** Inline nodes render a lightweight SVG preview and caption. A lazy-loaded Excalidraw modal handles creation and editing, which keeps document scrolling, selection, and initial bundle cost predictable.
+- KTD4. **Commit on Save:** `onChange` updates modal-local state only. Save validates the scene and replaces/inserts the atom in one transaction; Cancel discards it. Concurrent editing inside the same sketch is intentionally last-save-wins in this version, while the saved node continues to synchronize live with the rest of the document.
+- KTD5. **Use open, inspectable source representations:** Markdown snapshots serialize a fenced `excalidraw` block containing versioned JSON; HTML snapshots serialize a trusted `<figure data-thinkroom-sketch>` with escaped scene JSON and a visible `<figcaption>`. Both representations include description and extracted element text.
+- KTD6. **Treat Pencil as Pointer Events input:** Rely on Excalidraw's browser pointer handling rather than PencilKit or a native bridge. Isolate `touch-action` inside the canvas and verify pressure/free-draw behavior on iPad Safari.
+- KTD7. **Exclude embedded bitmap files initially:** Shapes, arrows, text, and strokes are in scope. Excalidraw image insertion/library files are disabled because base64 file blobs would rapidly consume the document's 2 MB content limit and complicate safe agent/API representation.
+- KTD8. **Make agent semantics deterministic:** The modal offers a short description field and previews extracted text labels. `DocumentPlainText` emits description/labels instead of raw scene JSON, and `AgentGuide` documents the versioned sketch block contract.
+
+## Scope boundaries
+
+### Included
+
+- Create, edit, save, cancel, copy SVG, and download SVG.
+- Inline SVG preview, caption, keyboard access, responsive modal, and iPad/Pencil input.
+- Markdown/HTML round-trip, Yjs synchronization, snapshot persistence, plain-text extraction, and agent guidance.
+- Lazy loading, scene validation, payload limits, and focused regression/browser coverage.
+
+### Outside this change
+
+- Real-time multi-cursor co-editing within one open Excalidraw canvas.
+- Bitmap/image insertion inside Excalidraw, Excalidraw libraries, cloud scene storage, or a separate sketch database table.
+- Native PencilKit integration, handwriting recognition, or server-side image understanding.
+- Agent-authored sketch mutation APIs beyond the documented source contract.
+
+## Acceptance examples
+
+- AE1. Given an Edit-mode cursor between two paragraphs, when the person chooses Sketch, draws with Apple Pencil, adds the description “Signup approval flow,” and saves, then a crisp inline preview appears at that position immediately and peers see it through the existing live connection.
+- AE2. Given a saved sketch, when the document reloads or opens in a second browser, then the preview, description, element labels, and editable scene are unchanged.
+- AE3. Given Read, Comment, or Suggest mode, when the person clicks a sketch, then no editor opens and no document transaction is produced.
+- AE4. Given a saved sketch containing boxes labeled “Draft,” “Review,” and “Publish,” when an agent fetches the document source or plain text, then it receives the description and those labels without needing to decode SVG pixels.
+- AE5. Given an open sketch with unsaved changes, when the person cancels, then the inline node and remote collaborators remain unchanged.
+- AE6. Given an oversized, malformed, or externally supplied sketch payload, when it crosses a client or server sanitization boundary, then it is rejected or downgraded to safe visible text without executing markup.
+- AE7. Given a saved sketch, when the person chooses Copy SVG or Download SVG, then the exported file is a valid scalable rendering of the current scene and contains no remote resources.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A[Edit-mode Sketch action] --> B[Lazy Excalidraw modal]
+  B -->|local onChange| C[Validated scene + description]
+  C -->|single Save transaction| D[Milkdown sketch atom]
+  D <--> E[Yjs / Action Cable]
+  D --> F[Derived inline SVG preview]
+  D --> G[Markdown or HTML snapshot]
+  G --> H[Rails sanitizer + persistence]
+  G --> I[Agent source and plain-text semantics]
+```
+
+## Implementation units
+
+### U1. Versioned sketch content contract
+
+- **Goal:** Define one validated scene shape that round-trips through Milkdown, Markdown, HTML, Yjs, and Rails without accepting executable SVG.
+- **Files:** `app/frontend/editor/sketch/schema.ts`, `app/frontend/editor/sketch/scene.ts`, `app/frontend/editor/document_format.ts`, `app/services/html_document_sanitizer.rb`, `app/services/document_plain_text.rb`, `app/services/agent_guide.rb`.
+- **Patterns:** Follow the atomic-node and Markdown-extension pattern in `app/frontend/editor/frontmatter/index.ts`; extend trusted metadata separately from external HTML metadata; keep `Document::MAX_CONTENT_BYTES` as the final aggregate limit.
+- **Test scenarios:** Valid Markdown fence and trusted HTML figure round-trip losslessly; external sketch attributes are stripped; malformed JSON, unknown versions, remote file references, overlong descriptions, excessive elements, and oversized scenes are rejected; plain text returns description/labels rather than raw JSON.
+- **Verification:** Focused TypeScript checks plus sanitizer, plain-text, agent-guide, and snapshot tests for both document formats.
+
+### U2. Lazy Excalidraw modal and SVG export
+
+- **Goal:** Provide a responsive creation/editing surface with local draft state, Pencil-compatible drawing, explicit Save/Cancel, and SVG export.
+- **Files:** `package.json`, `package-lock.json`, `app/frontend/editor/sketch/sketch_modal.tsx`, `app/frontend/editor/sketch/excalidraw_canvas.tsx`, `app/frontend/editor/sketch/export.ts`, `app/frontend/entrypoints/application.css`.
+- **Patterns:** Pin `@excalidraw/excalidraw` to the current compatible 0.18 release; use `React.lazy`/dynamic import for the editor and its CSS; use `initialData`, `onChange`, and `exportToSvg`; preserve focus and close on Escape only after honoring unsaved-change confirmation.
+- **Test scenarios:** New and existing scenes initialize correctly; Cancel is non-mutating; Save returns normalized scene data; mouse/touch/pen pointer paths work; image import is unavailable; Copy/Download SVG produces valid output; narrow iPad viewport remains usable.
+- **Verification:** Type-check, production Vite build, component-level helpers, and Playwright at desktop and tablet viewports.
+
+### U3. Inline node view and editor integration
+
+- **Goal:** Insert and update sketches through the document editor while rendering a lightweight accessible preview in every mode.
+- **Files:** `app/frontend/editor/sketch/index.ts`, `app/frontend/editor/sketch/node_view.ts`, `app/frontend/editor/milkdown_editor.tsx`, `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`.
+- **Patterns:** Register the node plugin beside frontmatter; expose typed insert/update helpers through the existing `EditorHandle`; dispatch node-edit callbacks through an editor context; derive SVG asynchronously and ignore stale exports after node updates/unmount.
+- **Test scenarios:** Insert at selection, reopen selected node, save replacement, keyboard activation, read-only behavior by mode, undo/redo, copy-clean behavior, remote peer update, reconnect, and reload all preserve the scene.
+- **Verification:** Existing editor regressions plus a two-page Playwright collaboration scenario.
+
+### U4. Agent parity and end-to-end release coverage
+
+- **Goal:** Prove sketches remain useful and safe across human UI, agent API, production serialization, and existing editor features.
+- **Files:** `test/services/html_document_sanitizer_test.rb`, `test/services/document_plain_text_test.rb`, `test/integration/agent_discovery_test.rb`, `test/integration/agent_api_test.rb`, `test/integration/snapshot_test.rb`, `script/browser_check.mjs`, `README.md` if the public feature list needs updating.
+- **Patterns:** Extend the existing browser smoke document instead of creating a disconnected harness; assert the API contract in integration tests; keep tests deterministic by using a small fixture scene.
+- **Test scenarios:** Human insert/edit/export, agent fetch, Markdown and HTML snapshots, two-client sync, refresh persistence, all four modes, malformed payload defense, content-size failure, title updates, links, tasks, and clean copy remain correct.
+- **Verification:** Full Rails suite, `npm run check`, HTML/link checks, production asset build, browser pipeline, and a final scoped security review.
+
+## System-wide impact
+
+- **Data and persistence:** No migration or new table. Scene JSON increases Yjs and snapshot size, bounded per sketch and by the existing 2 MB document limit.
+- **Collaboration:** Pointer movements remain local; Save produces one atom insert/replace that Yjs broadcasts. Two people saving the same sketch concurrently use last-save-wins semantics.
+- **Agents:** Source responses contain an explicit, versioned sketch block; plain-text responses surface only human-readable semantics. The agent guide gains examples and limits.
+- **Security:** SVG is generated from validated Excalidraw elements in the browser and is never trusted as source. HTML snapshot metadata is restored only through the trusted snapshot path.
+- **Performance:** The editor schema and preview renderer add a small baseline cost; the large Excalidraw bundle loads only on first edit. Preview exports should be cached by scene hash within the node view.
+- **Accessibility:** Figures have captions/labels, node controls are keyboard reachable in Edit mode, the modal traps/restores focus, and non-edit modes remain readable.
+
+## Risks and dependencies
+
+- Excalidraw scene JSON can grow quickly. Enforce byte, element, and point-count limits before save and test near the aggregate 2 MB snapshot boundary.
+- Excalidraw is client-only and references browser globals. Keep all package imports behind the lazy client component so Vite/Inertia initialization and tests do not evaluate it eagerly.
+- A JSON attribute in HTML must be escaped consistently by DOM serialization and Rails sanitization. Round-trip tests must include quotes, Unicode, newlines, and hostile strings.
+- ProseMirror node views are not used by `DOMSerializer`; schema `toDOM` must emit the canonical HTML figure independently of the richer runtime preview.
+- Apple Pencil support depends on iPad Safari Pointer Events. Automated tests can verify pen events and responsive behavior, but a short physical-device pass remains a release check.
+- Existing suggestion machinery is text-mark based. Sketch mutation stays Edit-only until atomic-node suggestion semantics are designed explicitly.
+
+## Release and verification notes
+
+- Keep both `thinkroom.kieranklaassen.com` and the legacy `pruf.kieranklaassen.com` working; no deployment identifier or persistent volume rename is part of this feature.
+- Verify initial document load does not fetch the Excalidraw application chunk; opening Sketch should fetch it once.
+- On a physical iPad, verify Pencil free-draw, finger pan/zoom behavior, modal sizing, Save, reload, and SVG export before declaring the release complete.
+- Deploy only after CI and the browser pipeline are green, then smoke-test one disposable document on the Thinkroom production hostname.
+
+## Sources and research
+
+- `STRATEGY.md` for the product requirement that Thinkroom support deliberate human thinking and agent-readable work without embedding an agent.
+- `app/frontend/editor/frontmatter/index.ts` for the existing atomic Milkdown node and Markdown round-trip pattern.
+- `app/frontend/editor/milkdown_editor.tsx` for Yjs binding, snapshot persistence, mode behavior, and editor callbacks.
+- `app/services/html_document_sanitizer.rb` and `app/frontend/editor/document_format.ts` for the trusted/external content boundaries.
+- Excalidraw integration documentation: https://docs.excalidraw.com/docs/@excalidraw/excalidraw/integration
+- Excalidraw component props: https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props
+- Excalidraw utilities and `exportToSvg`: https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils
+- Excalidraw repository and MIT package release history: https://github.com/excalidraw/excalidraw

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@excalidraw/excalidraw": "^0.18.1",
         "@handlewithcare/prosemirror-suggest-changes": "^0.1.8",
         "@inertiajs/react": "^3.3.1",
         "@inertiajs/vite": "^3.3.1",
@@ -37,6 +38,19 @@
         "playwright": "^1.60.0",
         "vite": "^8.0.16",
         "vite-plugin-ruby": "^5.2.2"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -72,6 +86,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
@@ -84,6 +107,51 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
+      "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.3",
@@ -529,6 +597,438 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@excalidraw/excalidraw": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.18.1.tgz",
+      "integrity": "sha512-6i5Gt7IDTOH//qa0Z315Ly5iVRhjWpu2whrlQFqkuwrkKUWgRsMk0P5qdE7bpyDpai7jeLeWYkyj1eVAfni1lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "6.0.2",
+        "@excalidraw/laser-pointer": "1.3.1",
+        "@excalidraw/mermaid-to-excalidraw": "2.2.2",
+        "@excalidraw/random-username": "1.1.0",
+        "@radix-ui/react-popover": "1.1.6",
+        "@radix-ui/react-tabs": "1.0.2",
+        "browser-fs-access": "0.29.1",
+        "canvas-roundrect-polyfill": "0.0.1",
+        "clsx": "1.1.1",
+        "cross-env": "7.0.3",
+        "es6-promise-pool": "2.5.0",
+        "fractional-indexing": "3.2.0",
+        "fuzzy": "0.1.3",
+        "image-blob-reduce": "3.0.1",
+        "jotai": "2.11.0",
+        "jotai-scope": "0.7.2",
+        "lodash.debounce": "4.0.8",
+        "lodash.throttle": "4.1.1",
+        "nanoid": "3.3.3",
+        "open-color": "1.9.1",
+        "pako": "2.0.3",
+        "perfect-freehand": "1.2.0",
+        "pica": "7.1.1",
+        "png-chunk-text": "1.0.0",
+        "png-chunks-encode": "1.0.0",
+        "png-chunks-extract": "1.0.0",
+        "points-on-curve": "1.0.1",
+        "pwacompat": "2.0.17",
+        "roughjs": "4.6.4",
+        "sass": "1.51.0",
+        "tunnel-rat": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.2.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.2.tgz",
+      "integrity": "sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-direction": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-roving-focus": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+      "integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.2.tgz",
+      "integrity": "sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-collection": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-direction": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
+      "integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "license": "MIT"
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw/node_modules/sass": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@excalidraw/laser-pointer": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@excalidraw/laser-pointer/-/laser-pointer-1.3.1.tgz",
+      "integrity": "sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g==",
+      "license": "MIT"
+    },
+    "node_modules/@excalidraw/markdown-to-text": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz",
+      "integrity": "sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==",
+      "license": "MIT"
+    },
+    "node_modules/@excalidraw/mermaid-to-excalidraw": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-2.2.2.tgz",
+      "integrity": "sha512-5VKQq5CdRocC82vOIUpQ5ufJOVV9FpBTdHGA+ULqazeIVV+cr299877omQCibsdS3Bpitz2fsnTwnIXEmLVDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@excalidraw/markdown-to-text": "0.1.2",
+        "@mermaid-js/parser": "^0.6.3",
+        "mermaid": "^11.12.1",
+        "nanoid": "4.0.2"
+      }
+    },
+    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@excalidraw/random-username": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@excalidraw/random-username/-/random-username-1.1.0.tgz",
+      "integrity": "sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -548,6 +1048,19 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
@@ -564,6 +1077,23 @@
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
         "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@inertiajs/core": {
@@ -840,6 +1370,15 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
+      "integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "3.3.1"
+      }
     },
     "node_modules/@milkdown/components": {
       "version": "7.21.2",
@@ -1305,6 +1844,416 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.6.tgz",
+      "integrity": "sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
     },
     "node_modules/@rails/actioncable": {
       "version": "8.1.300",
@@ -1981,6 +2930,259 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1989,6 +3191,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2078,6 +3286,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -2204,6 +3422,43 @@
       "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
       "license": "MIT"
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2213,6 +3468,42 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-fs-access": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.29.1.tgz",
+      "integrity": "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/canvas-roundrect-polyfill": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/canvas-roundrect-polyfill/-/canvas-roundrect-polyfill-0.0.1.tgz",
+      "integrity": "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==",
+      "license": "MIT"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2252,6 +3543,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.0.3",
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/regexp-to-ast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "@chevrotain/utils": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
       }
     },
     "node_modules/clsx": {
@@ -2297,11 +3614,61 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-0.3.0.tgz",
+      "integrity": "sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2319,6 +3686,520 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2351,6 +4232,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2368,6 +4258,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -2425,6 +4321,15 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/es6-promise-pool": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
+      "integrity": "sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -2486,12 +4391,33 @@
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/fractional-indexing": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz",
+      "integrity": "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -2508,11 +4434,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fuzzy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+      "integrity": "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glur": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
+      "integrity": "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
@@ -2560,6 +4527,94 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/image-blob-reduce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/image-blob-reduce/-/image-blob-reduce-3.0.1.tgz",
+      "integrity": "sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "pica": "^7.1.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -2571,6 +4626,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
@@ -2591,6 +4652,37 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.0.tgz",
+      "integrity": "sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jotai-scope": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/jotai-scope/-/jotai-scope-0.7.2.tgz",
+      "integrity": "sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jotai": ">=2.9.2",
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
@@ -2605,6 +4697,27 @@
       },
       "bin": {
         "katex": "cli.js"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
+      "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.0.3",
+        "chevrotain-allstar": "~0.3.0",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.0.8"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/laravel-precognition": {
@@ -2623,6 +4736,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lib0": {
       "version": "0.2.117",
@@ -2912,6 +5031,18 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -2939,6 +5070,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -3201,6 +5344,90 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/mermaid/node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mermaid/node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/mermaid/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/mermaid/node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/mermaid/node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "node_modules/micromark": {
@@ -3832,6 +6059,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multimath": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multimath/-/multimath-2.0.0.tgz",
+      "integrity": "sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==",
+      "license": "MIT",
+      "dependencies": {
+        "glur": "^1.1.2",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -3848,6 +6085,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/obug": {
@@ -3881,11 +6136,63 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/open-color": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/open-color/-/open-color-1.9.1.tgz",
+      "integrity": "sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==",
+      "license": "MIT"
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.3.tgz",
+      "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/perfect-freehand": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.0.tgz",
+      "integrity": "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==",
+      "license": "MIT"
+    },
+    "node_modules/pica": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/pica/-/pica-7.1.1.tgz",
+      "integrity": "sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "glur": "^1.1.2",
+        "inherits": "^2.0.3",
+        "multimath": "^2.0.0",
+        "object-assign": "^4.1.1",
+        "webworkify": "^1.5.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3951,6 +6258,53 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/png-chunk-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunk-text/-/png-chunk-text-1.0.0.tgz",
+      "integrity": "sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/png-chunks-encode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunks-encode/-/png-chunks-encode-1.0.0.tgz",
+      "integrity": "sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^0.3.0",
+        "sliced": "^1.0.1"
+      }
+    },
+    "node_modules/png-chunks-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunks-extract/-/png-chunks-extract-1.0.0.tgz",
+      "integrity": "sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^0.3.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-1.0.1.tgz",
+      "integrity": "sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/points-on-path/node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -4256,6 +6610,12 @@
         }
       }
     },
+    "node_modules/pwacompat": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/pwacompat/-/pwacompat-2.0.17.tgz",
+      "integrity": "sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -4275,6 +6635,75 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/regex": {
@@ -4426,6 +6855,12 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -4465,11 +6900,62 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/roughjs": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.4.tgz",
+      "integrity": "sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/roughjs/node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shiki": {
       "version": "4.2.0",
@@ -4489,6 +6975,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
+      "deprecated": "Unsupported",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4529,6 +7022,12 @@
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
@@ -4548,6 +7047,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4562,6 +7070,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/trim-lines": {
@@ -4584,12 +7104,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -4705,11 +7242,76 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -4830,6 +7432,55 @@
         "vite": ">=5.0.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.35",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
@@ -4856,6 +7507,27 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/webworkify": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
+      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/y-prosemirror": {
       "version": "1.3.7",
@@ -4931,6 +7603,34 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "vite-plugin-ruby": "^5.2.2"
   },
   "dependencies": {
+    "@excalidraw/excalidraw": "^0.18.1",
     "@handlewithcare/prosemirror-suggest-changes": "^0.1.8",
     "@inertiajs/react": "^3.3.1",
     "@inertiajs/vite": "^3.3.1",
@@ -39,5 +40,22 @@
     "check": "tsc -p tsconfig.app.json && tsc -p tsconfig.node.json",
     "check:html": "node script/html_document_check.mjs",
     "check:links": "node script/link_check.mjs"
+  },
+  "overrides": {
+    "@excalidraw/excalidraw": {
+      "nanoid": "3.3.12"
+    },
+    "@excalidraw/mermaid-to-excalidraw": {
+      "nanoid": "5.1.16"
+    },
+    "@chevrotain/cst-dts-gen": {
+      "lodash-es": "4.18.1"
+    },
+    "@chevrotain/gast": {
+      "lodash-es": "4.18.1"
+    },
+    "chevrotain": {
+      "lodash-es": "4.18.1"
+    }
   }
 }

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -268,6 +268,143 @@ try {
   await taskA.close()
   await taskB.close()
 
+  // Inline sketches: Excalidraw loads only on demand, Save creates one atom
+  // update, the lightweight SVG preview syncs, and agent-readable source
+  // survives reload. Non-edit modes remain preview-only.
+  const sketchDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Sketch check', markdown: '# Sketch check\n\nBody.\n' }),
+    })
+  ).json()
+  const sketchA = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+  const sketchB = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+  await Promise.all([
+    sketchA.goto(`${BASE}/d/${sketchDoc.slug}`),
+    sketchB.goto(`${BASE}/d/${sketchDoc.slug}`),
+  ])
+  await Promise.all([
+    sketchA.waitForSelector('.doc-status--live', { timeout: 15000 }),
+    sketchB.waitForSelector('.doc-status--live', { timeout: 15000 }),
+  ])
+  await sketchA.getByRole('button', { name: 'Sketch', exact: true }).click()
+  await sketchA.locator('.excalidraw').waitFor({ timeout: 15000 })
+  ok('sketch action lazy-loads the Excalidraw canvas')
+  await sketchA.getByTitle('Rectangle — R or 2').click()
+  const sketchCanvas = sketchA.locator('.excalidraw canvas').last()
+  const sketchBox = await sketchCanvas.boundingBox()
+  if (sketchBox) {
+    await sketchA.mouse.move(sketchBox.x + 300, sketchBox.y + 180)
+    await sketchA.mouse.down()
+    await sketchA.mouse.move(sketchBox.x + 520, sketchBox.y + 320, { steps: 8 })
+    await sketchA.mouse.up()
+  } else {
+    fail('Excalidraw canvas has no drawable bounds')
+  }
+  const sketchDescription = `Approval flow ${Date.now()}`
+  await sketchA.getByPlaceholder('e.g. Signup approval flow').fill(sketchDescription)
+  await sketchA.getByRole('button', { name: 'Save sketch' }).click()
+  await sketchA.locator('.thinkroom-sketch .sketch-preview-svg').waitFor({ timeout: 5000 })
+  await sketchB
+    .locator('.thinkroom-sketch-caption', { hasText: sketchDescription })
+    .waitFor({ timeout: 10000 })
+  ok('saved sketch renders as SVG and syncs to another editor')
+
+  let sketchState = null
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    sketchState = await (await fetch(`${BASE}/api/docs/${sketchDoc.slug}`)).json()
+    if (sketchState.content?.includes('```excalidraw') && sketchState.plain_text?.includes(sketchDescription)) break
+    await sketchA.waitForTimeout(250)
+  }
+  if (
+    sketchState?.content?.includes('```excalidraw') &&
+    sketchState.content.includes('"elements":[{"id"') &&
+    sketchState.plain_text.includes(sketchDescription)
+  ) {
+    ok('sketch source and human-readable semantics persist for agents')
+  } else {
+    fail(`sketch API contract did not persist: ${JSON.stringify(sketchState)}`)
+  }
+
+  await sketchA.reload()
+  await sketchA.locator('.thinkroom-sketch .sketch-preview-svg').waitFor({ timeout: 15000 })
+  if ((await sketchA.locator('.thinkroom-sketch-caption').innerText()) === sketchDescription) {
+    ok('editable sketch scene survives reload')
+  } else {
+    fail('sketch description or scene was lost on reload')
+  }
+  await sketchA.getByRole('button', { name: /Mode:/ }).click()
+  await sketchA.getByRole('option', { name: /^Read/ }).click()
+  await sketchA.locator('.thinkroom-sketch').click()
+  await sketchA.waitForTimeout(150)
+  if ((await sketchA.getByRole('dialog').count()) === 0) {
+    ok('Read mode keeps sketches preview-only')
+  } else {
+    fail('Read mode opened the sketch editor')
+  }
+  await sketchB.locator('.thinkroom-sketch').click()
+  await sketchB.getByRole('button', { name: 'Delete', exact: true }).click()
+  await sketchA.locator('.thinkroom-sketch').waitFor({ state: 'detached', timeout: 10000 })
+  await sketchB.reload()
+  if ((await sketchB.locator('.thinkroom-sketch').count()) === 0) {
+    ok('deleting a sketch syncs and survives reload')
+  } else {
+    fail('deleted sketch returned after reload')
+  }
+  await sketchA.close()
+  await sketchB.close()
+
+  const malformedSketch = JSON.stringify({
+    id: 'malformed_points',
+    formatVersion: 1,
+    description: 'Malformed sketch',
+    scene: {
+      type: 'excalidraw',
+      version: 2,
+      elements: [{ type: 'arrow', points: [null, null] }],
+      appState: {},
+      files: {},
+    },
+  })
+  const malformedDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Malformed sketch check',
+        markdown: `\`\`\`excalidraw\n${malformedSketch}\n\`\`\`\n`,
+      }),
+    })
+  ).json()
+  const malformedPage = await browser.newPage()
+  await malformedPage.goto(`${BASE}/d/${malformedDoc.slug}`)
+  await malformedPage.waitForSelector('.doc-status--live', { timeout: 15000 })
+  if (
+    (await malformedPage.locator('.thinkroom-sketch').count()) === 0 &&
+    (await malformedPage.locator('pre code').innerText()).includes('malformed_points')
+  ) {
+    ok('invalid sketch source stays visible without crashing the document')
+  } else {
+    fail('invalid sketch source was hidden or treated as an executable sketch')
+  }
+  await malformedPage.close()
+
+  const failedChunkContext = await browser.newContext()
+  const failedChunkPage = await failedChunkContext.newPage()
+  await failedChunkPage.route('**/vite-dev/editor/sketch/excalidraw_canvas.tsx*', (route) =>
+    route.abort(),
+  )
+  await failedChunkPage.goto(`${BASE}/d/${malformedDoc.slug}`)
+  await failedChunkPage.getByRole('button', { name: 'Sketch', exact: true }).click()
+  await failedChunkPage.locator('.sketch-load-error').waitFor({ timeout: 15000 })
+  if ((await failedChunkPage.locator('.milkdown .ProseMirror').count()) === 1) {
+    ok('canvas chunk failure leaves the document mounted')
+  } else {
+    fail('canvas chunk failure unmounted the document editor')
+  }
+  await failedChunkContext.close()
+
   // Clipboard: users should get portable Markdown, not Thinkroom's internal
   // provenance/suggestion wrappers. Ordinary Markdown formatting must stay.
   const clipboardDoc = await (

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -85,8 +85,11 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "html", contract["content_format"]
     assert_equal "content", contract["canonical_source_field"]
     assert_equal "plain_text", contract["rendered_text_field"]
+    assert_equal ThinkroomSketch::MAX_SCENE_BYTES,
+                 contract.dig("sketches", "limits", "scene_max_bytes")
     assert_includes contract.dig("html", "allowed_elements"), "table"
     assert_includes contract.dig("html", "allowed_elements"), "img"
+    assert_includes contract.dig("html", "allowed_elements"), "figure"
     assert_includes contract.dig("html", "css", "supported"), "text-align"
     assert_includes contract.dig("html", "css", "removed"), "<style> blocks"
     assert_equal "/api/uploads", URI(contract.dig("html", "images", "upload", "url")).path

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -55,6 +55,9 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert body["notes"].any? { |n| n.include?("content is canonical Markdown source") }
     assert body["notes"].any? { |n| n.include?("unique quote from plain_text") }
     assert_equal "markdown", body.dig("content_contract", "suggestion_body_format")
+    assert_includes body.dig("content_contract", "sketches", "markdown_source"), "excalidraw"
+    assert_equal false, body.dig("content_contract", "sketches", "limits", "embedded_images")
+    assert body["notes"].any? { |n| n.include?("inline Excalidraw") }
     refute body.dig("content_contract").key?("html")
   end
 
@@ -110,6 +113,7 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "canonical source in \"content\""
     assert_includes response.body, "ProseMirror/Yjs is"
     assert_includes response.body, "do not send editor JSON or CRDT data"
+    assert_includes response.body, "Inline Excalidraw sketches"
     assert_includes response.body, "missing or ambiguous replacement stays"
     assert_includes response.body, "creation permits no header"
     assert_includes response.body, "## HTML, CSS, and images"

--- a/test/integration/snapshot_test.rb
+++ b/test/integration/snapshot_test.rb
@@ -68,6 +68,30 @@ class SnapshotTest < ActionDispatch::IntegrationTest
     refute_match(/onclick|script/, content)
   end
 
+  test "HTML snapshot preserves a valid sketch and exposes its semantics" do
+    document = Document.create!(
+      title: "HTML sketch",
+      content_format: "html",
+      content_snapshot: "<p>original</p>"
+    )
+    scene = {
+      type: "excalidraw", version: 2,
+      elements: [ { type: "text", text: "Review" }, { type: "rectangle" } ],
+      appState: { viewBackgroundColor: "#ffffff" }, files: {}
+    }.to_json
+    figure = %(<figure data-thinkroom-sketch data-sketch-id="flow_1" data-format-version="1" data-description="Approval flow" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Approval flow</figcaption></figure>)
+
+    post document_snapshot_path(document.slug), params: {
+      content: "<p>Before</p>#{figure}<p>After</p>",
+      spans: [],
+      state_vector: Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+    }, as: :json
+
+    assert_response :ok
+    assert_includes document.reload.content_snapshot, "data-thinkroom-sketch"
+    assert_equal "Before Sketch: Approval flow — Review After", document.plain_text
+  end
+
   test "HTML snapshot claims an image uploaded by the browser API" do
     upload = Tempfile.new([ "snapshot-image", ".png" ])
     upload.binmode

--- a/test/services/document_plain_text_test.rb
+++ b/test/services/document_plain_text_test.rb
@@ -31,4 +31,31 @@ class DocumentPlainTextTest < ActiveSupport::TestCase
     assert_equal "Before robot and new",
                  DocumentPlainText.call(format: "markdown", content: source)
   end
+
+  test "extracts sketch description and labels without exposing scene JSON" do
+    scene = {
+      type: "excalidraw", version: 2,
+      elements: [
+        { type: "rectangle" },
+        { type: "text", text: "Draft" },
+        { type: "text", text: "Review" }
+      ],
+      appState: {}, files: {}
+    }
+    markdown = <<~MARKDOWN
+      Before
+
+      ```excalidraw
+      #{JSON.generate({ id: "approval_1", formatVersion: 1, description: "Approval flow", scene: })}
+      ```
+
+      After
+    MARKDOWN
+    html = %(<p>Before</p><figure data-thinkroom-sketch data-sketch-id="approval_1" data-format-version="1" data-description="Approval flow" data-scene="#{CGI.escapeHTML(scene.to_json)}"><figcaption>Approval flow</figcaption></figure><p>After</p>)
+
+    assert_equal "Before Sketch: Approval flow — Draft, Review After",
+                 DocumentPlainText.call(format: "markdown", content: markdown)
+    assert_equal "Before Sketch: Approval flow — Draft, Review After",
+                 DocumentPlainText.call(format: "html", content: html)
+  end
 end

--- a/test/services/html_document_sanitizer_test.rb
+++ b/test/services/html_document_sanitizer_test.rb
@@ -120,4 +120,72 @@ class HtmlDocumentSanitizerTest < ActiveSupport::TestCase
     assert_equal "text-align: right", fragment.at_css("th")["style"]
     assert_nil fragment.css("td")[1]["style"]
   end
+
+  test "trusted snapshots preserve valid sketch data but external html cannot forge it" do
+    scene = {
+      type: "excalidraw", version: 2, elements: [ { type: "text", text: "Review" } ],
+      appState: {}, files: {}
+    }.to_json
+    source = %(<figure data-thinkroom-sketch data-sketch-id="flow_1" data-format-version="1" data-description="Flow" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Flow</figcaption></figure>)
+
+    trusted = HtmlDocumentSanitizer.snapshot(source).content
+    external = HtmlDocumentSanitizer.external(source).content
+
+    assert_includes trusted, "data-thinkroom-sketch"
+    assert_includes trusted, "data-scene="
+    assert_includes trusted, "<figcaption>Flow</figcaption>"
+    refute_match(/data-thinkroom-sketch|data-scene|data-description|data-format-version/, external)
+    assert_includes external, "<figcaption>Flow</figcaption>"
+  end
+
+  test "trusted snapshots strip malformed or unsafe sketch data" do
+    scene = {
+      type: "excalidraw", version: 2,
+      elements: [ { type: "image", fileId: "remote" } ], files: { remote: {} }
+    }.to_json
+    source = %(<figure data-thinkroom-sketch data-sketch-id="unsafe_1" data-format-version="1" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Unsafe</figcaption></figure>)
+
+    result = HtmlDocumentSanitizer.snapshot(source).content
+
+    refute_match(/data-thinkroom-sketch|data-scene|data-format-version/, result)
+    assert_includes result, "Unsafe"
+  end
+
+  test "trusted snapshots strip sketches with oversized descriptions" do
+    scene = { type: "excalidraw", version: 2, elements: [], appState: {}, files: {} }.to_json
+    source = %(<figure data-thinkroom-sketch data-sketch-id="oversized" data-format-version="1" data-description="#{"a" * 501}" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Visible fallback</figcaption></figure>)
+
+    result = HtmlDocumentSanitizer.snapshot(source).content
+
+    refute_match(/data-thinkroom-sketch|data-scene|data-description/, result)
+    assert_includes result, "Visible fallback"
+  end
+
+  test "trusted snapshots strip sketch colors that could reference remote resources" do
+    scene = {
+      type: "excalidraw", version: 2,
+      elements: [ { type: "rectangle", strokeColor: "url(https://tracker.example/paint)" } ],
+      appState: {}, files: {}
+    }.to_json
+    source = %(<figure data-thinkroom-sketch data-sketch-id="remote_color" data-format-version="1" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Visible fallback</figcaption></figure>)
+
+    result = HtmlDocumentSanitizer.snapshot(source).content
+
+    refute_match(/data-thinkroom-sketch|tracker\.example/, result)
+    assert_includes result, "Visible fallback"
+  end
+
+  test "trusted snapshots strip malformed sketch point tuples" do
+    scene = {
+      type: "excalidraw", version: 2,
+      elements: [ { type: "arrow", points: [ nil, [ 1, 2 ] ] } ],
+      appState: {}, files: {}
+    }.to_json
+    source = %(<figure data-thinkroom-sketch data-sketch-id="bad_points" data-format-version="1" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Visible fallback</figcaption></figure>)
+
+    result = HtmlDocumentSanitizer.snapshot(source).content
+
+    refute_match(/data-thinkroom-sketch|data-scene/, result)
+    assert_includes result, "Visible fallback"
+  end
 end


### PR DESCRIPTION
## Summary

Thinkroom documents can now hold editable visual thinking alongside prose: people can insert an Excalidraw sketch, draw with mouse, touch, or Apple Pencil, save it inline, reopen it, and copy or download a scalable SVG. Sketches sync through the existing Yjs document, survive reloads, stay clean in Read/Comment/Suggest modes, and expose descriptions plus text labels to agents through the existing source and plain-text APIs.

## Design decisions

- The editable Excalidraw scene is canonical; SVG remains derived output for previews and export.
- A lightweight SVG renderer keeps normal document loads small. The full Excalidraw application loads only when someone opens a sketch.
- Canvas pointer movement stays local. Save creates one atomic collaborative update, avoiding high-frequency Yjs traffic while drawing.
- Markdown uses a versioned `excalidraw` fence and HTML uses trusted figure metadata. Invalid or future-version fences remain visible code rather than being discarded.
- Embedded bitmap files, remote links, unsafe SVG input, oversized scenes, and malformed point data are rejected at client and server boundaries.
- Dependency overrides keep the current React-compatible Excalidraw release while satisfying the repository's production audit gate.

## Validation

- `npm run check`
- `npm audit --omit=dev --audit-level=moderate`
- Focused sanitizer, plain-text, snapshot, agent-discovery, and agent-API Rails tests
- Production Vite build
- Browser coverage for create, draw, save, live two-client sync, reload, mode restrictions, agent-readable source, SVG export, delete, invalid-source fallback, and lazy-chunk failure
- Headless browser pipeline on a fresh local server port

Physical Apple Pencil pressure remains a release smoke check on iPad Safari; the implementation uses Excalidraw's Pointer Events path and does not require PencilKit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
