### PR TITLE
chore(agents): make AGENTS.md canonical, symlink CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,13 @@
 - Point Cloudflare review tunnels at the `bin/dev` Rails origin, not a production-mode preview server. Start an established port explicitly when needed (for example, `PORT=3001 bin/dev` for a tunnel already targeting 3001).
 - Keep Vite Ruby's development `skipProxy` disabled. Rails must proxy `/vite-dev` through the same tunnel origin; direct `localhost:3036` asset URLs produce a white page for remote reviewers.
 - Use `bin/vite build` only to verify a production build or prepare a production deployment, not for each tunnel iteration.
+
+# Deploying
+
+- Production runs on [Kamal](https://kamal-deploy.org/) (hosts: `thinkroom.kieranklaassen.com`, `pruf.kieranklaassen.com`). Deploy with `set -a; source .kamal/deploy.env; set +a; bin/kamal deploy`. See `DEPLOYING.md` for first-time setup and secrets.
+- There is no auto-deploy on merge — deploys are run manually after merging to `main`.
+
+# Documented knowledge
+
+- `docs/solutions/` — documented solutions to past problems (bugs, best practices, architecture patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in a documented area.
+- `docs/plans/` — implementation plans (`ce-plan` output); `CONCEPTS.md`, when present, holds shared domain vocabulary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
One instruction file: AGENTS.md holds the agent/dev/deploy guidance; CLAUDE.md is a symlink to it so Claude Code and other agents read the same source.

- Adds the deploy flow (manual Kamal) and a documented-knowledge pointer (docs/solutions/, docs/plans/, CONCEPTS.md) so agents discover the knowledge store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)