### PR TITLE
feat(ssr): timeout hardening, cookie-backed prefs, landing SSR

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -64,6 +64,13 @@ class DocumentsController < InertiaController
     seed_granted = initial_render? && !prefetch_request? && document.try_claim_seed
 
     render inertia: "documents/show", props: {
+      # UI prefs ride server-readable cookies so SSR renders panel/focus/mode at
+      # their stored values on first paint — no post-hydration flip for users
+      # who closed the panel, enabled focus, or picked a non-Edit mode. The
+      # client writes these cookies on change (see show.tsx). mode for the demo
+      # doc is forced to "edit" client-side (modeLocked), so any stale cookie is
+      # ignored there.
+      ui: ui_prefs,
       document: document.slice(:id, :slug, :title, :content_format).merge(
         seed_content: document.seed_content,
         seed_granted: seed_granted,
@@ -298,6 +305,21 @@ class DocumentsController < InertiaController
 
   def remember_recent(document)
     session[:recent_slugs] = ([ document.slug ] + Array(session[:recent_slugs])).uniq.first(12)
+  end
+
+  # Cookie-backed UI prefs, read server-side so SSR's first paint matches the
+  # user's stored panel/focus/mode (no flip). Defaults match the historical
+  # localStorage fallbacks: panel open, focus off, Edit mode. Cookies are
+  # "1"/"0" flags and a "edit|suggest|comment|read" mode string; anything else
+  # falls back to the default.
+  UI_MODES = %w[edit suggest comment read].freeze
+
+  def ui_prefs
+    {
+      panel_open: cookies[:pruf_panel] != "0",
+      focus_mode: cookies[:pruf_focus] == "1",
+      mode: UI_MODES.include?(cookies[:pruf_mode]) ? cookies[:pruf_mode] : "edit"
+    }
   end
 
   # Browsers identify as Mozilla/...; curl, wget, httpx, ruby, etc. don't.

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,13 +1,15 @@
 class DocumentsController < InertiaController
   rate_limit_document_creation
 
-  # SSR is scoped to the document page only — #show server-renders the shell,
-  # header, and the static content_html preview into the initial HTML so the
-  # prose is on screen at first byte. Every other action (index, create, …)
-  # stays CSR. The lambda is instance_exec'd per request, so #index never
-  # pays for SSR. Browser-only branches of #show (agent UA / .txt / .json)
-  # return before the inertia render, so SSR never touches them.
-  inertia_config ssr_enabled: -> { action_name == "show" }
+  # SSR is scoped to the read-only document surfaces — #show (shell, header,
+  # static content_html preview) and #index (the landing page) — so their
+  # content is on screen at first byte. Both pages are SSR-safe: the live
+  # editor is a client-only island (useIsClient), and the landing reads no
+  # browser globals at render time (origin is filled post-hydration). Other
+  # actions (create, claim, …) stay CSR. The lambda is instance_exec'd per
+  # request. Browser-only branches of #show (agent UA / .txt / .json) return
+  # before the inertia render, so SSR never touches them.
+  inertia_config ssr_enabled: -> { %w[show index].include?(action_name) }
 
   def index
     # Signed-in ownership follows the account across browsers. Guests retain

--- a/app/frontend/lib/cookies.ts
+++ b/app/frontend/lib/cookies.ts
@@ -1,0 +1,17 @@
+/**
+ * Server-readable UI-pref persistence. Cookies (not localStorage) are the
+ * source of truth for first paint so SSR can render panel/focus/mode at their
+ * stored values — no post-hydration flip. Mirrors the theme cookie convention
+ * in theme_picker.tsx: path=/, SameSite=Lax, one-year max-age.
+ */
+const ONE_YEAR_SECONDS = 31536000
+
+export function setCookie(name: string, value: string): void {
+  // SSR / non-browser guard — writes are a no-op on the server.
+  if (typeof document === 'undefined') return
+  document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=${ONE_YEAR_SECONDS};samesite=lax`
+}
+
+export function setCookieFlag(name: string, value: boolean): void {
+  setCookie(name, value ? '1' : '0')
+}

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
 import { userIdentity } from '../../editor/identity'
 import { useClaim } from '../../lib/use_claim'
+import { useIsClient } from '../../lib/use_is_client'
 import type { OwnershipPayload } from '../../components/ownership_chip'
 import type { ViewerPayload } from '../../types/viewer'
 
@@ -63,8 +64,22 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     name: userIdentity(viewer.name).name,
   }))
   const [copied, setCopied] = useState(false)
+  // RiffrecRecorder (the Feedback button) is not SSR-isomorphic — its Node
+  // passthrough renders different markup than the browser build, so rendering
+  // it on the server would mismatch on hydration. Gate it as a client-only
+  // island: the corner shows AccountControl (SSR-safe) on first paint and the
+  // Feedback button mounts one frame later, after hydration. On the doc page
+  // FeedbackButton lives inside a closed HeaderMenu, so it never renders on
+  // first paint there — this gate is only needed where it renders eagerly.
+  const isClient = useIsClient()
 
-  const origin = typeof window === 'undefined' ? '' : window.location.origin
+  // SSR-safe: the server and the client's first render both use an empty
+  // origin so the rendered agent instruction matches (no hydration mismatch);
+  // the real origin is filled in a post-hydration effect, one frame later.
+  const [origin, setOrigin] = useState('')
+  useEffect(() => {
+    setOrigin(window.location.origin)
+  }, [])
   const agentInstruction =
     `Create a Thinkroom document for me: POST ${origin}/api/docs with JSON ` +
     `{"title": "…", "format": "markdown", "content": "# …"} ` +
@@ -88,7 +103,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
       <div className="landing">
         <div className="landing-corner">
           <AccountControl viewer={viewer} />
-          <FeedbackButton />
+          {isClient && <FeedbackButton />}
         </div>
         <main className="landing-main">
           <h1 className="landing-wordmark">

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -60,12 +60,7 @@ import { useAnchoredPopover } from '../../lib/use_anchored_popover'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import { patchJSON } from '../../lib/csrf'
 import type { ViewerPayload } from '../../types/viewer'
-import {
-  getStoredFlag,
-  getStoredString,
-  setStoredFlag,
-  setStoredString,
-} from '../../lib/local_storage'
+import { setCookie, setCookieFlag } from '../../lib/cookies'
 import './show.css'
 
 export interface ActivityPayload {
@@ -93,6 +88,13 @@ export interface DocumentProps {
     display_title: string
   }
   viewer: ViewerPayload
+  // Server-rendered UI prefs from cookies — the source of truth for first
+  // paint so SSR and the client's first render agree (no post-hydration flip).
+  ui: {
+    panel_open: boolean
+    focus_mode: boolean
+    mode: EditorMode
+  }
   ownership: OwnershipPayload
   suggestions: SuggestionPayload[]
   comments: CommentPayload[]
@@ -129,18 +131,10 @@ const capAnchor = (text: string): string => {
   return new TextDecoder().decode(bytes.slice(0, ANCHOR_BYTE_CAP)).replace(/�+$/, '')
 }
 
-// Editor mode persists per doc (Google-Docs semantics: your mode, your
-// browser). Client-side only by design — never server state, never shared.
-const modeKey = (slug: string) => `pruf:mode:${slug}`
-
-const readStoredMode = (slug: string): EditorMode => {
-  const raw = getStoredString(modeKey(slug))
-  return raw === 'suggest' || raw === 'comment' || raw === 'read' ? raw : 'edit'
-}
-
 export default function DocumentShow({
   document: doc,
   viewer,
+  ui,
   ownership,
   suggestions,
   comments,
@@ -197,27 +191,17 @@ export default function DocumentShow({
   // a closure-captured handle goes stale when the editor remounts mid-flight.
   const handleRef = useRef<EditorHandle | null>(null)
   handleRef.current = handle
-  // Hydration-safe init: server and the first client render use the same fixed
-  // defaults these flags fall back to anyway (panel open, focus off, Edit
-  // mode). The stored localStorage prefs are applied in a post-hydration effect
-  // below — one frame later, before the editor mounts — so SSR markup matches.
-  const [panelOpen, setPanelOpen] = useState(true)
-  const [focusMode, setFocusMode] = useState(false)
-  // Demo doc always opens in Edit and stays locked there.
+  // Hydration-safe init from server-rendered cookie prefs: SSR and the client's
+  // first render derive panel/focus/mode from the same `ui` props, so a user
+  // who closed the panel (etc.) sees it closed at first paint — no flip. The
+  // client writes the cookie on change (effects below); cookies, not
+  // localStorage, are now the source of truth for first paint.
+  const [panelOpen, setPanelOpen] = useState(ui.panel_open)
+  const [focusMode, setFocusMode] = useState(ui.focus_mode)
+  // Demo doc always opens in Edit and stays locked there — a stale mode cookie
+  // can't override it (the server also defaults it; this is the client guard).
   const modeLocked = doc.slug === 'demo'
-  const [mode, setMode] = useState<EditorMode>('edit')
-  // Tracks whether stored prefs have been applied — gates the persisting
-  // effects below so the initial deterministic defaults aren't written back
-  // over the real stored values during the first commit.
-  const prefsHydrated = useRef(false)
-  useEffect(() => {
-    setPanelOpen(getStoredFlag('pruf:panel', true))
-    setFocusMode(getStoredFlag('pruf:focus', false))
-    if (!modeLocked) setMode(readStoredMode(doc.slug))
-    prefsHydrated.current = true
-    // doc.slug / modeLocked are stable for the page's lifetime.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  const [mode, setMode] = useState<EditorMode>(modeLocked ? 'edit' : ui.mode)
   const isReading = mode === 'read'
   // handleSelection is a stable callback — it reads the live mode via ref.
   const modeRef = useRef(mode)
@@ -263,18 +247,19 @@ export default function DocumentShow({
     if (isMobile && composerAnchor !== null) setActiveSheet('comments')
   }, [isMobile, composerAnchor])
 
-  // Persist only after the stored prefs have been read back in (the effect
-  // above). Without this gate the first commit's deterministic defaults would
-  // clobber the real stored values before they were ever applied.
+  // Persist prefs to server-readable cookies on change so the next first paint
+  // (SSR) matches. No hydration gate is needed: state initializes from the same
+  // cookie-backed props, so the first commit writes back the value it just read
+  // — idempotent, not a clobber. Demo doc never persists mode (it's locked).
   useEffect(() => {
-    if (prefsHydrated.current) setStoredFlag('pruf:panel', panelOpen)
+    setCookieFlag('pruf_panel', panelOpen)
   }, [panelOpen])
   useEffect(() => {
-    if (prefsHydrated.current) setStoredFlag('pruf:focus', focusMode)
+    setCookieFlag('pruf_focus', focusMode)
   }, [focusMode])
   useEffect(() => {
-    if (prefsHydrated.current && !modeLocked) setStoredString(modeKey(doc.slug), mode)
-  }, [mode, modeLocked, doc.slug])
+    if (!modeLocked) setCookie('pruf_mode', mode)
+  }, [mode, modeLocked])
 
   // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
   useEffect(() => {

--- a/config/initializers/inertia_ssr_timeout.rb
+++ b/config/initializers/inertia_ssr_timeout.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# inertia_rails (3.21.1) renders SSR by POSTing the page JSON to the Node SSR
+# process via Net::HTTP with NO open/read timeout, so it inherits Ruby's ~60s
+# default. A *hung* (not crashed) SSR process would therefore pin a Puma thread
+# for ~60s before the CSR fallback fires — a handful of hung renders exhaust the
+# thread pool and stall the whole app. The gem exposes no timeout config option
+# (see InertiaRails::Configuration::DEFAULTS), so we bound the SSR HTTP call to a
+# short timeout here. A timeout raises inside SSRRenderer#request, which the gem
+# already rescues into an SSRError → on_ssr_error logging → CSR fallback (in
+# production, where ssr_raise_on_error is false). A hung SSR process now fails
+# fast to CSR instead of starving Puma.
+#
+# Implementation: rather than re-implement the gem's #request body (which would
+# drift if the gem changes its error handling), we leave the gem's request flow
+# untouched and only inject open_timeout/read_timeout into the Net::HTTP
+# connection it opens, scoped to the SSR call via a thread-local flag. This
+# keeps coupling to gem internals minimal — we depend only on the gem opening
+# its connection through Net::HTTP.start inside #request.
+#
+# Override INERTIA_SSR_TIMEOUT to tune (seconds).
+InertiaRails::SSRRenderer.class_eval do
+  # Loud boot-time guard: if a future gem version removes #request, the patch is
+  # silently dead and a hung SSR process is back to ~60s. Fail at boot instead.
+  unless private_method_defined?(:request)
+    raise "inertia_ssr_timeout: InertiaRails::SSRRenderer no longer defines #request " \
+          "(gem internals changed). Re-verify the SSR HTTP timeout patch against the " \
+          "installed inertia_rails version before removing this guard."
+  end
+end
+
+module InertiaSSRTimeout
+  TIMEOUT_SECONDS = Float(ENV.fetch("INERTIA_SSR_TIMEOUT", "2"))
+
+  # Marks the SSR HTTP call so the Net::HTTP patch below only bounds inertia's
+  # SSR connection, never every Net::HTTP.start in the app.
+  def request
+    Thread.current[:inertia_ssr_http_active] = true
+    super
+  ensure
+    Thread.current[:inertia_ssr_http_active] = nil
+  end
+
+  # Injects the short timeouts into the connection inertia opens. Net::HTTP.start
+  # accepts open_timeout/read_timeout as opts; we merge them in only for the SSR
+  # call. Guarded so it fails loudly at boot if Net::HTTP.start's arity changes.
+  module NetHTTPPatch
+    def start(address, *args, &block)
+      if Thread.current[:inertia_ssr_http_active]
+        opts = args.last.is_a?(Hash) ? args.pop.dup : {}
+        opts[:open_timeout] = InertiaSSRTimeout::TIMEOUT_SECONDS
+        opts[:read_timeout] = InertiaSSRTimeout::TIMEOUT_SECONDS
+        args.push(opts)
+      end
+      super(address, *args, &block)
+    end
+  end
+end
+
+InertiaRails::SSRRenderer.prepend(InertiaSSRTimeout)
+Net::HTTP.singleton_class.prepend(InertiaSSRTimeout::NetHTTPPatch)

--- a/test/integration/inertia_ssr_timeout_test.rb
+++ b/test/integration/inertia_ssr_timeout_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+require "socket"
+
+# Guards config/initializers/inertia_ssr_timeout.rb: a *hung* SSR Node process
+# (TCP connect succeeds, read blocks forever) must fail fast via a short HTTP
+# timeout rather than pinning a Puma thread for Ruby's ~60s default. The gem
+# wraps any SSR error into an SSRError → CSR fallback, so a hung process now
+# degrades to CSR quickly instead of starving the thread pool.
+class InertiaSsrTimeoutTest < ActiveSupport::TestCase
+  test "the timeout patch is wired into the renderer and Net::HTTP" do
+    assert_includes InertiaRails::SSRRenderer.ancestors, InertiaSSRTimeout,
+      "SSRRenderer#request must be wrapped to flag the SSR HTTP call"
+    assert_includes Net::HTTP.singleton_class.ancestors, InertiaSSRTimeout::NetHTTPPatch,
+      "Net::HTTP.start must be patched to inject the SSR timeout"
+    assert_operator InertiaSSRTimeout::TIMEOUT_SECONDS, :<=, 5,
+      "SSR timeout must stay short so a hung render fails fast"
+  end
+
+  test "a hung SSR server fails fast instead of blocking ~60s" do
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    # Accept connections but never write a response — connect succeeds, the
+    # read blocks. This is the hung-process case the timeout must bound.
+    accept_thread = Thread.new do
+      loop do
+        server.accept
+      rescue StandardError
+        break
+      end
+    end
+
+    config = InertiaRails::Configuration.default
+    config.ssr_url = "http://127.0.0.1:#{port}"
+    config.ssr_bundle = nil          # skip bundle check → actually attempt SSR
+    config.ssr_raise_on_error = true # surface the timeout so the test can see it
+
+    page = { component: "documents/show", props: {}, url: "/", version: "x" }
+    renderer = InertiaRails::SSRRenderer.new(config, page: page)
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    error = assert_raises(InertiaRails::SSRError) { renderer.render }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_match(/timeout/i, error.message, "the failure must be a timeout")
+    # Comfortably under Ruby's ~60s default; the configured timeout is ~2s.
+    assert_operator elapsed, :<, 10, "a hung SSR render must fail fast (got #{elapsed.round(2)}s)"
+  ensure
+    server&.close
+    accept_thread&.kill
+  end
+end


### PR DESCRIPTION
SSR follow-ups from the PR #50 review + the post-ship decisions. Builds on the live document-page SSR.

## 1. Bound the SSR render with a short HTTP timeout (`fix(ssr)`)
`inertia_rails` does the SSR render over `Net::HTTP` with no timeout (~60s default), so a *hung* (not crashed) SSR process could pin Puma threads before the CSR fallback fires. The gem exposes no timeout option, so a small, version-guarded initializer injects a 2s open/read timeout **scoped to the SSR connection only** (thread-local flag; never touches other `Net::HTTP` calls). A timeout now raises → gem's `SSRError` rescue → `on_ssr_error` → CSR fallback. Verified: hung server → fails in 2.01s → CSR; dead port → CSR in 0.001s. New renderer-level test.

## 2. Server-render panel/focus/mode from cookies (`feat(ssr)`)
These prefs were read from `localStorage` post-hydration, so under SSR they rendered the default then flipped for non-default users. Now read from `pruf_panel`/`pruf_focus`/`pruf_mode` cookies server-side (mirroring the existing `proof_theme` pattern) and passed as the `ui` prop, so first paint matches the user's prefs — no flip, no hydration mismatch. The client writes the cookie on change. Removes the redundant-localStorage-write the review flagged.

## 3. Server-render the landing page (`feat(ssr)`)
SSR scope broadened from `show` to `%w[show index]`. Made `documents/index.tsx` SSR-safe: `window.location.origin` now fills post-hydration (was a render-time read → mismatch), and the `RiffrecRecorder` feedback button (not SSR-isomorphic) is gated behind `useIsClient` as a client-only island.

## Verification
- Doc-page SSR **not regressed** (data-server-rendered + content; 0 hydration warnings; editor mounts, phase → live).
- Landing SSR live (content in HTML, `data-server-rendered`, 0 hydration warnings, 0 page errors).
- Cookie prefs: `pruf_panel=0;pruf_focus=1;pruf_mode=read` → SSR `class="doc-page is-panel-hidden is-read-mode"`, no flip.
- `npm run check` clean; `bin/rails test` 298 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
