### PR TITLE
fix(editor): instant first paint with zero layout shift

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -19,5 +19,23 @@ module Api
     rescue ActionController::ParameterMissing
       render json: { error: "body is required — what you want to say." }, status: :unprocessable_entity
     end
+
+    # POST /api/docs/:slug/comments/:id/resolve — close a comment thread.
+    # The web UI resolves over a CSRF-protected Inertia request; agents get the
+    # same capability here over plain HTTP, attributed via X-Agent-Name.
+    def resolve
+      comment = document.comments.find(params[:id])
+      comment.resolve!
+      Activity.log!(
+        document:, actor_name: current_agent, actor_kind: "agent",
+        action: "resolved_comment", detail: comment.body.truncate(80)
+      )
+      DocumentMetaChannel.broadcast_event(document, :comments)
+      touch_presence(location: comment.anchor_text)
+
+      render json: { comment: comment.as_props }
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "No comment with that id on this document." }, status: :not_found
+    end
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -63,6 +63,12 @@ class DocumentsController < InertiaController
         seed_author_name: document.seed_author_name,
         has_state: document.yjs_state.present?,
         yjs_state_b64: (Base64.strict_encode64(document.yjs_state) if document.yjs_state.present?),
+        # Server-rendered prose for an instant first paint; the live editor
+        # swaps in over it once Milkdown binds the hydrated Yjs state.
+        content_html: document.preview_html,
+        # First-H1 title derived on the server so the header reads correctly on
+        # first paint, before the editor mounts and derives the same title.
+        display_title: document.display_title,
         **(document.content_format == "markdown" ? { seed_markdown: document.seed_content } : {})
       ),
       # Ownership rides its own lazy prop so claim events reload cheaply —

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -88,7 +88,6 @@ export interface EditorHandle {
   editor: Editor
   ydoc: Y.Doc
   provider: CableProvider
-  openSketch: () => void
 }
 
 export type ConnectionStatus = 'connecting' | 'live'
@@ -562,7 +561,7 @@ function CollabEditor({
         if (title) callbacksRef.current.onTitleChange?.(title)
       })
 
-      const handle = { editor, ydoc, provider, openSketch: () => insertSketchRef.current() }
+      const handle = { editor, ydoc, provider }
       startedRef.current = true
       // Seed/initial sync ran with suggesting off; apply a pre-stored
       // suggest mode only now that the document content is settled.

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -749,9 +749,11 @@ a:focus-visible {
   inset: 0;
 }
 
-/* While booting the editor has no content yet; don't let the empty overlay
-   intercept pointer events meant for the (inert) preview underneath. */
-.doc-editor-stack[data-phase='booting'] .doc-live-editor {
+/* While the preview is still mounted underneath (booting + revealing), the
+   live editor overlays it; don't let that overlay intercept pointer events
+   meant for the content until it fully takes over the flow at 'live'. */
+.doc-editor-stack[data-phase='booting'] .doc-live-editor,
+.doc-editor-stack[data-phase='revealing'] .doc-live-editor {
   pointer-events: none;
 }
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -729,6 +729,44 @@ a:focus-visible {
   min-height: 50vh;
 }
 
+/* Instant first paint: a server-rendered prose preview and the live editor
+   share one stacking context. The preview (in flow) holds the layout height;
+   the live editor overlays it while Milkdown boots and binds the synced state,
+   painting its content directly over the identical preview. Once painted, the
+   preview is dropped and the editor returns to normal flow. The preview stays
+   behind the editor until that handoff, so content is never blank — it is
+   replaced, not deleted and re-added. */
+.doc-editor-stack {
+  position: relative;
+  min-height: 50vh;
+}
+
+/* booting + revealing: editor is an absolute overlay above the in-flow preview.
+   It is transparent, so the preview shows through any not-yet-painted region. */
+.doc-editor-stack[data-phase='booting'] .doc-live-editor,
+.doc-editor-stack[data-phase='revealing'] .doc-live-editor {
+  position: absolute;
+  inset: 0;
+}
+
+/* While booting the editor has no content yet; don't let the empty overlay
+   intercept pointer events meant for the (inert) preview underneath. */
+.doc-editor-stack[data-phase='booting'] .doc-live-editor {
+  pointer-events: none;
+}
+
+.doc-static-preview {
+  user-select: none;
+}
+
+/* Neutral box standing in for a sketch canvas until Excalidraw mounts, so a
+   sketch doc reserves the right height instead of reflowing on swap. */
+.doc-sketch-skeleton {
+  margin: 1.5rem 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
 .milkdown .ProseMirror {
   outline: none;
   font-family: var(--font-doc);
@@ -2925,25 +2963,6 @@ a:focus-visible {
   font-size: 12px;
 }
 
-.sketch-insert-button {
-  min-height: 30px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: transparent;
-  color: var(--ink);
-  padding: 5px 9px;
-  font: 500 12px/1 var(--font-ui);
-  cursor: pointer;
-}
-
-.sketch-insert-button:hover:not(:disabled) {
-  background: var(--surface);
-}
-
-.sketch-insert-button:disabled {
-  opacity: 0.45;
-}
-
 .thinkroom-sketch {
   isolation: isolate;
   position: relative;
@@ -3250,7 +3269,6 @@ a:focus-visible {
 }
 
 @media (max-width: 700px) {
-  .sketch-insert-button { padding-inline: 7px; }
   .thinkroom-sketch { margin: 18px 0; border-radius: 9px; }
   .thinkroom-sketch-preview { min-height: 150px; }
 }

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -88,6 +88,8 @@ export interface DocumentProps {
     seed_author_name: string | null
     has_state: boolean
     yjs_state_b64: string | null
+    content_html: string
+    display_title: string
   }
   viewer: ViewerPayload
   ownership: OwnershipPayload
@@ -149,10 +151,20 @@ export default function DocumentShow({
   // `viewer` would silently clobber mid-rename.
   const [identity, setIdentity] = useState<UserIdentity>(() => userIdentity(viewer.name))
   const [guest, setGuest] = useState(viewer.guest)
-  const [status, setStatus] = useState<ConnectionStatus>('connecting')
-  const [documentTitle, setDocumentTitle] = useState(doc.title)
+  // Optimistic: a hydrated or freshly-seeded doc is functionally live the
+  // moment it paints — the websocket only confirms it. Starting at 'live'
+  // avoids the connecting→live dot flash on every load.
+  const [status, setStatus] = useState<ConnectionStatus>(
+    doc.has_state || doc.seed_granted ? 'live' : 'connecting',
+  )
+  // Server-derived first-H1 title so the header reads correctly on first paint;
+  // the editor keeps it live via onTitleChange once it mounts.
+  const [documentTitle, setDocumentTitle] = useState(doc.display_title || doc.title)
   const [newVersionAvailable, setNewVersionAvailable] = useState(false)
   const [handle, setHandle] = useState<EditorHandle | null>(null)
+  // Drops the static first-paint preview only after the live editor has painted
+  // its synced content — so the preview is replaced, never briefly deleted.
+  const [editorSwapped, setEditorSwapped] = useState(false)
   const [spans, setSpans] = useState<ProvenanceSpan[]>([])
   const [peers, setPeers] = useState<UserIdentity[]>([])
   const [reviewTarget, setReviewTarget] = useState<ReviewTarget | null>(null)
@@ -963,16 +975,6 @@ export default function DocumentShow({
                 {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
               </button>
             )}
-            {mode === 'edit' && (
-              <button
-                type="button"
-                className="sketch-insert-button"
-                disabled={!handle}
-                onClick={() => handle?.openSketch()}
-              >
-                Sketch
-              </button>
-            )}
             <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
             <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
             <HeaderMenu
@@ -1005,24 +1007,52 @@ export default function DocumentShow({
         <main className="doc-body">
           <div className={`doc-canvas ${focusMode ? 'is-focus' : ''}`}>
             <article className="doc-main">
-              <DocumentEditor
-                slug={doc.slug}
-                identity={identity}
-                contentFormat={doc.content_format}
-                initialStateB64={doc.yjs_state_b64}
-                seedContent={doc.seed_content}
-                seedGranted={doc.seed_granted}
-                seedAuthorKind={doc.seed_author_kind}
-                seedAuthorName={doc.seed_author_name}
-                editable={mode === 'edit' || mode === 'suggest'}
-                suggesting={mode === 'suggest'}
-                taskInteractive={mode !== 'comment'}
-                onReady={setHandle}
-                onStatus={setStatus}
-                onSpans={setSpans}
-                onSelection={isReading ? undefined : handleSelection}
-                onTitleChange={setDocumentTitle}
-              />
+              {/* Instant first paint: server-rendered prose fills the reserved
+                  editor frame and holds the layout height. The live editor sits
+                  on top of it (transparent) while Milkdown boots, so its synced
+                  content paints over the identical preview — then the preview is
+                  dropped a couple frames later. The preview is always behind the
+                  editor until then, so content is never momentarily blank. */}
+              <div
+                className="doc-editor-stack"
+                data-phase={editorSwapped ? 'live' : handle ? 'revealing' : 'booting'}
+              >
+                {!editorSwapped && doc.content_html && (
+                  <div className="doc-static-preview milkdown" aria-hidden="true">
+                    <div
+                      className="ProseMirror"
+                      dangerouslySetInnerHTML={{ __html: doc.content_html }}
+                    />
+                  </div>
+                )}
+                <div className="doc-live-editor">
+                  <DocumentEditor
+                    slug={doc.slug}
+                    identity={identity}
+                    contentFormat={doc.content_format}
+                    initialStateB64={doc.yjs_state_b64}
+                    seedContent={doc.seed_content}
+                    seedGranted={doc.seed_granted}
+                    seedAuthorKind={doc.seed_author_kind}
+                    seedAuthorName={doc.seed_author_name}
+                    editable={mode === 'edit' || mode === 'suggest'}
+                    suggesting={mode === 'suggest'}
+                    taskInteractive={mode !== 'comment'}
+                    onReady={(h) => {
+                      setHandle(h)
+                      // Wait two frames so ProseMirror has painted the synced
+                      // content before the preview is removed.
+                      requestAnimationFrame(() =>
+                        requestAnimationFrame(() => setEditorSwapped(true)),
+                      )
+                    }}
+                    onStatus={setStatus}
+                    onSpans={setSpans}
+                    onSelection={isReading ? undefined : handleSelection}
+                    onTitleChange={setDocumentTitle}
+                  />
+                </div>
+              </div>
             </article>
             {!isReading && (
               <div className="margin-gutter">

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -76,6 +76,22 @@ class Document < ApplicationRecord
     DocumentPlainText.call(format: content_format, content: current_content)
   end
 
+  # Sanitized HTML of the current content, painted on first load so the editor
+  # frame shows real text before Milkdown finishes binding the hydrated state.
+  def preview_html
+    DocumentPreviewHtml.call(format: content_format, content: current_content)
+  end
+
+  # The title to show before the editor mounts. The editor derives the header
+  # title from the document's first H1; deriving the same thing here means the
+  # header reads correctly on first paint instead of flashing the stored title.
+  def display_title
+    content = current_content
+    return title if content.blank?
+
+    DocumentTitle.call(format: content_format, content: content).presence || title
+  end
+
   def claimed? = user_id.present? || owner_token.present?
 
   def claimable? = !claimed? && UNCLAIMABLE_SLUGS.exclude?(slug)

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -76,6 +76,11 @@ class AgentGuide
                    rate_limits: contribution_rate_limits,
                    body: { body: "(required) what you want to say", anchor_text: "(optional) the doc text you're commenting on" },
                    purpose: "Leave a comment anchored to a text selection." },
+        resolve_comment: { method: "POST", url: "#{api_base}/comments/:id/resolve",
+                           headers: { "X-Agent-Name": "required" },
+                           success_status: 200,
+                           rate_limits: contribution_rate_limits,
+                           purpose: "Close a comment thread (the id comes from open_comments). Attributed to you in the activity feed." },
         announce_presence: { method: "POST", url: "#{api_base}/presence",
                              headers: { "X-Agent-Name": "required", "Content-Type": "application/json" },
                              success_status: 200,
@@ -259,6 +264,9 @@ class AgentGuide
            curl -X POST #{api_base}/comments \\
              -H "X-Agent-Name: YOUR_NAME" -H "Content-Type: application/json" \\
              -d '{"body": "Consider a source here.", "anchor_text": "the text you mean"}'
+
+           Resolve a thread once it's addressed (id comes from open_comments):
+           curl -X POST #{api_base}/comments/COMMENT_ID/resolve -H "X-Agent-Name: YOUR_NAME"
 
         5. React to humans (poll + ack):
            curl #{api_base}/events/pending -H "X-Agent-Name: YOUR_NAME"

--- a/app/services/document_preview_html.rb
+++ b/app/services/document_preview_html.rb
@@ -16,8 +16,13 @@ class DocumentPreviewHtml
       html = if format == "html"
         source
       else
+        # header_ids: nil drops Commonmarker's empty heading anchor (<a class=
+        # "anchor">). The live Milkdown editor renders a bare <h1>, so without
+        # this the preview's heading is structurally taller and the first
+        # paragraph jumps ~30px when the editor swaps in.
         Commonmarker.to_html(
           source,
+          options: { extension: { header_ids: nil } },
           plugins: { table: true, strikethrough: true, tasklist: true }
         )
       end
@@ -26,11 +31,39 @@ class DocumentPreviewHtml
       # it is sanitized before it can reach dangerouslySetInnerHTML on the client.
       sanitized = HtmlDocumentSanitizer.snapshot(html).content
       fragment = Nokogiri::HTML5.fragment(sanitized)
+      collapse_block_whitespace(fragment)
       skeletonize_sketches(fragment, format:)
       fragment.to_html
     end
 
     private
+
+    # Block containers whose children are block elements; the whitespace between
+    # those children is the markdown renderer's pretty-printing, never content.
+    WHITESPACE_BLOCK_PARENTS = %w[
+      ul ol li blockquote table thead tbody tr figure dl
+    ].freeze
+
+    # ProseMirror's DOM carries no whitespace text nodes between block elements,
+    # but Commonmarker pretty-prints a "\n" between each one. The editor renders
+    # with white-space: break-spaces, so in the preview those newlines become
+    # phantom blank lines and the first paragraph sits ~30px too low until the
+    # live editor swaps in. Drop the inter-block whitespace so the preview's box
+    # model matches the editor exactly. Inline whitespace (inside p, headings)
+    # and pre/code contents are left untouched.
+    def collapse_block_whitespace(fragment)
+      fragment.xpath(".//text()").each do |node|
+        next unless node.content.match?(/\A\s*\z/)
+
+        parent = node.parent
+        next unless parent
+        next if parent.name == "pre" || parent.name == "code"
+
+        if parent.name == "#document-fragment" || WHITESPACE_BLOCK_PARENTS.include?(parent.name)
+          node.remove
+        end
+      end
+    end
 
     # Replace each sketch with a neutral, height-reserving box. The preview can't
     # run Excalidraw, so without this a markdown doc would flash raw scene JSON
@@ -58,9 +91,17 @@ class DocumentPreviewHtml
       end
     end
 
+    # Match only a real sketch payload, not any code block that happens to hold
+    # JSON with a "scene" key. The live editor keys sketches on a lang=excalidraw
+    # fence, but the sanitizer strips that hint — so mirror the sketch wrapper
+    # shape instead (a formatVersion plus an excalidraw scene). Otherwise a
+    # JSON/Ruby code sample gets erased into a blank skeleton on first paint.
     def parse_scene(text)
       data = JSON.parse(text)
-      data if data.is_a?(Hash) && data.key?("scene")
+      return nil unless data.is_a?(Hash) && data.key?("formatVersion")
+
+      scene = data["scene"]
+      data if scene.is_a?(Hash) && scene["type"] == "excalidraw"
     rescue JSON::ParserError
       nil
     end

--- a/app/services/document_preview_html.rb
+++ b/app/services/document_preview_html.rb
@@ -1,0 +1,83 @@
+# Server-rendered HTML for the document's current content, painted instantly on
+# page load so the editor frame shows real text before Milkdown finishes its
+# async boot. The live editor (hydrated from yjs_state) swaps in over this once
+# it is ready; because both render the same content into the same prose styles,
+# the swap is seamless. See app/frontend/pages/documents/show.tsx (doc-editor-stack).
+class DocumentPreviewHtml
+  DEFAULT_SKETCH_HEIGHT = 448
+  MIN_SKETCH_HEIGHT = 180
+  MAX_SKETCH_HEIGHT = 1200
+
+  class << self
+    def call(format:, content:)
+      source = content.to_s
+      return "" if source.blank?
+
+      html = if format == "html"
+        source
+      else
+        Commonmarker.to_html(
+          source,
+          plugins: { table: true, strikethrough: true, tasklist: true }
+        )
+      end
+
+      # Security boundary: document content is authored by humans and agents, so
+      # it is sanitized before it can reach dangerouslySetInnerHTML on the client.
+      sanitized = HtmlDocumentSanitizer.snapshot(html).content
+      fragment = Nokogiri::HTML5.fragment(sanitized)
+      skeletonize_sketches(fragment, format:)
+      fragment.to_html
+    end
+
+    private
+
+    # Replace each sketch with a neutral, height-reserving box. The preview can't
+    # run Excalidraw, so without this a markdown doc would flash raw scene JSON
+    # and an HTML doc would collapse the canvas — both reflow when the live editor
+    # mounts the real sketch. A fixed-height placeholder keeps the layout stable.
+    # Runs post-sanitize, so the injected inline height is trusted, not user input.
+    def skeletonize_sketches(fragment, format:)
+      sketch_nodes(fragment, format:).each do |node, height|
+        node.replace(skeleton(node.document, height))
+      end
+    end
+
+    def sketch_nodes(fragment, format:)
+      if format == "html"
+        fragment.css("figure[data-thinkroom-sketch]").map do |node|
+          [ node, clamp_height(node["data-sketch-height"]) ]
+        end
+      else
+        # The excalidraw fence sanitizes down to <pre><code>{scene json}</code></pre>
+        # (the lang hint is dropped), so the JSON payload itself is the signal.
+        fragment.css("pre > code").filter_map do |code|
+          payload = parse_scene(code.text) or next
+          [ code.parent, clamp_height(payload["height"]) ]
+        end
+      end
+    end
+
+    def parse_scene(text)
+      data = JSON.parse(text)
+      data if data.is_a?(Hash) && data.key?("scene")
+    rescue JSON::ParserError
+      nil
+    end
+
+    def skeleton(document, height)
+      figure = Nokogiri::XML::Node.new("figure", document)
+      figure["class"] = "doc-sketch-skeleton"
+      figure["style"] = "height: #{height}px"
+      figure["aria-hidden"] = "true"
+      figure
+    end
+
+    def clamp_height(raw)
+      value = raw.to_i
+      return DEFAULT_SKETCH_HEIGHT if value <= 0
+
+      value.clamp(MIN_SKETCH_HEIGHT, MAX_SKETCH_HEIGHT)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     get "docs/:slug", to: "docs#show", as: :doc
     post "docs/:slug/suggestions", to: "suggestions#create", as: :doc_suggestions
     post "docs/:slug/comments", to: "comments#create", as: :doc_comments
+    post "docs/:slug/comments/:id/resolve", to: "comments#resolve", as: :doc_resolve_comment
     post "docs/:slug/presence", to: "presences#create", as: :doc_presence
     get "docs/:slug/events/pending", to: "events#pending", as: :doc_pending_events
     post "docs/:slug/events/ack", to: "events#ack", as: :doc_ack_events

--- a/docs/plans/2026-06-24-004-fix-instant-first-paint-plan.md
+++ b/docs/plans/2026-06-24-004-fix-instant-first-paint-plan.md
@@ -1,0 +1,199 @@
+---
+title: "fix: Instant first paint for the document editor"
+type: fix
+date: 2026-06-24
+origin: user request (load flicker on /d/:slug)
+---
+
+# Instant first paint for the document editor
+
+## Summary
+
+Remove the load flicker on `GET /d/:slug`. The document content already ships in the first HTTP response as the `yjs_state_b64` Inertia prop and hydrates the editor before the WebSocket connects — so the flicker was never the socket redrawing. It was the **async Milkdown boot** leaving the reserved editor frame blank until ProseMirror painted, compounded by the header title flashing the stored value and the connection dot flashing `connecting → live`.
+
+The fix paints a sanitized, server-rendered copy of the current content into the reserved editor frame at React-mount time, derives the header title on the server, and runs a small three-phase swap so the live editor *replaces* the preview (never blanks it). It also removes two small sources of chrome flicker (the optimistic status dot and the redundant header Sketch button).
+
+This plan is retrospective: the work is implemented on branch `fix/instant-first-paint` and is being routed through the LFG pipeline for review, browser verification, and shipping. Implementation units map to the change set already in the working tree.
+
+---
+
+## Problem frame
+
+On load/refresh, a reader saw the document area sit blank inside its reserved 50vh frame, then pop in once Milkdown finished building (schema, plugins, Shiki, Yjs binding). Three things changed state at slightly different moments and read as a single flicker:
+
+1. **Blank editor frame → content.** `content_html` did not exist; the only content source on the client was the binary `yjs_state_b64`, which is invisible until the async editor binds and paints.
+2. **Header title flash.** The header rendered `document.title` (often the stored default, e.g. "Untitled") until the editor extracted the first H1 and called `onTitleChange`.
+3. **Status dot flash.** The connection dot initialized to `connecting` and only flipped to `live` when the editor started — even though a hydrated doc is functionally live on first paint.
+
+A naive first cut (remove the preview the instant `handle` arrived) reproduced a worse symptom the user described as "it deletes it instead of replacing": the preview was removed a frame or two before ProseMirror had actually painted the synced content, briefly blanking the column.
+
+---
+
+## Requirements
+
+- R1. The document's current content is visible in the editor column on first paint, before Milkdown finishes its async boot.
+- R2. The first paint is safe: server-rendered content is sanitized before reaching `dangerouslySetInnerHTML`.
+- R3. The transition from server preview to live editor is seamless — content is replaced, never momentarily blank.
+- R4. The header title (in-app `.doc-title` and the browser tab `<Head>`) reads the real document title on first paint.
+- R5. Sketch-bearing documents reserve the correct height in the preview so the layout does not jump when the live canvas mounts.
+- R6. No behavioral regressions: live collaboration, snapshots, seed claims, suggestions, and presence continue to work; sketches remain insertable.
+- R7. Reduced chrome flicker: the connection dot does not flash `connecting → live` for a doc that is already hydrated; the redundant header Sketch button is removed.
+
+---
+
+## Key technical decisions
+
+- **Reuse the existing render + sanitize stack.** `DocumentPreviewHtml` renders markdown via `Commonmarker` (mirroring `DocumentPlainText`) or passes through HTML, then routes everything through `HtmlDocumentSanitizer.snapshot` — the same trusted-metadata boundary used for snapshots. This keeps one sanitization policy rather than introducing a second. (R2)
+- **Skeletonize sketches post-sanitize.** The preview can't run Excalidraw, and the sanitizer's tag allowlist excludes `div`/inline styles. So sketch replacement runs *after* sanitization (the injected height is trusted, not user input): HTML sketch figures and markdown ```excalidraw fences become a neutral `figure.doc-sketch-skeleton` with the sketch's height. Prevents both a raw-JSON flash (markdown) and a collapsed canvas (HTML). (R5)
+- **Three-phase swap, gated on paint — not on `handle`.** The preview holds layout height in normal flow; the live editor overlays it (`position: absolute`, transparent) while booting so it paints *over* the identical preview, and the preview is removed two animation frames after `onReady`. The preview is always behind the live editor until then, so content is never blank. This is the core fix for the "deletes instead of replacing" symptom. (R3)
+- **Derive title on the server.** `Document#display_title` extracts the first H1 via the existing `DocumentTitle` service (guarded against blank content, which `nil.to_s` makes US-ASCII and `Commonmarker` rejects). Shipped as `display_title` and used to initialize `documentTitle`. (R4)
+- **Optimistic status.** Initialize `status` to `live` when `has_state || seed_granted`; the WebSocket still confirms in the background. Consistent with current behavior (the provider only ever emits `connecting → live`; there is no wired disconnect path). (R7)
+- **Drop the header Sketch button.** It duplicated the `/` slash-menu "Sketch" entry and was a flicker source (`disabled` until `handle`). Removed with its orphaned CSS. (R7)
+
+---
+
+## High-level technical design
+
+### Data flow on first load
+
+```mermaid
+flowchart TD
+    R["DocumentsController#show"] -->|Inertia props| P["yjs_state_b64 · content_html · display_title · seed_*"]
+    P --> M["React mounts DocumentShow"]
+    M --> PV["Static preview paints<br/>(content_html in reserved frame)"]
+    M --> ED["DocumentEditor boots (async)"]
+    ED --> H["acquireSession(): new Y.Doc<br/>+ Y.applyUpdate(yjs_state_b64)"]
+    H --> CP["CableProvider → SyncChannel<br/>(background sync)"]
+    H --> ST["start(): bind Y.Doc → ProseMirror paints"]
+    ST --> SW["live editor overlays preview, paints same content"]
+    SW --> LV["+2 frames → drop preview, editor in flow"]
+```
+
+### Editor swap state machine (`doc-editor-stack[data-phase]`)
+
+```mermaid
+stateDiagram-v2
+    [*] --> booting
+    booting --> revealing: onReady (Y.Doc bound, content painted)
+    revealing --> live: +2 animation frames
+    note right of booting
+        Static preview in flow (holds height).
+        Live editor overlays it, transparent,
+        pointer-events: none.
+    end note
+    note right of revealing
+        Editor painted on top of the identical
+        preview; preview still mounted behind.
+    end note
+    note right of live
+        Preview removed; editor in normal flow.
+        Fully interactive.
+    end note
+```
+
+---
+
+## Implementation units
+
+### U1. `DocumentPreviewHtml` service
+
+**Goal:** Render sanitized HTML of a document's current content for first paint, with sketches reduced to height-reserving skeletons.
+**Requirements:** R1, R2, R5
+**Dependencies:** none
+**Files:** `app/services/document_preview_html.rb` (new), `test/services/document_preview_html_test.rb` (new)
+**Approach:** `call(format:, content:)` returns `""` for blank content; markdown → `Commonmarker.to_html` (same plugins as `DocumentPlainText`), HTML passed through; both routed through `HtmlDocumentSanitizer.snapshot`. Post-sanitize, replace HTML sketch figures (`figure[data-thinkroom-sketch]`, height from `data-sketch-height`) and markdown sketch fences (`pre > code` whose JSON has a `scene` key, height from payload) with `figure.doc-sketch-skeleton` carrying an inline `height`. Clamp height to `[180, 1200]`, default `448`.
+**Patterns to follow:** `app/services/document_plain_text.rb` (Commonmarker invocation, Nokogiri sketch traversal), `app/services/html_document_sanitizer.rb` (`snapshot` boundary).
+**Test scenarios:**
+- Markdown renders to prose HTML (`<strong>`, `<p>`, heading text present).
+- Blank/nil content returns `""` (both formats).
+- `<script>` and unsafe markup are stripped.
+- A markdown ```excalidraw fence becomes `figure.doc-sketch-skeleton` with the payload height; raw scene JSON (`formatVersion`) is absent.
+- An out-of-range sketch height clamps to `MAX_SKETCH_HEIGHT`.
+- A valid HTML sketch figure becomes a skeleton at its `data-sketch-height`.
+**Verification:** New test passes; service returns sanitized HTML with skeletons for sketch content.
+
+### U2. `Document#preview_html` and `#display_title`
+
+**Goal:** Expose the preview HTML and a server-derived header title on the model.
+**Requirements:** R1, R4
+**Dependencies:** U1
+**Files:** `app/models/document.rb`
+**Approach:** `preview_html` delegates to `DocumentPreviewHtml.call(format: content_format, content: current_content)`. `display_title` returns `title` when `current_content` is blank (guards `Commonmarker`'s UTF-8 requirement against `nil.to_s` US-ASCII), else `DocumentTitle.call(...).presence || title`.
+**Patterns to follow:** existing `plain_text` delegation on `Document`.
+**Test scenarios:**
+- `display_title` returns the first H1 of seeded content.
+- `display_title` falls back to the stored `title` when content is blank (no `Commonmarker` UTF-8 error). *Covers the regression found in `document_seed_claim_test`.*
+**Verification:** Model methods return expected values; `document_seed_claim_test` and `document_test` stay green.
+
+### U3. Ship `content_html` and `display_title` props
+
+**Goal:** Make the new data available to the page.
+**Requirements:** R1, R4
+**Dependencies:** U2
+**Files:** `app/controllers/documents_controller.rb`
+**Approach:** Add `content_html: document.preview_html` and `display_title: document.display_title` to the `documents/show` document prop. Initial-render path only (agent/JSON/txt branches return earlier).
+**Patterns to follow:** the existing `document.slice(...).merge(...)` prop block.
+**Test scenarios:** `Test expectation: none` — prop wiring; covered by the show-path integration tests (`document_seed_claim_test`, `snapshot_test`) staying green and U6's browser verification.
+**Verification:** Show response includes both props (asserted via browser prop read in U6).
+
+### U4. Seamless preview→editor swap
+
+**Goal:** Paint the preview instantly and hand off to the live editor without a blank frame.
+**Requirements:** R1, R3
+**Dependencies:** U3
+**Files:** `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`
+**Approach:** Add `DocumentProps.document.content_html`. Wrap the editor in `div.doc-editor-stack` with `data-phase={editorSwapped ? 'live' : handle ? 'revealing' : 'booting'}`. Render the preview (`div.doc-static-preview.milkdown > div.ProseMirror` via `dangerouslySetInnerHTML`) while `!editorSwapped`. `onReady` sets `handle` then schedules `setEditorSwapped(true)` after two `requestAnimationFrame`s. CSS: `booting`/`revealing` make `.doc-live-editor` an absolute overlay (`inset: 0`); `booting` adds `pointer-events: none`; `.doc-editor-stack` reserves `min-height: 50vh`; `.doc-sketch-skeleton` is a neutral box.
+**Technical design (directional):** the preview wrapper carries `.milkdown .ProseMirror` so it inherits the editor's prose styles; the live editor is transparent during overlay so the identical preview shows through any not-yet-painted region.
+**Patterns to follow:** existing `.milkdown { min-height: 50vh }` reservation; `DocumentEditor` callback wiring.
+**Test scenarios:**
+- (browser, U6) No blank content frames between preview and live editor across the swap.
+- (browser, U6) Booting preview is visually identical to the live editor.
+**Verification:** Headless Playwright shows 0 blank frames; phases progress `booting → revealing → live`.
+
+### U5. Optimistic status + remove header Sketch button
+
+**Goal:** Eliminate the remaining chrome flicker.
+**Requirements:** R7
+**Dependencies:** U4
+**Files:** `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`
+**Approach:** Initialize `documentTitle` from `doc.display_title || doc.title`. Initialize `status` to `live` when `doc.has_state || doc.seed_granted`, else `connecting`. Remove the `mode === 'edit'` header Sketch button and its `.sketch-insert-button` CSS (the `/` slash-menu entry remains the insertion path; `handle.openSketch` stays on the handle).
+**Patterns to follow:** existing `ConnectionStatus` usage and slash menu (`app/frontend/editor/slash_menu.ts`).
+**Test scenarios:**
+- (browser, U6) Header title reads the real title from the first painted frame, never "Untitled".
+- (browser, U6) No `.sketch-insert-button` in the header; status dot is `live` on a doc with state.
+- (manual/regression) The `/` slash menu still inserts a sketch.
+**Verification:** Browser checks pass; sketch insertion via slash menu unaffected.
+
+### U6. Verification harness
+
+**Goal:** Prove the flicker is gone and nothing regressed.
+**Requirements:** R1, R3, R4, R6
+**Dependencies:** U4, U5
+**Files:** none committed (throwaway Playwright scripts under `tmp/`, which is gitignored)
+**Approach:** Headless Playwright under CPU throttle, sampling per animation frame: assert 0 blank content frames after first content; assert header `.doc-title` is correct from the first frame; capture booting vs. live screenshots for visual parity. Run `npm run check` (tsc) and the Ruby model/service/integration tests.
+**Test scenarios:** see U4/U5 browser scenarios.
+**Verification:** `npm run check` clean; `bin/rails test` for `document_preview_html_test`, `document_test`, `document_seed_claim_test`, `snapshot_test` green; Playwright reports 0 blank frames and correct first-frame title.
+
+---
+
+## Scope boundaries
+
+**In scope:** server-rendered first-paint preview, server-derived title, the swap state machine, optimistic status, header Sketch button removal.
+
+**Non-goals:**
+- Inertia SSR — the app is client-rendered; the preview wins by painting at React-mount, no SSR required.
+- Rendering ```mermaid fences as diagrams — Thinkroom shows them as code (convertible to sketches in-UI); unchanged here.
+- Changing the Yjs/ActionCable sync protocol, persistence, seed-claim, or provenance behavior.
+
+**Deferred to follow-up work:**
+- A cross-fade transition on the swap (current handoff is an instant, content-identical replace; a fade is cosmetic polish).
+- Reconsidering React `StrictMode` double-mount in dev (a dev-only amplifier; the swap is robust regardless, and production React does not double-invoke).
+
+---
+
+## Risks & dependencies
+
+- **Preview/editor style drift.** If the preview's prose styling diverges from the live `.milkdown .ProseMirror`, the swap could shift. Mitigated by reusing the same `.milkdown .ProseMirror` selectors and verified pixel-identical in U6.
+- **Sketch height accuracy.** Markdown sketch payloads may omit height; the skeleton falls back to the default (448) and can reflow slightly when the real canvas mounts. Acceptable; HTML figures carry exact height.
+- **Page weight.** `content_html` roughly duplicates the document text already present as `yjs_state_b64`. Acceptable for the UX win on typical documents; revisit only if large documents show a regression.
+- **Sanitization is load-bearing.** `content_html` reaches `dangerouslySetInnerHTML`; it must always pass through `HtmlDocumentSanitizer`. Covered by U1's XSS test.

--- a/docs/plans/2026-06-24-005-feat-inertia-ssr-plan.md
+++ b/docs/plans/2026-06-24-005-feat-inertia-ssr-plan.md
@@ -1,0 +1,206 @@
+---
+title: "feat: Inertia SSR for the document page (loaded in one go)"
+type: feat
+date: 2026-06-24
+origin: user request (SSR follow-up to instant-first-paint, PR #48)
+---
+
+# Inertia SSR for the document page
+
+## Summary
+
+Render the document page's HTML on the server so the shell, header, and the server-rendered `content_html` preview are in the **initial HTTP response** — visible before any JavaScript loads. The browser-only editor (Milkdown/ProseMirror, Excalidraw, Yjs, the ActionCable `CableProvider`) renders nothing on the server and mounts only after client hydration, where the existing `booting → revealing → live` swap takes over.
+
+This is the follow-up to the instant-first-paint work (`content_html`, `display_title`, the seamless swap on branch `fix/instant-first-paint`). Measurement showed the remaining blank window is **before React mounts** (~220ms on a warm load; ProseMirror then paints ~14ms later) — and a React-rendered preview can't fill a pre-React gap. Only SSR closes it. Ships in this branch.
+
+---
+
+## Problem frame
+
+The instant-paint preview is rendered by React, so it appears only after the JS bundle downloads, parses, and React mounts — the ~220ms during which the page is the empty Inertia shell. SSR moves the first paint to the server: the same `content_html` + `display_title` already computed for props are rendered into the HTML response, so content is on screen at first byte. The hard part is that the document page is **browser-coupled** — the editor and several render-time reads (`localStorage`, `window`, a media query) would crash or mismatch under Node `renderToString`. The win is real but the work is making one large page SSR-safe without regressing the editor, the zero-shift swap, or the agent/txt/JSON response branches.
+
+---
+
+## Requirements
+
+- R1. `GET /d/:slug` returns the rendered document content (title + prose) **in the initial HTML**, not only in the Inertia `data-page` JSON.
+- R2. No React hydration mismatch warnings on load for the document page.
+- R3. The live editor still mounts, binds the hydrated Yjs state, syncs over ActionCable, and the `booting → revealing → live` swap still yields **0 layout shift**.
+- R4. Browser-only code (editor, Excalidraw, Yjs, `CableProvider`, `RiffrecProvider`, `localStorage`/`window`/media-query reads) never executes during the server render.
+- R5. The non-HTML branches of `documents#show` (agent guide via `agent_user_agent?`, `.txt`, `.json`) are unaffected.
+- R6. SSR failure falls back to client-side rendering gracefully (no 500 for a render error in production).
+- R7. SSR runs in development with no extra process (Vite dev server) and is wired for production (SSR bundle + Node process under the existing Kamal/Docker deploy).
+- R8. Blast radius is controlled: SSR is enabled for the document page first; other pages are not forced SSR-safe in the same change unless verified.
+
+---
+
+## Key technical decisions
+
+- **Use the `@inertiajs/vite` plugin SSR path (v3).** It's already a dependency and the `inertia()` plugin is already in `vite.config.ts`. Dev SSR runs through the Vite dev server (no separate process); only production needs a built SSR bundle + Node process. Avoids a hand-rolled SSR entry. (R7)
+- **`hydrateRoot`, not `createRoot`, on the client.** The client entry must hydrate the server HTML rather than re-render it, or React discards the SSR output and the benefit is lost. Keep `StrictMode` and `RiffrecProvider` in the tree. (R2)
+- **Conditional SSR, document page first.** Enable SSR via `inertia_config(ssr_enabled: …)` scoped to `DocumentsController#show` (or a thin allowlist), not globally. The landing/auth pages aren't the latency target and shouldn't be forced SSR-safe in one shot. Revisit global SSR later. (R8)
+- **The editor is a client-only island.** `DocumentEditor` renders `null` (the preview already covers first paint) on the server and mounts only after hydration via an `isClient` gate (`useSyncExternalStore` with a server snapshot of `false`, or a mount `useEffect`). The preview is plain server-rendered HTML and is identical on server and client's first render, so `editorSwapped` is `false` on both → no mismatch. (R3, R4)
+- **Deterministic server defaults for browser-derived state.** Anything read from `localStorage`/`window`/media queries at render time (`mode`, `panelOpen`, `focusMode`, `isMobile`, `identity`) renders a fixed server default on first paint and applies the real client value in a post-hydration `useEffect`. First render must be identical server↔client. (R2)
+- **Graceful degradation.** `ssr_raise_on_error = !Rails.env.production?` + `on_ssr_error` logging + `ssr_bundle` presence detection so a missing/failed SSR bundle falls back to CSR rather than erroring. (R6)
+
+---
+
+## High-level technical design
+
+### Request → first paint (with SSR)
+
+```mermaid
+flowchart TD
+    REQ["GET /d/:slug (HTML)"] --> CTRL["DocumentsController#show<br/>ssr_enabled for this action"]
+    CTRL --> PROPS["props: content_html, display_title,<br/>yjs_state_b64, seed_*"]
+    PROPS --> SSR["Inertia → Node SSR (renderToString)"]
+    SSR --> SAFE{"render-time:<br/>browser-only?"}
+    SAFE -->|"editor / Riffrec / window reads"| NULL["render null / server default"]
+    SAFE -->|"shell · header · preview"| HTML["rendered HTML"]
+    NULL --> HTML
+    HTML --> RESP["initial HTML response<br/>(content visible, no JS)"]
+    RESP --> HYDRATE["client: hydrateRoot"]
+    HYDRATE --> CLIENT["isClient flips true → DocumentEditor mounts"]
+    CLIENT --> SWAP["booting → revealing → live (0 shift)"]
+```
+
+### Hydration-safe state pattern (directional)
+
+The invariant: **first render is identical on server and client.** Browser values arrive after.
+
+```
+// directional — not implementation
+const [mode, setMode] = useState(SERVER_DEFAULT)          // not readStoredMode() at init
+useEffect(() => { setMode(readStoredMode(slug)) }, [])    // client-only, post-hydration
+
+const isClient = useIsClient()                            // false on server + first client render
+return isClient ? <DocumentEditor/> : null               // editor never renders on server
+```
+
+---
+
+## Implementation units
+
+### U1. SSR infrastructure: plugin SSR, `hydrateRoot`, Rails config
+
+**Goal:** Turn SSR on end-to-end for the document page in development, with CSR fallback.
+**Requirements:** R1, R6, R7, R8
+**Dependencies:** none
+**Files:** `app/frontend/entrypoints/inertia.tsx`, `config/initializers/inertia_rails.rb`, `config/vite.json`, `vite.config.ts` (verify `inertia()` SSR options), `app/controllers/documents_controller.rb`
+**Approach:** Switch the client `setup` to `hydrateRoot` (keep `StrictMode` + `RiffrecProvider`). Configure the `@inertiajs/vite` plugin's SSR entry per the v3 docs. In the initializer set `ssr_enabled` (scoped — see U5), `ssr_url` nil for dev auto-detect, `ssr_raise_on_error = !Rails.env.production?`, `on_ssr_error` logging, and `ssr_bundle` detection. Add `inertia_config(ssr_enabled: …)` to `DocumentsController#show` only. Confirm `inertia_ssr_head` is already in the layout (it is).
+**Patterns to follow:** the inertia-rails-ssr v3 Vite-plugin setup; existing `inertia.tsx` `setup` shape.
+**Test scenarios:**
+- Dev: `GET /d/:slug` (browser UA) returns HTML whose body contains the document title text and first paragraph (not just `data-page` JSON). *Covers R1.*
+- With SSR disabled/bundle absent, the page still renders via CSR (no 500). *Covers R6.*
+- Agent UA / `.txt` / `.json` branches return their existing non-Inertia responses unchanged. *Covers R5.*
+**Verification:** curl with a browser UA shows rendered content in the HTML; agent/txt/json unaffected; toggling SSR off falls back to CSR.
+
+### U2. Editor as a client-only island
+
+**Goal:** Ensure the editor and its browser-only dependencies never render on the server.
+**Requirements:** R3, R4
+**Dependencies:** U1
+**Files:** `app/frontend/pages/documents/show.tsx`, `app/frontend/editor/milkdown_editor.tsx`, a small `app/frontend/lib/use_is_client.ts` (new)
+**Approach:** Add a `useIsClient` hook (server snapshot `false`). Gate `<DocumentEditor>` so the server renders `null` while the static preview (already present) carries first paint; the editor mounts after hydration. Verify nothing in the editor module graph (Milkdown `useEditor`, Excalidraw import, `CableProvider`, Yjs) executes at module-eval or render time on the server — defer browser-only imports if any run eagerly.
+**Patterns to follow:** the existing `doc-editor-stack` phase gating; `editorSwapped`/`handle` state.
+**Test scenarios:**
+- Server HTML for `/d/:slug` contains `doc-static-preview` content but **no** `.milkdown`/ProseMirror editor DOM. *Covers R4.*
+- After hydration the editor mounts, `data-phase` advances `booting → live`, and content stays stable (0 blank frames, 0 CLS). *Covers R3.*
+- A doc with a sketch renders the skeleton on the server and the real Excalidraw canvas only after mount. *Covers R4.*
+**Verification:** Playwright — server HTML has preview + no editor; post-hydration editor works and swap is zero-shift.
+
+### U3. Hydration-safe browser-derived state
+
+**Goal:** Remove every render-time browser-API read from the document page's first render.
+**Requirements:** R2
+**Dependencies:** U1
+**Files:** `app/frontend/pages/documents/show.tsx` (and the `getStored*`/`readStoredMode`/`userIdentity` helpers it calls)
+**Approach:** Initialize `mode`, `panelOpen`, `focusMode`, `isMobile`, and `identity` to deterministic server defaults; apply the `localStorage`/`window`/media-query values in a post-hydration `useEffect`. Audit `userIdentity(viewer.name)` and the `getStored*` helpers for `localStorage`/`window` access during init and guard them. Keep the optimistic `status` and server-derived `documentTitle` (already prop-derived, SSR-safe).
+**Patterns to follow:** the existing initializer-only state comments in `show.tsx`.
+**Test scenarios:**
+- Console shows **no** hydration mismatch warning on load. *Covers R2.*
+- Stored mode/panel/focus still apply after load (just one frame later). 
+- Mobile viewport still collapses the gutter after hydration.
+**Verification:** no React hydration warnings; stored prefs still take effect post-hydration.
+
+### U4. SSR-safe provider/render-time wrappers
+
+**Goal:** Confirm the always-mounted wrappers survive `renderToString`.
+**Requirements:** R4, R6
+**Dependencies:** U1
+**Files:** `app/frontend/entrypoints/inertia.tsx`, any shared layout/provider components, `app/frontend/lib/use_is_client.ts`
+**Approach:** Verify `RiffrecProvider` (screen/voice capture) does not touch `window`/`navigator`/media during SSR render; if it does, gate its browser-only effects behind `isClient` or render a passthrough on the server. Sweep shared layout/header components rendered on every page for render-time browser access.
+**Patterns to follow:** U2's `useIsClient` gate.
+**Test scenarios:**
+- SSR render of the document page does not throw (no `window is not defined` / `document is not defined`). *Covers R4.*
+- `on_ssr_error` is exercised by a deliberately-thrown SSR error in a test and the page still serves via CSR. *Covers R6.*
+**Verification:** SSR render completes without browser-global errors; forced error degrades to CSR.
+
+### U5. SSR scope decision and landing/auth verification
+
+**Goal:** Keep SSR scoped to the document page and confirm nothing else broke.
+**Requirements:** R8
+**Dependencies:** U1
+**Files:** `config/initializers/inertia_rails.rb`, `app/controllers/documents_controller.rb`, `app/controllers/*` for other Inertia pages
+**Approach:** Lock SSR to `documents#show` via per-controller `inertia_config`. Confirm the landing page (`/`) and auth pages still render correctly under CSR (they remain CSR since SSR is scoped). Document the path to broaden SSR later.
+**Patterns to follow:** Rails `inertia_config` conditional SSR from the inertia-rails docs.
+**Test scenarios:**
+- Landing and auth pages render and function (CSR). *Covers R8.*
+- Only `documents#show` returns server-rendered content in HTML.
+**Verification:** doc page is SSR; other pages are CSR and unbroken.
+**Test expectation: none beyond the above** — this unit is configuration + verification of existing pages.
+
+### U6. Production deploy wiring
+
+**Goal:** Build the SSR bundle and run the Node SSR process in production.
+**Requirements:** R7
+**Dependencies:** U1–U4
+**Files:** `Dockerfile`, `config/deploy.yml` (Kamal), `Procfile.dev` (dev needs no SSR process, but document it), build scripts / `package.json`
+**Approach:** Add the SSR bundle build (`bin/vite build --ssr` or the plugin equivalent) to the production image build. Run the Node SSR server as a process Kamal manages (sidecar/accessory or a process in the container alongside Puma), with `ssr_url` pointing at it. Consider `ssr_cache` for the document page. Ensure graceful fallback if the SSR process is down (CSR).
+**Patterns to follow:** existing `Dockerfile` node-install stage; `config/deploy.yml` structure.
+**Test scenarios:** `Test expectation: none` — deploy/infra config; validated by U7's production-shaped smoke (SSR bundle builds; container serves SSR HTML; SSR process down → CSR fallback).
+**Verification:** production image builds the SSR bundle; a built-bundle run serves SSR HTML; killing the SSR process degrades to CSR, not 500.
+
+### U7. Verification harness
+
+**Goal:** Prove SSR delivers content in the initial HTML without regressing anything.
+**Requirements:** R1, R2, R3, R5
+**Dependencies:** U2, U3, U4
+**Files:** none committed (throwaway Playwright/curl scripts under `tmp/`, gitignored)
+**Approach:** (a) curl `/d/:slug` with a browser UA → assert title + first paragraph present in HTML and `.milkdown` editor DOM absent; (b) Playwright load → assert no hydration mismatch console warning, editor mounts, `data-phase` reaches `live`, 0 blank frames, CLS 0.0000; (c) curl agent UA / `.txt` / `.json` → unchanged; (d) forced SSR error → CSR fallback.
+**Test scenarios:** the four checks above (R1, R2/R3, R5, R6).
+**Verification:** all four pass; `npm run check` clean; full Ruby suite green.
+
+---
+
+## Scope boundaries
+
+**In scope:** SSR for `documents#show` (shell + header + preview in initial HTML), client-only editor island, hydration-safe state, graceful CSR fallback, dev + production wiring.
+
+**Non-goals:**
+- Global SSR for every page (landing, auth) — scoped to the doc page first.
+- SSR-rendering the live editor / Yjs / Excalidraw — these stay client-only by design.
+- Changing the swap state machine, persistence, sync protocol, or the `content_html`/`display_title` server rendering (already shipped in PR #48).
+
+**Deferred to follow-up work:**
+- Broadening SSR to landing/marketing pages for SEO once the doc page is proven.
+- `ssr_cache` tuning and SSR render-latency monitoring for very large docs.
+- Open-Graph/meta-tag SSR via `inertia_meta` (related but separate from first-paint).
+
+---
+
+## Risks & dependencies
+
+- **Hydration mismatches (dominant risk).** Any server↔client first-render difference (a stored pref read at init, a `Date`, a random id, a `window` check) prints a warning and can discard SSR output. Mitigation: U3's deterministic-default pattern + U7's explicit no-warning assertion. This is where execution time will go.
+- **Browser globals during `renderToString`.** A single eager `window`/`document` access anywhere in the document page's module graph crashes SSR. Mitigation: the `isClient` island (U2), provider sweep (U4), and `ssr_raise_on_error=false` in production as a safety net (U6).
+- **StrictMode + `hydrateRoot`.** StrictMode double-invokes in dev; combined with hydration and the existing session-grace-period logic in `milkdown_editor.tsx`, watch for double-acquire. Mitigation: editor mounts post-hydration only (U2); verify session ref-count symmetry.
+- **Deploy/process management.** Production now needs a Node SSR process Kamal manages alongside Puma. Mitigation: CSR fallback means an SSR-process outage degrades gracefully rather than taking the site down.
+- **RiffrecProvider SSR-safety** is an unknown (third-party-ish capture provider in the render tree on every page) — U4 must verify or guard it.
+
+---
+
+## Operational / rollout notes
+
+- Dev: no new process — `bin/vite dev` serves SSR. Keep `Procfile.dev` as-is; document the behavior.
+- Production: SSR bundle build added to the image; Node SSR process managed by Kamal; `ssr_cache` optional. CSR fallback is the kill-switch — disabling `ssr_enabled` or stopping the SSR process reverts to today's behavior with no code change.
+- Rollback: flip `ssr_enabled` off for `documents#show`.

--- a/docs/solutions/architecture-patterns/server-first-instant-paint.md
+++ b/docs/solutions/architecture-patterns/server-first-instant-paint.md
@@ -1,0 +1,86 @@
+---
+title: "Server-first instant paint: lean into Inertia, render on the server, hydrate optimistically"
+module: documents/show editor
+date: 2026-06-24
+problem_type: architecture_pattern
+component: rails_view
+severity: medium
+related_components:
+  - service_object
+  - rails_controller
+tags:
+  - instant-paint
+  - inertia
+  - ssr
+  - optimistic-ui
+  - layout-shift
+  - prosemirror
+  - yjs
+applies_when:
+  - "An async client editor (ProseMirror/Milkdown, CodeMirror, etc.) hydrates content that is already known on the server"
+  - "Eliminating first-paint flicker, blank frames, or layout shift on load"
+  - "Deciding what to render on the server vs the client in an Inertia app"
+---
+
+# Server-first instant paint
+
+## Context
+
+The document editor flickered on load: the content area sat blank in its reserved frame, then popped in once Milkdown finished its async boot, while the header title and connection dot changed a beat later. The instinct was "the websocket is redrawing everything." It wasn't — the whole document already ships in the first HTTP response as an Inertia prop (`yjs_state_b64`, the Yjs/CRDT binary) and hydrates the editor *before* the websocket connects. The blank frame was purely the **async editor boot**: the client editor mounts asynchronously, so there is always a window where React has rendered the page but the editor has not yet painted.
+
+Principle the team settled on: **server is king — make first paint as fast and optimistic as possible, and lean into Inertia to ship rendered content, not just data.**
+
+## Guidance
+
+**1. Render the content on the server for instant paint — don't wait on the client editor.**
+The CRDT binary (`yjs_state_b64`) is authoritative but invisible until JS boots and the editor binds it. Ship a *second, human-renderable projection* alongside it: a `content_html` prop (server-rendered, sanitized HTML of the current content) painted straight into the reserved editor frame at mount, plus a server-derived `display_title` (first H1) so the header is correct on first paint. The editor then overlays and replaces this preview once it has painted the same content.
+
+**2. Initialize state optimistically.**
+A hydrated doc is functionally live the moment it paints — the websocket only confirms it. Initialize the connection status to `live` when the doc has state, instead of `connecting → live`, to kill the status flash.
+
+**3. When you keep two renderers, normalize the server HTML to match the client DOM *exactly*.**
+The server (Commonmarker) and the client (ProseMirror) will never be byte-identical, and any difference becomes a layout shift on swap. The subtle one that bit us: ProseMirror's editable content uses `white-space: break-spaces`, and Commonmarker pretty-prints a literal `\n` text node between block elements. ProseMirror's DOM has no such whitespace, so the `\n` rendered as a **phantom blank line** and pushed the first paragraph ~30px down — only until the editor swapped in. Fix: strip inter-block whitespace from the server HTML (preserving `pre`/`code` contents) so its box model matches the editor's.
+
+**4. Swap by replace, never by blank.**
+Keep the static preview behind the live editor (transparent overlay) until the editor has actually painted, then drop the preview a couple of animation frames *after* `onReady`. Removing it the instant the handle arrives reintroduces a one-frame blank ("deletes instead of replaces").
+
+**5. The end-state is SSR.**
+A React-rendered preview only covers the gap *after* React mounts. Measured on a warm load: React mounts ~220ms after navigation (JS download/parse/execute), and ProseMirror paints only ~14ms (one frame) after that. So the real "nothing on screen" window is the ~220ms before React mounts — which a React-rendered preview cannot fill. Truly "loaded in one go" requires **Inertia SSR**, which renders the shell + header + preview into the initial HTML response, with the browser-only editor hydrating client-side.
+
+## Why This Matters
+
+Perceived performance is dominated by first paint, not by when the editor becomes interactive. Shipping the rendered content as a prop turns a blank-then-fill flicker into content that is simply there. Two-renderer parity is the trap: it looks done but drifts in subtle, measurable ways (a stray anchor, a `\n`, a trailing break) that read as jank. Measure it — per-frame element positions and CLS — rather than eyeballing a sub-300ms transition. And remember that the dominant blank window is pre-React; only SSR closes it.
+
+This also keeps the app **agent-native**: the same `content_html`/`plain_text` projection that paints instantly is what agents read over the HTTP API, since they have no CRDT runtime.
+
+## When to Apply
+
+Any time an async client component hydrates content the server already knows — rich-text editors, canvases, charts. Especially in Inertia apps, where the natural move is to ship *rendered* HTML as a prop rather than making the client render from raw data. Reach for SSR when the pre-mount blank window (not the editor boot) is the remaining flicker.
+
+## Examples
+
+Strip inter-block whitespace so the server preview matches ProseMirror's DOM (`app/services/document_preview_html.rb`):
+
+```ruby
+# ProseMirror emits no whitespace text nodes between block elements, but
+# Commonmarker pretty-prints "\n" between them. Under white-space: break-spaces
+# those render as phantom blank lines and shift the first paragraph on swap.
+def collapse_block_whitespace(fragment)
+  fragment.xpath(".//text()").each do |node|
+    next unless node.content.match?(/\A\s*\z/)
+    parent = node.parent
+    next if parent.nil? || parent.name == "pre" || parent.name == "code"
+    node.remove if parent.name == "#document-fragment" ||
+      WHITESPACE_BLOCK_PARENTS.include?(parent.name)
+  end
+end
+```
+
+Optimistic status + server-derived title on first paint (`app/frontend/pages/documents/show.tsx`):
+
+```tsx
+const [status] = useState(doc.has_state || doc.seed_granted ? 'live' : 'connecting')
+const [documentTitle] = useState(doc.display_title || doc.title)
+```
+
+Verification that the swap is genuinely zero-shift: a CPU-throttled Playwright run sampling each element's `getBoundingClientRect().top` per frame plus a `layout-shift` PerformanceObserver — assert **0 blank frames** and **CLS 0.0000** with every element stable from the first painted frame.

--- a/test/integration/comment_flow_test.rb
+++ b/test/integration/comment_flow_test.rb
@@ -79,6 +79,39 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     # The second resolve re-stamps but never un-resolves; both are accepted.
     assert_operator comment.resolved_at, :>=, first_resolved_at
   end
+
+  test "an agent resolves a comment over the API (no CSRF) attributed to its name" do
+    comment = @document.comments.create!(author_name: "A", author_kind: "human", body: "Fix this")
+
+    post api_doc_resolve_comment_path(slug: @document.slug, id: comment.id),
+      headers: { "X-Agent-Name" => "Scout" }, as: :json
+
+    assert_response :success
+    assert comment.reload.resolved_at.present?
+    assert_empty @document.comments.open
+    # Logs a resolved_comment activity attributed to the agent (the first API
+    # call also logs a presence "joined", so don't assert an exact count).
+    activity = @document.activities.where(action: "resolved_comment").last
+    assert_equal "agent", activity.actor_kind
+    assert_equal "Scout", activity.actor_name
+  end
+
+  test "API resolve requires an X-Agent-Name header" do
+    comment = @document.comments.create!(author_name: "A", author_kind: "human", body: "Fix this")
+
+    post api_doc_resolve_comment_path(slug: @document.slug, id: comment.id), as: :json
+
+    assert_response :unprocessable_entity
+    assert_nil comment.reload.resolved_at
+  end
+
+  test "API resolve of an unknown comment id returns 404 with a clear error" do
+    post api_doc_resolve_comment_path(slug: @document.slug, id: -42),
+      headers: { "X-Agent-Name" => "Scout" }, as: :json
+
+    assert_response :not_found
+    assert_match(/no comment/i, JSON.parse(response.body)["error"])
+  end
 end
 
 class ThemePersistenceTest < ActionDispatch::IntegrationTest

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -337,4 +337,24 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal({ claimed: true, claimable: false, owner_name: "Owner", yours: false }, doc.ownership_props("tok-b"))
     assert_not doc.ownership_props("tok-a").value?("tok-a")
   end
+
+  test "display_title derives the first H1 from the current content" do
+    doc = Document.create!(title: "Untitled", seed_markdown: "# Real Heading\n\nBody text.")
+
+    assert_equal "Real Heading", doc.display_title
+  end
+
+  test "display_title falls back to the stored title when content is blank" do
+    # Guards the Commonmarker UTF-8 requirement: nil.to_s is US-ASCII and would
+    # raise if handed to the renderer, so blank content must short-circuit.
+    doc = Document.create!(title: "Stored Title", seed_markdown: nil)
+
+    assert_equal "Stored Title", doc.display_title
+  end
+
+  test "display_title falls back to the stored title when content has no heading" do
+    doc = Document.create!(title: "Stored Title", seed_markdown: "Just a paragraph, no heading.")
+
+    assert_equal "Stored Title", doc.display_title
+  end
 end

--- a/test/services/document_preview_html_test.rb
+++ b/test/services/document_preview_html_test.rb
@@ -1,12 +1,18 @@
 require "test_helper"
 
 class DocumentPreviewHtmlTest < ActiveSupport::TestCase
+  # A realistic markdown sketch fence: the SketchData wrapper (formatVersion +
+  # an excalidraw scene), matching what the editor serializes.
+  def sketch_fence(height: 600)
+    payload = { formatVersion: 1, description: "flow", height: height, scene: { type: "excalidraw", version: 2, elements: [] } }
+    "```excalidraw\n#{JSON.generate(payload)}\n```"
+  end
+
   test "renders markdown to sanitized prose html" do
     html = DocumentPreviewHtml.call(format: "markdown", content: "# Title\n\nA **bold** line.")
 
-    assert_includes html, "Title"
+    assert_includes html, "<h1>Title</h1>"
     assert_includes html, "<strong>bold</strong>"
-    assert_includes html, "<p>"
   end
 
   test "returns empty string for blank content" do
@@ -14,7 +20,24 @@ class DocumentPreviewHtmlTest < ActiveSupport::TestCase
     assert_equal "", DocumentPreviewHtml.call(format: "html", content: nil)
   end
 
-  test "strips scripts and unsafe markup" do
+  test "collapses inter-block whitespace so the preview matches the editor DOM" do
+    html = DocumentPreviewHtml.call(format: "markdown", content: "# Title\n\nParagraph one.\n\n## Section\n")
+
+    # ProseMirror emits no whitespace text nodes between block elements; the
+    # editor renders with white-space: break-spaces, so a stray "\n" would show
+    # as a phantom blank line and shift the text on swap.
+    assert_includes html, "</h1><p>"
+    assert_includes html, "</p><h2>"
+    refute_match(/>\s+</, html)
+  end
+
+  test "preserves whitespace inside code blocks" do
+    html = DocumentPreviewHtml.call(format: "markdown", content: "```ruby\ndef x\n  1\nend\n```")
+
+    assert_includes html, "def x\n  1\nend"
+  end
+
+  test "strips scripts and unsafe markup in markdown" do
     html = DocumentPreviewHtml.call(format: "markdown", content: "<script>alert(1)</script>\n\nsafe")
 
     refute_includes html, "<script"
@@ -22,31 +45,49 @@ class DocumentPreviewHtmlTest < ActiveSupport::TestCase
     assert_includes html, "safe"
   end
 
-  test "replaces a markdown sketch fence with a height-reserving skeleton" do
-    fence = <<~MARKDOWN
-      Before
+  test "strips event handlers and scripts on the html passthrough path" do
+    source = "<p>safe</p><script>evil()</script><img src=\"x\" onerror=\"steal()\">"
+    html = DocumentPreviewHtml.call(format: "html", content: source)
 
-      ```excalidraw
-      {"scene":[],"description":"flow","formatVersion":1,"height":600}
-      ```
+    refute_includes html, "<script"
+    refute_includes html, "onerror"
+    refute_includes html, "evil()"
+    assert_includes html, "safe"
+  end
 
-      After
-    MARKDOWN
-
-    html = DocumentPreviewHtml.call(format: "markdown", content: fence)
+  test "replaces a real sketch fence with a height-reserving skeleton" do
+    html = DocumentPreviewHtml.call(format: "markdown", content: "Before\n\n#{sketch_fence(height: 600)}\n\nAfter")
 
     assert_includes html, 'class="doc-sketch-skeleton"'
     assert_includes html, "height: 600px"
-    # The raw scene JSON must never reach the preview.
-    refute_includes html, "formatVersion"
+    refute_includes html, "formatVersion" # raw scene JSON never reaches the preview
   end
 
-  test "clamps an out-of-range sketch height" do
-    fence = "```excalidraw\n{\"scene\":[],\"height\":999999}\n```"
+  test "does NOT skeletonize a non-sketch code block that merely has a scene key" do
+    # A JSON/config code sample with a top-level "scene" key must survive as code
+    # (the sanitizer strips the lang hint, so detection keys on the sketch shape).
+    fence = "```json\n#{JSON.generate({ scene: "a beach at sunset", note: "tutorial" })}\n```"
+    html = DocumentPreviewHtml.call(format: "markdown", content: fence)
+
+    refute_includes html, "doc-sketch-skeleton"
+    assert_includes html, "a beach at sunset"
+  end
+
+  test "clamps sketch height to the allowed range" do
+    high = DocumentPreviewHtml.call(format: "markdown", content: sketch_fence(height: 999_999))
+    low = DocumentPreviewHtml.call(format: "markdown", content: sketch_fence(height: 10))
+
+    assert_includes high, "height: #{DocumentPreviewHtml::MAX_SKETCH_HEIGHT}px"
+    assert_includes low, "height: #{DocumentPreviewHtml::MIN_SKETCH_HEIGHT}px"
+  end
+
+  test "falls back to the default height when the sketch omits one" do
+    payload = { formatVersion: 1, scene: { type: "excalidraw", elements: [] } }
+    fence = "```excalidraw\n#{JSON.generate(payload)}\n```"
 
     html = DocumentPreviewHtml.call(format: "markdown", content: fence)
 
-    assert_includes html, "height: #{DocumentPreviewHtml::MAX_SKETCH_HEIGHT}px"
+    assert_includes html, "height: #{DocumentPreviewHtml::DEFAULT_SKETCH_HEIGHT}px"
   end
 
   test "reserves height for an html sketch figure" do

--- a/test/services/document_preview_html_test.rb
+++ b/test/services/document_preview_html_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class DocumentPreviewHtmlTest < ActiveSupport::TestCase
+  test "renders markdown to sanitized prose html" do
+    html = DocumentPreviewHtml.call(format: "markdown", content: "# Title\n\nA **bold** line.")
+
+    assert_includes html, "Title"
+    assert_includes html, "<strong>bold</strong>"
+    assert_includes html, "<p>"
+  end
+
+  test "returns empty string for blank content" do
+    assert_equal "", DocumentPreviewHtml.call(format: "markdown", content: "")
+    assert_equal "", DocumentPreviewHtml.call(format: "html", content: nil)
+  end
+
+  test "strips scripts and unsafe markup" do
+    html = DocumentPreviewHtml.call(format: "markdown", content: "<script>alert(1)</script>\n\nsafe")
+
+    refute_includes html, "<script"
+    refute_includes html, "alert(1)"
+    assert_includes html, "safe"
+  end
+
+  test "replaces a markdown sketch fence with a height-reserving skeleton" do
+    fence = <<~MARKDOWN
+      Before
+
+      ```excalidraw
+      {"scene":[],"description":"flow","formatVersion":1,"height":600}
+      ```
+
+      After
+    MARKDOWN
+
+    html = DocumentPreviewHtml.call(format: "markdown", content: fence)
+
+    assert_includes html, 'class="doc-sketch-skeleton"'
+    assert_includes html, "height: 600px"
+    # The raw scene JSON must never reach the preview.
+    refute_includes html, "formatVersion"
+  end
+
+  test "clamps an out-of-range sketch height" do
+    fence = "```excalidraw\n{\"scene\":[],\"height\":999999}\n```"
+
+    html = DocumentPreviewHtml.call(format: "markdown", content: fence)
+
+    assert_includes html, "height: #{DocumentPreviewHtml::MAX_SKETCH_HEIGHT}px"
+  end
+
+  test "reserves height for an html sketch figure" do
+    scene = { type: "excalidraw", version: 2, elements: [ { type: "text", text: "Review" } ], appState: {}, files: {} }.to_json
+    figure = %(<figure data-thinkroom-sketch data-sketch-id="flow_1" data-sketch-height="320" ) +
+      %(data-format-version="1" data-description="Flow" data-scene="#{CGI.escapeHTML(scene)}"><figcaption>Flow</figcaption></figure>)
+
+    html = DocumentPreviewHtml.call(format: "html", content: figure)
+
+    assert_includes html, 'class="doc-sketch-skeleton"'
+    assert_includes html, "height: 320px"
+  end
+end


### PR DESCRIPTION
## Problem

On load/refresh, the document area sat blank in its reserved frame and then popped in content as Milkdown finished its async boot — and the header title and connection dot changed a beat later. The content already ships in the first response (`yjs_state_b64`) and hydrates before the websocket, so the flicker was never the socket redrawing — it was the **async editor boot** leaving the reserved frame blank.

## Fix — instant first paint, zero shift

- **Server-rendered preview.** New `DocumentPreviewHtml` renders the current content (Commonmarker → `HtmlDocumentSanitizer`) into a `content_html` prop, painted into the reserved editor frame at mount. Sketches become height-reserving skeletons.
- **Seamless swap.** A `booting → revealing → live` state machine: the live editor overlays the preview while it boots and only replaces it two frames **after** it has painted the same content — replaced, never blanked.
- **Server-derived title.** `display_title` (first H1) so the header reads correctly on first paint.
- **Zero layout shift.** The editor renders with `white-space: break-spaces`; Commonmarker pretty-prints `\n` between blocks, which showed as a phantom blank line and pushed the first paragraph ~30px down on swap. We collapse inter-block whitespace (preserving code blocks) so the preview's box model matches the editor exactly.
- **Chrome.** Optimistic `live` status when the doc has state; removed the redundant header Sketch button (the `/` slash menu still inserts sketches).

## Verification

- Headless Playwright (CPU-throttled): **0 blank frames** through the swap; every element (h1, first paragraph, banner, gutter, title) stable from first paint; **CLS 0.0000**.
- Booting preview is pixel-identical to the live editor; header title correct from frame one.
- Full Ruby suite green (293 runs); TypeScript clean.

## Code review

Ran a multi-agent review (correctness, security, frontend-races, maintainability, testing, adversarial). Security verdict: the `content_html` → `dangerouslySetInnerHTML` boundary is airtight (sanitize + post-sanitize re-parse both use `Nokogiri::HTML5`; injected skeleton height is an integer-clamped value). Addressed in this PR: tightened the sketch detector to the real sketch shape (was erasing any code block with a `"scene"` key), `pointer-events` through the `revealing` phase, dead `openSketch` removal, and added coverage (`display_title`, whitespace collapse, non-sketch preservation, html-format XSS, height clamp branches).

## Follow-up

This is the foundation for **Inertia SSR** (a separate PR): SSR will render this same shell + preview into the initial HTML response so content is visible before JS loads, with the editor hydrating and swapping in client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this branch

- **`feat(api)`** — agents can now resolve comment threads over the HTTP API (`POST /api/docs/:slug/comments/:id/resolve`, X-Agent-Name authed). Closes an agent-native parity gap (an agent could open a comment but not resolve one — the web resolve is CSRF-gated).
- **`docs(plans)`** — Inertia SSR plan for the document page (the "loaded in one go" follow-up); implementation handed off for a focused run.
- **`docs(solutions)`** — server-first instant-paint learning.
