### PR TITLE
feat: Inertia SSR for the document page (loaded in one go)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,14 @@
 !/app/assets/builds/.keep
 /public/assets
 
+# Ignore Vite build output — the image rebuilds these (client via
+# assets:precompile, SSR via `vite build --ssr`). Excluding them keeps the
+# build context small and prevents stale host artifacts from leaking in.
+/public/vite
+/public/vite-ssr
+/public/vite-dev
+/public/vite-test
+
 # Ignore CI service files.
 /.github
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,13 +58,35 @@ COPY . .
 RUN bundle exec bootsnap precompile -j 1 app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+# (this runs the Vite CLIENT build via vite-plugin-ruby).
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
+# Build the Inertia SSR bundle. `bin/vite build --ssr` (vite-ruby's flavor)
+# insists on its own app/frontend/ssr/ssr.js entry; we use the @inertiajs/vite
+# plugin path instead. vite-plugin-ruby resolves the SSR entrypoint from
+# config/vite.json (ssrEntrypoint) and emits the entry chunk to
+# public/vite-ssr/ssr.js — exactly where config.ssr_bundle expects it. The
+# emitted file is a standalone Node server (createServer on port 13714).
+RUN npx vite build --ssr
 
 
 
 
 # Final stage for app image
 FROM base
+
+# Install a minimal Node.js runtime so the final image can run the Inertia SSR
+# bundle (public/vite-ssr/ssr.js). The build stage installed Node from
+# nodesource; mirror that here. node_modules are NOT copied into the runtime
+# image — the SSR bundle is self-contained (Vite bundles its deps), so only the
+# `node` binary is needed. If this install ever fails the image build fails
+# loudly rather than shipping a runtime that silently can't run SSR.
+ARG NODE_VERSION=22
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install --no-install-recommends -y nodejs && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,14 @@
 class DocumentsController < InertiaController
   rate_limit_document_creation
 
+  # SSR is scoped to the document page only — #show server-renders the shell,
+  # header, and the static content_html preview into the initial HTML so the
+  # prose is on screen at first byte. Every other action (index, create, …)
+  # stays CSR. The lambda is instance_exec'd per request, so #index never
+  # pays for SSR. Browser-only branches of #show (agent UA / .txt / .json)
+  # return before the inertia render, so SSR never touches them.
+  inertia_config ssr_enabled: -> { action_name == "show" }
+
   def index
     # Signed-in ownership follows the account across browsers. Guests retain
     # the original permanent-cookie ownership model.

--- a/app/frontend/editor/identity.ts
+++ b/app/frontend/editor/identity.ts
@@ -32,10 +32,16 @@ const pick = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
  * record is never overwritten by a chosen name, so clearing the session
  * name falls back to the same guest identity as before.
  */
-export function userIdentity(serverName?: string | null): UserIdentity {
+export function userIdentity(
+  serverName?: string | null,
+  options?: { allowStorage?: boolean },
+): UserIdentity {
   // Render-path callers (useForm initializers) must survive non-browser
-  // environments where localStorage doesn't exist.
-  if (typeof window === 'undefined') {
+  // environments where localStorage doesn't exist. `allowStorage: false` also
+  // forces this deterministic shape on the client's first (hydration) render
+  // so the server and client markup match — the stored guest identity is then
+  // applied in a post-hydration effect.
+  if (typeof window === 'undefined' || options?.allowStorage === false) {
     return { name: serverName ?? 'Anonymous', color: COLORS[0] }
   }
   const guest = guestIdentity()

--- a/app/frontend/editor/sketch/preview.ts
+++ b/app/frontend/editor/sketch/preview.ts
@@ -1,13 +1,15 @@
 import {
-  exportToSvg,
-  getCommonBounds,
-  sceneCoordsToViewportCoords,
-} from '@excalidraw/excalidraw'
-import {
   MAX_SKETCH_HEIGHT,
   MIN_SKETCH_HEIGHT,
   type SketchScene,
 } from './scene'
+
+// Excalidraw is loaded dynamically (like sketch/export.ts) so it never enters
+// the editor's static module graph. That keeps the editor bundle small AND
+// keeps the server-side render graph free of Excalidraw, whose eager
+// open-color.json import breaks Vite's SSR module loader. Only the exact
+// preview path below touches it, and it is already async + fire-and-forget.
+const loadExcalidraw = () => import('@excalidraw/excalidraw')
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 const SKETCH_PADDING = 24
@@ -255,6 +257,8 @@ export async function renderExactSketchPreview(
 ): Promise<SVGSVGElement | null> {
   const elements = scene.elements.filter((element) => element.isDeleted !== true)
   if (elements.length === 0) return null
+
+  const { exportToSvg, getCommonBounds, sceneCoordsToViewportCoords } = await loadExcalidraw()
 
   const exportPadding = SKETCH_PADDING
   const exported = await exportToSvg({

--- a/app/frontend/entrypoints/inertia.tsx
+++ b/app/frontend/entrypoints/inertia.tsx
@@ -1,7 +1,19 @@
 import { createInertiaApp } from '@inertiajs/react'
-import { createRoot } from 'react-dom/client'
-import { StrictMode } from 'react'
+import { createRoot, hydrateRoot } from 'react-dom/client'
+import { StrictMode, type ReactNode } from 'react'
 import { RiffrecProvider } from 'riffrec'
+
+// Every page mounts inside RiffrecProvider — the header's Feedback button
+// records screen/voice/event sessions anywhere. RiffrecProvider renders a
+// transparent passthrough on its first render (only Context.Provider, no DOM,
+// overlays start null) and the SSR build resolves riffrec's Node export (a
+// pure passthrough), so the server HTML and the client's first render are
+// byte-identical — no hydration mismatch.
+const Root = ({ children }: { children: ReactNode }) => (
+  <StrictMode>
+    <RiffrecProvider forceEnable>{children}</RiffrecProvider>
+  </StrictMode>
+)
 
 void createInertiaApp({
   pages: "../pages",
@@ -16,17 +28,23 @@ void createInertiaApp({
     },
   },
 
-  // Custom setup so every page mounts inside RiffrecProvider — the
-  // header's Feedback button records screen/voice/event sessions anywhere.
+  // Custom setup: on the server (no `el`) return the tree for renderToString;
+  // on the client hydrate the server-rendered HTML (or mount fresh for CSR
+  // pages where SSR is disabled and no server markup exists).
   setup({ el, App, props }) {
-    if (!el) return
-    createRoot(el).render(
-      <StrictMode>
-        <RiffrecProvider forceEnable>
-          <App {...props} />
-        </RiffrecProvider>
-      </StrictMode>,
+    const tree = (
+      <Root>
+        <App {...props} />
+      </Root>
     )
+    // Server render: @inertiajs/react/server passes el: null and expects the
+    // React element back to feed renderToString.
+    if (!el) return tree
+    if (el.dataset.serverRendered === "true") {
+      hydrateRoot(el, tree)
+    } else {
+      createRoot(el).render(tree)
+    }
   },
 }).catch((error) => {
   // This ensures this entrypoint is only loaded on Inertia pages

--- a/app/frontend/lib/use_is_client.ts
+++ b/app/frontend/lib/use_is_client.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from 'react'
+
+// The server snapshot is always false and the client snapshot is always true,
+// so the first client render matches the server (false → no hydration
+// mismatch) and the value flips to true on the next commit. Components gate
+// browser-only subtrees (the live editor, anything reading window/localStorage
+// at render time) behind this so they never render during SSR or the first
+// hydration pass.
+const subscribe = () => () => {}
+const getClientSnapshot = () => true
+const getServerSnapshot = () => false
+
+export function useIsClient(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot)
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -55,6 +55,7 @@ import {
 } from '../../components/mobile_dock'
 import { useMetaChannel } from '../../lib/use_meta_channel'
 import { useMediaQuery } from '../../lib/use_media_query'
+import { useIsClient } from '../../lib/use_is_client'
 import { useAnchoredPopover } from '../../lib/use_anchored_popover'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import { patchJSON } from '../../lib/csrf'
@@ -146,10 +147,29 @@ export default function DocumentShow({
   activities,
   presences,
 }: DocumentProps) {
+  // SSR/hydration island flag: the live editor and any render-time browser
+  // reads are gated on this so the server (and the client's first hydration
+  // render) produce identical markup. It flips true on the next client commit.
+  const isClient = useIsClient()
+
   // Initializer-only state plus an explicit rename handler — NOT a
   // sync-on-prop-change effect, which a future reload batch listing
   // `viewer` would silently clobber mid-rename.
-  const [identity, setIdentity] = useState<UserIdentity>(() => userIdentity(viewer.name))
+  //
+  // Hydration-safe init: server and the first client render derive identity
+  // from the server-provided viewer name only (userIdentity returns the SSR
+  // shape when window is absent, and we skip the localStorage guest read on the
+  // first client render). The stored guest identity (name + color) is applied
+  // in a post-hydration effect, one frame later, before the editor mounts.
+  const [identity, setIdentity] = useState<UserIdentity>(() =>
+    userIdentity(viewer.name, { allowStorage: false }),
+  )
+  useEffect(() => {
+    setIdentity(userIdentity(viewer.name))
+    // viewer.name is stable for the life of the page; the rename handler owns
+    // subsequent identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   const [guest, setGuest] = useState(viewer.guest)
   // Optimistic: a hydrated or freshly-seeded doc is functionally live the
   // moment it paints — the websocket only confirms it. Starting at 'live'
@@ -177,13 +197,27 @@ export default function DocumentShow({
   // a closure-captured handle goes stale when the editor remounts mid-flight.
   const handleRef = useRef<EditorHandle | null>(null)
   handleRef.current = handle
-  const [panelOpen, setPanelOpen] = useState(() => getStoredFlag('pruf:panel', true))
-  const [focusMode, setFocusMode] = useState(() => getStoredFlag('pruf:focus', false))
+  // Hydration-safe init: server and the first client render use the same fixed
+  // defaults these flags fall back to anyway (panel open, focus off, Edit
+  // mode). The stored localStorage prefs are applied in a post-hydration effect
+  // below — one frame later, before the editor mounts — so SSR markup matches.
+  const [panelOpen, setPanelOpen] = useState(true)
+  const [focusMode, setFocusMode] = useState(false)
   // Demo doc always opens in Edit and stays locked there.
   const modeLocked = doc.slug === 'demo'
-  const [mode, setMode] = useState<EditorMode>(() =>
-    modeLocked ? 'edit' : readStoredMode(doc.slug),
-  )
+  const [mode, setMode] = useState<EditorMode>('edit')
+  // Tracks whether stored prefs have been applied — gates the persisting
+  // effects below so the initial deterministic defaults aren't written back
+  // over the real stored values during the first commit.
+  const prefsHydrated = useRef(false)
+  useEffect(() => {
+    setPanelOpen(getStoredFlag('pruf:panel', true))
+    setFocusMode(getStoredFlag('pruf:focus', false))
+    if (!modeLocked) setMode(readStoredMode(doc.slug))
+    prefsHydrated.current = true
+    // doc.slug / modeLocked are stable for the page's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   const isReading = mode === 'read'
   // handleSelection is a stable callback — it reads the live mode via ref.
   const modeRef = useRef(mode)
@@ -194,8 +228,12 @@ export default function DocumentShow({
   }, [mode])
 
   // ≤64rem: rail and margin cards give way to anchor markers, a bottom dock,
-  // and sheets — the full product, rearranged for one hand.
-  const isMobile = useMediaQuery('(max-width: 64rem)')
+  // and sheets — the full product, rearranged for one hand. Masked by isClient
+  // so the first render is the desktop layout on both server and client (the
+  // matchMedia read happens only after mount) — the responsive collapse then
+  // applies one frame later, matching the editor mount.
+  const rawIsMobile = useMediaQuery('(max-width: 64rem)')
+  const isMobile = isClient && rawIsMobile
   const [activeSheet, setActiveSheet] = useState<SheetKind | null>(null)
   const [sheetFocusId, setSheetFocusId] = useState<number | null>(null)
   const suggestionsRef = useRef(suggestions)
@@ -225,10 +263,17 @@ export default function DocumentShow({
     if (isMobile && composerAnchor !== null) setActiveSheet('comments')
   }, [isMobile, composerAnchor])
 
-  useEffect(() => setStoredFlag('pruf:panel', panelOpen), [panelOpen])
-  useEffect(() => setStoredFlag('pruf:focus', focusMode), [focusMode])
+  // Persist only after the stored prefs have been read back in (the effect
+  // above). Without this gate the first commit's deterministic defaults would
+  // clobber the real stored values before they were ever applied.
   useEffect(() => {
-    if (!modeLocked) setStoredString(modeKey(doc.slug), mode)
+    if (prefsHydrated.current) setStoredFlag('pruf:panel', panelOpen)
+  }, [panelOpen])
+  useEffect(() => {
+    if (prefsHydrated.current) setStoredFlag('pruf:focus', focusMode)
+  }, [focusMode])
+  useEffect(() => {
+    if (prefsHydrated.current && !modeLocked) setStoredString(modeKey(doc.slug), mode)
   }, [mode, modeLocked, doc.slug])
 
   // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
@@ -1025,32 +1070,40 @@ export default function DocumentShow({
                     />
                   </div>
                 )}
+                {/* The editor is a client-only island: Milkdown/ProseMirror,
+                    Yjs, the ActionCable provider, and Excalidraw never render
+                    on the server. The server emits an empty doc-live-editor
+                    shell (identical on the client's first hydration render) and
+                    the static preview above carries first paint until the
+                    editor mounts post-hydration and the swap takes over. */}
                 <div className="doc-live-editor">
-                  <DocumentEditor
-                    slug={doc.slug}
-                    identity={identity}
-                    contentFormat={doc.content_format}
-                    initialStateB64={doc.yjs_state_b64}
-                    seedContent={doc.seed_content}
-                    seedGranted={doc.seed_granted}
-                    seedAuthorKind={doc.seed_author_kind}
-                    seedAuthorName={doc.seed_author_name}
-                    editable={mode === 'edit' || mode === 'suggest'}
-                    suggesting={mode === 'suggest'}
-                    taskInteractive={mode !== 'comment'}
-                    onReady={(h) => {
-                      setHandle(h)
-                      // Wait two frames so ProseMirror has painted the synced
-                      // content before the preview is removed.
-                      requestAnimationFrame(() =>
-                        requestAnimationFrame(() => setEditorSwapped(true)),
-                      )
-                    }}
-                    onStatus={setStatus}
-                    onSpans={setSpans}
-                    onSelection={isReading ? undefined : handleSelection}
-                    onTitleChange={setDocumentTitle}
-                  />
+                  {isClient && (
+                    <DocumentEditor
+                      slug={doc.slug}
+                      identity={identity}
+                      contentFormat={doc.content_format}
+                      initialStateB64={doc.yjs_state_b64}
+                      seedContent={doc.seed_content}
+                      seedGranted={doc.seed_granted}
+                      seedAuthorKind={doc.seed_author_kind}
+                      seedAuthorName={doc.seed_author_name}
+                      editable={mode === 'edit' || mode === 'suggest'}
+                      suggesting={mode === 'suggest'}
+                      taskInteractive={mode !== 'comment'}
+                      onReady={(h) => {
+                        setHandle(h)
+                        // Wait two frames so ProseMirror has painted the synced
+                        // content before the preview is removed.
+                        requestAnimationFrame(() =>
+                          requestAnimationFrame(() => setEditorSwapped(true)),
+                        )
+                      }}
+                      onStatus={setStatus}
+                      onSpans={setSpans}
+                      onSelection={isReading ? undefined : handleSelection}
+                      onTitleChange={setDocumentTitle}
+                    />
+                  )}
                 </div>
               </div>
             </article>

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,6 +3,24 @@
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
+
+  # Start the Inertia SSR server alongside the web server. inertia-rails only
+  # attempts SSR when this bundle exists AND it can reach the SSR process, and
+  # ssr_raise_on_error is false in production — so a missing bundle or a dead
+  # SSR process degrades the document page to client-side rendering, never a
+  # 500. We background SSR here (never exec it, never `&&` it to the web boot)
+  # so that:
+  #   - if `node` or the bundle is missing/broken, the web server still boots
+  #     (the container stays healthy and serves CSR — no crash loop), and
+  #   - Thruster + Rails remain the container's foreground/PID-tracked process,
+  #     so Kamal's health check follows the web server, not this side process.
+  SSR_BUNDLE="/rails/public/vite-ssr/ssr.js"
+  if [ -f "$SSR_BUNDLE" ]; then
+    echo "[ssr] starting Inertia SSR server: node $SSR_BUNDLE"
+    node "$SSR_BUNDLE" &
+  else
+    echo "[ssr] bundle not found at $SSR_BUNDLE — serving client-side rendering only"
+  fi
 fi
 
 exec "${@}"

--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -29,8 +29,18 @@ InertiaRails.configure do |config|
   # Bundle detection gates whether SSR is even attempted. In dev the Vite dev
   # server serves SSR (this check is bypassed when the dev server is running).
   # In production SSR proceeds only once the SSR bundle exists at this path —
-  # so until the production SSR build is wired (deploy unit, deferred), the doc
-  # page degrades cleanly to CSR instead of hammering a missing SSR server on
-  # every request. The plugin's SSR build emits the entry basename here.
-  config.ssr_bundle = Rails.root.join("public/vite-ssr/inertia.js").to_s
+  # so if the production SSR build is ever absent, the doc page degrades
+  # cleanly to CSR instead of hammering a missing SSR server on every request.
+  # `vite build --ssr` (vite-plugin-ruby) emits the entry chunk as ssr.js
+  # under its ssrOutputDir (public/vite-ssr); the Docker build produces it and
+  # the runtime image runs it as the Node SSR process (see Dockerfile).
+  config.ssr_bundle = Rails.root.join("public/vite-ssr/ssr.js").to_s
+
+  # In production point Inertia at the Node SSR process the container starts
+  # alongside Rails (backgrounded in bin/docker-entrypoint). Default matches
+  # @inertiajs/react/server's createServer port (13714) on localhost; override
+  # with INERTIA_SSR_URL if the SSR process is moved. In dev/test this stays
+  # nil so inertia-rails auto-detects the Vite dev server's /__inertia_ssr
+  # endpoint and no separate process is needed.
+  config.ssr_url = ENV.fetch("INERTIA_SSR_URL", "http://localhost:13714") if Rails.env.production?
 end

--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -8,4 +8,29 @@ InertiaRails.configure do |config|
   config.always_include_errors_hash = true
   config.use_script_element_for_initial_page = true
   config.use_data_inertia_head_attribute = true
+
+  # SSR. Globally OFF — DocumentsController#show opts in via inertia_config so
+  # only the document page is server-rendered (landing/auth stay CSR). In dev
+  # the Vite dev server serves SSR through inertia_rails' auto-detected
+  # /__inertia_ssr endpoint, so ssr_url stays nil. Production points ssr_url at
+  # the Node SSR process and ships an ssr_bundle (deferred — U6).
+  #
+  # Surface SSR render errors loudly in dev and degrade to CSR in production:
+  # a render failure must never 500 the production-critical doc page.
+  # on_ssr_error logs every failure so silent CSR fallbacks are visible.
+  config.ssr_raise_on_error = Rails.env.development?
+  config.on_ssr_error = ->(error, page) do
+    Rails.logger.error(
+      "[inertia-ssr] #{page&.dig(:component) || page&.dig('component')} render failed: " \
+      "#{error.class}: #{error.message}"
+    )
+  end
+
+  # Bundle detection gates whether SSR is even attempted. In dev the Vite dev
+  # server serves SSR (this check is bypassed when the dev server is running).
+  # In production SSR proceeds only once the SSR bundle exists at this path —
+  # so until the production SSR build is wired (deploy unit, deferred), the doc
+  # page degrades cleanly to CSR instead of hammering a missing SSR server on
+  # every request. The plugin's SSR build emits the entry basename here.
+  config.ssr_bundle = Rails.root.join("public/vite-ssr/inertia.js").to_s
 end

--- a/config/vite.json
+++ b/config/vite.json
@@ -1,7 +1,8 @@
 {
   "all": {
     "sourceCodeDir": "app/frontend",
-    "watchAdditionalPaths": []
+    "watchAdditionalPaths": [],
+    "ssrEntrypoint": "~/entrypoints/inertia.tsx"
   },
   "development": {
     "autoBuild": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,14 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     RubyPlugin(),
-    inertia(),
+    // Our client entry lives outside the plugin's auto-detected SSR paths
+    // (resources/js/*, src/*), so point it at the Inertia entry explicitly.
+    // The path is resolved against Vite's root, which vite-plugin-ruby sets to
+    // app/frontend (sourceCodeDir) — hence the root-relative entrypoints/…
+    // rather than app/frontend/…. The plugin reuses this entry's
+    // createInertiaApp for the SSR build and serves dev SSR through the Vite
+    // dev server's /__inertia_ssr endpoint (no separate process).
+    inertia({ ssr: 'entrypoints/inertia.tsx' }),
     react(),
   ],
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,12 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
+  // Bundle every dependency into the production SSR output so the runtime
+  // image can run `node public/vite-ssr/ssr.js` with only the node binary on
+  // PATH — no node_modules ship in the final Docker stage. Scoped to the SSR
+  // build (isSsrBuild) so the client build keeps Vite's default externals.
+  ...(isSsrBuild ? { ssr: { noExternal: true } } : {}),
   plugins: [
     tailwindcss(),
     RubyPlugin(),
@@ -14,8 +19,12 @@ export default defineConfig({
     // app/frontend (sourceCodeDir) — hence the root-relative entrypoints/…
     // rather than app/frontend/…. The plugin reuses this entry's
     // createInertiaApp for the SSR build and serves dev SSR through the Vite
-    // dev server's /__inertia_ssr endpoint (no separate process).
+    // dev server's /__inertia_ssr endpoint (no separate process). The
+    // matching vite-plugin-ruby SSR entrypoint is configured in
+    // config/vite.json (ssrEntrypoint), and `vite build --ssr` emits the
+    // bundle to public/vite-ssr/ssr.js (vite-plugin-ruby keys the SSR input
+    // as "ssr"); config.ssr_bundle in the initializer points there.
     inertia({ ssr: 'entrypoints/inertia.tsx' }),
     react(),
   ],
-})
+}))


### PR DESCRIPTION
## What

Inertia SSR for the document page — the shell, header, and the server-rendered `content_html` preview are now in the **initial HTML response**, before JS loads. Closes the ~220ms pre-React-mount blank window that the instant-first-paint work (PR #48) couldn't reach (a React-rendered preview can't fill a pre-React gap). The browser-only editor (Milkdown/ProseMirror/Excalidraw/Yjs/ActionCable) is a client-only island that mounts after hydration; the `booting → revealing → live` swap stays client-side.

Implements `docs/plans/2026-06-24-005-feat-inertia-ssr-plan.md` (U1–U6).

## How

- **`@inertiajs/vite` plugin SSR** (dev SSR runs through the Vite dev server — no separate process). `inertia({ ssr: 'entrypoints/inertia.tsx' })`; the client entry branches server (`renderToString`) vs client (`hydrateRoot`).
- **Client-only editor island** via a `useIsClient` hook — `DocumentEditor` renders nothing on the server; the static preview carries first paint; `editorSwapped`/`handle` start false on both server and client → byte-identical first render.
- **Hydration-safe state** — `identity`, `mode`, `panelOpen`, `focusMode`, `isMobile` render deterministic server defaults and apply `localStorage`/`window` values post-hydration.
- **Scoped to `documents#show`** via `inertia_config(ssr_enabled: …)`; landing/auth stay CSR.
- **Production wiring (U6):** the SSR bundle is built in the Docker build stage (`vite build --ssr`, `noExternal` → self-contained), Node 22 added to the runtime image, and `bin/docker-entrypoint` backgrounds the SSR server before `exec`-ing Thruster. `ssr_bundle` detection + `ssr_raise_on_error=false` + the backgrounded (never chained) process guarantee **graceful CSR fallback** — a missing/broken SSR process degrades to CSR, never a 500 or crash-loop.

## Verification

- **Dev SSR (Playwright):** server HTML contains `<h1>Instant Paint Demo</h1>` + first paragraph; **0 React hydration warnings**, **0 blank frames**, **CLS ~0.00003**, editor mounts post-hydration, agent/`.txt`/`.json` branches unchanged, landing stays CSR.
- **Production image:** full `docker build` succeeded; Node 22 + bundle present in-image; SSR server boots in-container (`/health` → 200); bundle proven self-contained (runs with no `node_modules`).
- `npm run check` clean; `bin/rails test` 296 runs, 0 failures.

## Code review (2 focused reviewers)

Server↔client first render verified byte-identical; CSR fallback verified three independent ways. Residual / follow-up:

- **P1 (pre-existing, `inertia_rails` gem):** the SSR `Net::HTTP` call has no `open_timeout`/`read_timeout` — a *hung* SSR process blocks a Puma thread ~60s before CSR fallback fires. Low probability for this lightweight render (no async/looping components; a crash gives fast `ECONNREFUSED` → immediate CSR), but worth a follow-up (gem timeout, or a sidecar proxy timeout).
- **P3:** redundant transient `localStorage` write on first mount (self-heals); SSR-error log noise if a non-prod env runs with `RAILS_ENV=production` and no SSR process.
- **Follow-up:** move `panelOpen`/`focusMode`/`mode` to cookies (like the theme already is) so the server renders the user's actual prefs and avoids a post-hydration flip for non-default users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
