### PR TITLE
fix(ssr): stop the collaborator header flicker (cookie-backed identity + reserved presence lane)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,3 +79,44 @@
 .doc-static-preview .ProseMirror li {
   position: relative;
 }
+
+/* ---------------------------------------------------------------------------
+ * Header presence-bar reserved lane (on-load layout stability)
+ *
+ * The document header's people cluster (.doc-header-people in
+ * app/frontend/pages/documents/show.tsx) holds: identity chip · provenance
+ * chip · PresenceBar. Human peers join via Yjs awareness over the websocket,
+ * so they CANNOT be server-rendered — they fade in a beat after first paint.
+ * Before this, the empty bar took zero width, so the first peer (0→N avatars +
+ * "N here") widened the cluster and shoved the Edit/Share/⋯ controls left.
+ *
+ * Fix: reserve a fixed-width lane for .presence-bar in THIS render-blocking
+ * Rails-pipeline stylesheet, so the lane's geometry is determined at first
+ * paint. Avatars then appear WITHIN the lane (acceptable) instead of pushing
+ * the neighbouring controls (a layout shift, not acceptable). The bar always
+ * renders now (even empty, data-empty) so the lane exists from the first frame.
+ *
+ * Scoped to .presence-bar in the header; the editor body is untouched. The
+ * Vite stylesheet (app/frontend/entrypoints/application.css) styles the bar's
+ * internals (avatars, count) — these rules only pin the lane width.
+ * ------------------------------------------------------------------------- */
+.doc-header-people .presence-bar {
+  /* Room for a couple of overlapping 28px avatars + the "N here" count, so a
+   * small group fits without reflow; larger groups collapse into the +N
+   * overflow chip, which also stays within the lane. */
+  min-width: 7.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+/* The empty bar reserves its lane but shows nothing — no stray gap from the
+ * inherited flex gap on a childless box. */
+.doc-header-people .presence-bar[data-empty] {
+  gap: 0;
+}
+
+/* Compact (mobile) header: 24px avatars, max 3 — a tighter lane. */
+.doc-header-people .presence-bar--compact {
+  min-width: 5rem;
+}

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -21,13 +21,44 @@ class InertiaController < ApplicationController
   # see https://inertia-rails.dev/guide/shared-data
   # Account identity wins over the optional guest display name. Only the
   # small public account shape reaches the client.
+  #
+  # The guest identity (random name + presence color) lives only in the
+  # browser, so it rides a plain `pruf_guest` cookie (written client-side,
+  # see app/frontend/lib/cookies.ts) so SSR can render the real guest name +
+  # color at first paint — no Anonymous→name flash post-hydration. Signed-in
+  # users ignore it (their account name wins).
   inertia_share viewer: -> {
     account = current_user&.slice(:id, :name, :email)
     name = current_user&.name || session[:display_name]
-    { name:, guest: current_user.nil? && name.blank?, account: }
+    guest = guest_identity_cookie
+    {
+      name:,
+      guest: current_user.nil? && name.blank?,
+      account:,
+      guest_name: (guest["name"] if current_user.nil?),
+      guest_color: (guest["color"] if current_user.nil?)
+    }
   }
 
   private
+
+  # Parse the client-written `pruf_guest` JSON cookie ({name, color}). It's
+  # presentation-only (a random label + a paper-friendly color), so a plain
+  # cookie is fine — no signing. Malformed/oversized values degrade to {}.
+  def guest_identity_cookie
+    raw = cookies[:pruf_guest]
+    return {} if raw.blank? || raw.bytesize > 512
+
+    parsed = JSON.parse(raw)
+    return {} unless parsed.is_a?(Hash)
+
+    {
+      "name" => (parsed["name"] if parsed["name"].is_a?(String) && parsed["name"].present?),
+      "color" => (parsed["color"] if parsed["color"].is_a?(String) && parsed["color"].match?(/\A#[0-9a-fA-F]{3,8}\z/))
+    }.compact
+  rescue JSON::ParserError
+    {}
+  end
 
   # Session name wins over client-posted names on every attribution write —
   # a stale tab can't sign your old guest name once you've introduced

--- a/app/frontend/components/presence_bar.tsx
+++ b/app/frontend/components/presence_bar.tsx
@@ -29,15 +29,21 @@ const initials = (name: string): string =>
 
 export function PresenceBar({ humans, agents, compact = false }: Props) {
   const total = humans.length + agents.length
-  if (total === 0) return null
 
   const visibleHumans = humans.slice(0, compact ? MAX_VISIBLE_COMPACT : MAX_VISIBLE)
   const overflow = humans.length - visibleHumans.length
 
+  // Always render the container — even with 0 collaborators — so its reserved
+  // lane (a min-width in render-blocking CSS, scoped to .presence-bar) holds
+  // the header's layout stable. Human peers arrive over the websocket after
+  // first paint; they fade in WITHIN this lane instead of pushing the
+  // Edit/Share/⋯ controls. Empty is visually blank but occupies the lane.
   return (
     <span
       className={`presence-bar ${compact ? 'presence-bar--compact' : ''}`}
-      aria-label={`${total} collaborators present`}
+      data-empty={total === 0 ? '' : undefined}
+      aria-label={total === 0 ? undefined : `${total} collaborators present`}
+      aria-hidden={total === 0 ? true : undefined}
     >
       {agents.map((agent) => (
         <span

--- a/app/frontend/editor/identity.ts
+++ b/app/frontend/editor/identity.ts
@@ -1,7 +1,21 @@
+import { setCookie } from '../lib/cookies'
+
 export interface UserIdentity {
   name: string
   color: string
 }
+
+/** The browser's guest identity as the server saw it, from the `pruf_guest`
+ *  cookie included in the viewer prop. Null when no guest cookie was set. */
+export interface ServerGuestIdentity {
+  guest_name: string | null
+  guest_color: string | null
+}
+
+// Plain cookie (presentation-only) mirroring the localStorage record so the
+// server can render the guest name + color at first paint. Read in
+// InertiaController#guest_identity_cookie.
+const GUEST_COOKIE = 'pruf_guest'
 
 const ADJECTIVES = [
   'Quiet', 'Amber', 'Swift', 'Gentle', 'Bold', 'Velvet', 'Lucid', 'Mellow',
@@ -48,11 +62,46 @@ export function userIdentity(
   return serverName ? { ...guest, name: serverName } : guest
 }
 
-/** The random localStorage identity — what you are with no chosen name. */
+/**
+ * The SSR-stable identity for the document header's first render. The server
+ * already inlined the guest identity (name + color) from the `pruf_guest`
+ * cookie into the viewer prop, so both the server render and the client's
+ * first hydration render derive identity from props alone — byte-identical,
+ * no localStorage read, no hydration mismatch.
+ *
+ * A chosen session name (serverName) always wins over the guest identity.
+ * When neither is present (first-ever visit, before the cookie exists) it
+ * falls back to the deterministic Anonymous shape; the stored localStorage
+ * guest is then reconciled in a one-time post-hydration effect.
+ */
+export function serverIdentity(
+  serverName: string | null | undefined,
+  guest: ServerGuestIdentity,
+): UserIdentity {
+  if (serverName) return { name: serverName, color: guest.guest_color ?? COLORS[0] }
+  if (guest.guest_name) {
+    return { name: guest.guest_name, color: guest.guest_color ?? COLORS[0] }
+  }
+  return { name: 'Anonymous', color: COLORS[0] }
+}
+
+/** True when the server already knew the guest identity from the cookie — in
+ *  that case there is nothing to reconcile post-hydration (no flicker). */
+export function serverKnewGuest(guest: ServerGuestIdentity): boolean {
+  return Boolean(guest.guest_name)
+}
+
+/** The random localStorage identity — what you are with no chosen name. The
+ *  cookie is kept in sync on every read so the NEXT load is server-correct
+ *  (the one-time migration for users whose identity predates the cookie). */
 function guestIdentity(): UserIdentity {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) return JSON.parse(stored) as UserIdentity
+    if (stored) {
+      const identity = JSON.parse(stored) as UserIdentity
+      writeGuestCookie(identity)
+      return identity
+    }
   } catch {
     // storage unavailable — fall through to a fresh identity
   }
@@ -61,10 +110,43 @@ function guestIdentity(): UserIdentity {
     name: `${pick(ADJECTIVES)} ${pick(ANIMALS)}`,
     color: pick(COLORS),
   }
+  persistGuestIdentity(identity)
+  return identity
+}
+
+/** Persist a guest identity to both localStorage (legacy source of truth) and
+ *  the `pruf_guest` cookie (server-readable for first-paint SSR). */
+export function persistGuestIdentity(identity: UserIdentity): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(identity))
   } catch {
-    // fine — identity just won't persist
+    // fine — identity just won't persist to storage
   }
-  return identity
+  writeGuestCookie(identity)
+}
+
+function writeGuestCookie(identity: UserIdentity): void {
+  // Only the fields the server reads — keep it small and stable so a present
+  // cookie never disagrees with the localStorage record byte-for-byte.
+  setCookie(GUEST_COOKIE, JSON.stringify({ name: identity.name, color: identity.color }))
+}
+
+/** Read the stored guest identity without generating one — used by the
+ *  document page's post-hydration migration (cookie absent on first load). */
+export function storedGuestIdentity(): UserIdentity | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored ? (JSON.parse(stored) as UserIdentity) : null
+  } catch {
+    return null
+  }
+}
+
+/** Sync the `pruf_guest` cookie from localStorage when present, generating a
+ *  fresh guest identity (and cookie) when absent. Returns the identity that is
+ *  now the server's source of truth for the NEXT load. Safe to call from a
+ *  post-hydration effect — never during render. */
+export function reconcileGuestCookie(): UserIdentity {
+  return guestIdentity()
 }

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -8,7 +8,15 @@ import {
   type EditorHandle,
 } from '../../editor/milkdown_editor'
 import type { DocumentFormat } from '../../editor/document_format'
-import { userIdentity, type UserIdentity } from '../../editor/identity'
+import {
+  userIdentity,
+  serverIdentity,
+  serverKnewGuest,
+  persistGuestIdentity,
+  reconcileGuestCookie,
+  storedGuestIdentity,
+  type UserIdentity,
+} from '../../editor/identity'
 import { provenanceIdentityCtx } from '../../editor/provenance'
 import {
   aiSpanAt,
@@ -150,17 +158,40 @@ export default function DocumentShow({
   // sync-on-prop-change effect, which a future reload batch listing
   // `viewer` would silently clobber mid-rename.
   //
-  // Hydration-safe init: server and the first client render derive identity
-  // from the server-provided viewer name only (userIdentity returns the SSR
-  // shape when window is absent, and we skip the localStorage guest read on the
-  // first client render). The stored guest identity (name + color) is applied
-  // in a post-hydration effect, one frame later, before the editor mounts.
+  // Hydration-safe init: server and the first client render BOTH derive
+  // identity from the viewer prop alone — the chosen session name, else the
+  // guest name + color the server read from the `pruf_guest` cookie, else
+  // Anonymous. No localStorage read during render, so the markup is
+  // byte-identical (zero hydration mismatch).
+  //
+  // When the cookie was present (the common returning-user case) the server
+  // already rendered the real guest identity → NOTHING changes post-hydration.
+  // Only when the cookie was absent (first-ever load, or a user whose identity
+  // predates the cookie) does the post-hydration effect reconcile from
+  // localStorage and write the cookie so the NEXT load is server-correct.
   const [identity, setIdentity] = useState<UserIdentity>(() =>
-    userIdentity(viewer.name, { allowStorage: false }),
+    serverIdentity(viewer.name, viewer),
   )
   useEffect(() => {
-    setIdentity(userIdentity(viewer.name))
-    // viewer.name is stable for the life of the page; the rename handler owns
+    // A chosen session name always wins and is server-known — never overridden
+    // by the guest identity.
+    if (viewer.name) return
+    if (serverKnewGuest(viewer)) {
+      // Server already rendered the cookie-backed guest identity. Re-seed
+      // localStorage from it when storage is empty (cookie present but storage
+      // cleared) so the cookie stays authoritative — never regenerate a fresh
+      // identity here, which would silently rename the user on the next load.
+      // Do NOT change React state: that would be the post-hydration flip we
+      // just worked to avoid.
+      if (!storedGuestIdentity()) persistGuestIdentity(identity)
+      return
+    }
+    // Cookie absent: reconcile from localStorage (one-time migration) and write
+    // the cookie. If there's no stored identity yet, generate + persist one.
+    const stored = storedGuestIdentity()
+    setIdentity(stored ?? reconcileGuestCookie())
+    if (stored) persistGuestIdentity(stored)
+    // viewer is stable for the life of the page; the rename handler owns
     // subsequent identity changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/app/frontend/types/viewer.ts
+++ b/app/frontend/types/viewer.ts
@@ -8,4 +8,9 @@ export interface ViewerPayload {
   name: string | null
   guest: boolean
   account: AccountPayload | null
+  // The browser's random guest identity, cookie-backed so the server can
+  // render the real name + color at first paint (no Anonymous→name flash).
+  // Null when no guest cookie is set (first-ever visit, or signed in).
+  guest_name: string | null
+  guest_color: string | null
 }


### PR DESCRIPTION
## What

Stops the header "collaborators" area from flickering on load (under SSR).

**Before:** header-right rendered `Anonymous · guest … Edit Share ⋯` on SSR first paint, then flipped to `Velvet Stoat · guest  [avatars]  Edit Share ⋯` after hydration + websocket — two visible changes (your own name, and the presence avatars shoving the buttons over).

## Fixes

1. **Cookie-back the guest identity** — the guest name + color lived only in `localStorage`, so the server rendered the `Anonymous` fallback then the client swapped your real name in. Now mirrored to a `pruf_guest` cookie (same pattern as the `pruf_panel`/`pruf_focus`/`pruf_mode` UI-pref cookies), read server-side into the `viewer` prop, so the server renders your real name + color **from the first byte**. `show.tsx` initializes identity from the prop (no `localStorage` read during render → no hydration mismatch); post-hydration only reconciles in the cookie-absent migration case. Matches the app's existing `owner_token` "persistent anonymous identity = cookie" convention (sessions are reserved for auth/flow).
2. **Reserve the presence lane** — the presence bar now always occupies a fixed min-width (render-blocking CSS), so when live human peers fade in over the websocket they don't shift the identity chip / Edit / Share / ⋯ buttons.

## Verification (real Chrome, browser UA)

- With the `pruf_guest` cookie set, the SSR HTML carries the real name + color from the first byte; header-right text is **identical at first-paint, after-load, and live** (`Velvet Stoat · guest … Edit Share ⋯`). No `Anonymous` flash.
- **0 React hydration warnings** (the pre-existing header mismatch on `main` is gone).
- Header button x-positions are **unchanged** whether 0 or N presence avatars are shown.
- Editor unaffected; `npm run check` clean; `bin/rails test` 298 runs, 0 failures.

Note: the very first visit on a brand-new browser (no cookie yet) still shows `Anonymous` for one paint while the cookie is written; every load after is clean. Eliminating that fully would mean server-side name generation (a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
