### PR TITLE
fix(api): document the markdown sketch schema and surface silent fence failures

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -66,8 +66,8 @@ module Api
       warning =
         if normalization&.changed?
           "Unsupported HTML was removed or normalized."
-        elsif sketch_audit&.unrecognized?
-          unrecognized_sketch_warning(sketch_audit.unrecognized_count)
+        else
+          sketch_audit&.warning_message
         end
 
       response = {
@@ -91,16 +91,6 @@ module Api
     def show
       touch_presence
       render json: AgentGuide.state(document, request.base_url)
-    end
-
-    private
-
-    def unrecognized_sketch_warning(count)
-      if count == 1
-        "An excalidraw block was not a valid sketch and was kept as a code block."
-      else
-        "#{count} excalidraw blocks were not valid sketches and were kept as code blocks."
-      end
     end
   end
 end

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -57,6 +57,19 @@ module Api
         )
       end
 
+      # Markdown isn't server-normalized, but an excalidraw fence that fails
+      # ThinkroomSketch.parse is silently kept as a dead code block. Audit the
+      # stored source (== plain_text's source) so the response can report it
+      # instead of looking byte-for-byte identical to a recognized sketch.
+      sketch_audit = format == "html" ? nil : MarkdownSketchAudit.call(doc.seed_content)
+      normalized = normalization&.changed? || sketch_audit&.unrecognized? || false
+      warning =
+        if normalization&.changed?
+          "Unsupported HTML was removed or normalized."
+        elsif sketch_audit&.unrecognized?
+          unrecognized_sketch_warning(sketch_audit.unrecognized_count)
+        end
+
       response = {
         slug: doc.slug,
         title: doc.title,
@@ -64,8 +77,8 @@ module Api
         content_format: doc.content_format,
         content: doc.seed_content,
         plain_text: doc.plain_text,
-        normalized: normalization&.changed? || false,
-        warning: ("Unsupported HTML was removed or normalized." if normalization&.changed?),
+        normalized: normalized,
+        warning: warning,
         note: "This document is unclaimed. The first person to open the share URL in a browser can claim it — claiming grants them ownership (including delete).",
         content_contract: AgentGuide.content_contract(doc.content_format, request.base_url),
         api: AgentGuide.endpoints(doc, request.base_url)
@@ -78,6 +91,16 @@ module Api
     def show
       touch_presence
       render json: AgentGuide.state(document, request.base_url)
+    end
+
+    private
+
+    def unrecognized_sketch_warning(count)
+      if count == 1
+        "An excalidraw block was not a valid sketch and was kept as a code block."
+      else
+        "#{count} excalidraw blocks were not valid sketches and were kept as code blocks."
+      end
     end
   end
 end

--- a/app/controllers/api/suggestions_controller.rb
+++ b/app/controllers/api/suggestions_controller.rb
@@ -19,11 +19,23 @@ module Api
       )
       DocumentAsset.claim_from_html!(document:, source: suggestion.body) if document.html?
 
+      # A markdown suggestion can carry an excalidraw sketch fence; audit it so a
+      # malformed sketch is reported here rather than discovered only when a
+      # human accepts the suggestion and the editor renders "Invalid sketch".
+      sketch_audit = document.html? ? nil : MarkdownSketchAudit.call(suggestion.body)
+      normalized = suggestion.normalization_changed || sketch_audit&.unrecognized? || false
+      warning =
+        if suggestion.normalization_changed
+          "Unsupported HTML was removed or normalized."
+        else
+          sketch_audit&.warning_message
+        end
+
       render json: {
         suggestion: suggestion.as_props,
         status: "pending_human_review",
-        normalized: suggestion.normalization_changed,
-        warning: ("Unsupported HTML was removed or normalized." if suggestion.normalization_changed)
+        normalized: normalized,
+        warning: warning
       }, status: :created
     rescue ActionController::ParameterMissing
       source_name = document.html? ? "HTML" : "markdown"

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -114,7 +114,9 @@ class AgentGuide
 
     def content_contract(format, base_url)
       contract = {
-        version: 1,
+        # v2: sketches.markdown_source became a structured schema object (was a
+        # one-line string in v1). Consumers can branch on this to detect the shape.
+        version: 2,
         content_format: format,
         immutable: true,
         canonical_source_field: "content",

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -132,9 +132,9 @@ class AgentGuide
             format: %(A fenced "excalidraw" code block whose body is a single JSON object (the SketchData wrapper). The fence language must be exactly "excalidraw".),
             schema: {
               formatVersion: "(required) integer, must equal #{ThinkroomSketch::FORMAT_VERSION}.",
-              id: %[(required) string matching /^[a-zA-Z0-9_-]{1,100}$/.],
+              id: %[(required) string matching /^[a-zA-Z0-9_-]{1,100}$/. Enforced by the editor — include it even though the create-time signal does not check it (see enforcement).],
               description: "(optional) human summary up to #{ThinkroomSketch::MAX_DESCRIPTION_LENGTH} characters; surfaced in plain_text.",
-              height: "(optional) integer reserved render height in pixels, #{ThinkroomSketch::MIN_HEIGHT}-#{ThinkroomSketch::MAX_HEIGHT}, default #{ThinkroomSketch::DEFAULT_HEIGHT}.",
+              height: "(required by the editor) integer reserved render height in pixels, #{ThinkroomSketch::MIN_HEIGHT}-#{ThinkroomSketch::MAX_HEIGHT}, default #{ThinkroomSketch::DEFAULT_HEIGHT}; out-of-range values are rejected by the editor (see enforcement).",
               scene: {
                 type: %((required) must equal "excalidraw".),
                 version: "(required) integer greater than 0 (the Excalidraw scene version, e.g. 2).",
@@ -144,7 +144,8 @@ class AgentGuide
               }
             },
             example: markdown_sketch_example,
-            recognition: %(A recognized sketch renders in plain_text as "Sketch: <description> - <labels>". If plain_text instead echoes the raw scene JSON, the fence was not recognized; the create response then reports normalized: true with a warning.),
+            recognition: %(A recognized sketch renders in plain_text as "Sketch: <description> — <labels>". If plain_text instead echoes the raw scene JSON, the fence was not recognized; the create response then reports normalized: true with a warning.),
+            enforcement: %(The create-time signal (normalized/warning) validates the scene shape only. id and height are enforced when the editor opens the document, not at create — a scene with a missing/invalid id or out-of-range height returns normalized: false here yet still renders as "Invalid sketch" to humans, so follow this schema in full rather than relying on the absence of a warning.),
             reference: "Excalidraw scene/element format and drawing semantics: https://docs.excalidraw.com/docs/codebase/json-schema"
           },
           html_source: "A trusted figure[data-thinkroom-sketch] snapshot; external HTML cannot set reserved sketch attributes.",

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -128,7 +128,24 @@ class AgentGuide
         },
         sketches: {
           purpose: "Inline Excalidraw sketches remain editable in the human UI and expose text semantics to agents.",
-          markdown_source: "A fenced excalidraw block containing versioned JSON with id, description, and scene.",
+          markdown_source: {
+            format: %(A fenced "excalidraw" code block whose body is a single JSON object (the SketchData wrapper). The fence language must be exactly "excalidraw".),
+            schema: {
+              formatVersion: "(required) integer, must equal #{ThinkroomSketch::FORMAT_VERSION}.",
+              id: %[(required) string matching /^[a-zA-Z0-9_-]{1,100}$/.],
+              description: "(optional) human summary up to #{ThinkroomSketch::MAX_DESCRIPTION_LENGTH} characters; surfaced in plain_text.",
+              height: "(optional) integer reserved render height in pixels, #{ThinkroomSketch::MIN_HEIGHT}-#{ThinkroomSketch::MAX_HEIGHT}, default #{ThinkroomSketch::DEFAULT_HEIGHT}.",
+              scene: {
+                type: %((required) must equal "excalidraw".),
+                version: "(required) integer greater than 0 (the Excalidraw scene version, e.g. 2).",
+                elements: %[(required) array of Excalidraw elements. Each element type must be one of #{ThinkroomSketch::ELEMENT_TYPES.join(", ")}; any strokeColor/backgroundColor must match /^(?:transparent|#[0-9a-f]{3,8})$/i; fileId and link are not allowed.],
+                appState: %[(optional) object; viewBackgroundColor must match the safe-color pattern. Only an allowlist of keys (theme, grid/zoom/scroll settings, viewBackgroundColor) is retained.],
+                files: "(required) must be exactly {} - embedded bitmap files are not supported."
+              }
+            },
+            example: markdown_sketch_example,
+            recognition: %(A recognized sketch renders in plain_text as "Sketch: <description> - <labels>". If plain_text instead echoes the raw scene JSON, the fence was not recognized; the create response then reports normalized: true with a warning.)
+          },
           html_source: "A trusted figure[data-thinkroom-sketch] snapshot; external HTML cannot set reserved sketch attributes.",
           rendered_context: "plain_text emits the sketch description and text labels instead of raw scene JSON.",
           canonical: "The Excalidraw scene is canonical; SVG is generated in the browser for preview, copy, and download.",
@@ -180,7 +197,7 @@ class AgentGuide
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
-        "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported.",
+        "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported. To author one in Markdown, embed a fenced excalidraw block following content_contract.sketches.markdown_source (formatVersion, id, description, height, and a full excalidraw scene with type/version/appState/files) — copy its example to start. A recognized sketch shows in plain_text as \"Sketch: <description> — <labels>\"; raw scene JSON in plain_text means the block was not recognized, and the create response then returns normalized: true with a warning.",
         "Suggestion targeting: use a unique quote from plain_text for replaces or anchor_text; source-formatted quotes are parsed too. A missing or ambiguous replaces target stays pending and changes nothing. A missing anchor_text falls back to appending if a human accepts it.",
         "Tracked changes use <ins data-suggestion-id> / <del data-suggestion-id> in the source snapshot. They are human-typed suggestions pending review, not your proposals, and are not resolvable through this API.",
         "Review is human-gated by design: accepting/rejecting suggestions and advancing review states happen in the editor, by humans. Your job is to propose well.",
@@ -236,7 +253,12 @@ class AgentGuide
         Inline Excalidraw sketches are versioned source blocks. Their editable
         scene appears in content; plain_text gives you the human description
         and text labels without raw scene JSON. SVG is a derived browser
-        preview/export, and embedded bitmap files are not supported.
+        preview/export, and embedded bitmap files are not supported. Author one
+        with a fenced excalidraw block matching the JSON guide's
+        content_contract.sketches.markdown_source (formatVersion, id,
+        description, height, and a full excalidraw scene). When recognized,
+        plain_text reads "Sketch: <description> — <labels>"; raw scene JSON in
+        plain_text means it was not recognized.
 
         #{html_contract_text(document, base_url)}
         ## Participate
@@ -322,6 +344,18 @@ class AgentGuide
     end
 
     private
+
+    # A copy-pasteable, validation-passing markdown sketch fence. Agents drop
+    # this straight into content; it is recognized by ThinkroomSketch.parse and
+    # renders in plain_text as "Sketch: Human and AI agent edit the same Yjs
+    # room — Human". Kept on one JSON line so it survives a literal copy.
+    def markdown_sketch_example
+      <<~MARKDOWN
+        ```excalidraw
+        {"id":"flow1","formatVersion":1,"description":"Human and AI agent edit the same Yjs room","height":260,"scene":{"type":"excalidraw","version":2,"elements":[{"id":"r1","type":"rectangle","x":100,"y":100,"width":220,"height":90,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"#d3f9d8","fillStyle":"solid","strokeWidth":2,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":3},"seed":1,"version":1,"versionNonce":1,"isDeleted":false,"boundElements":null,"updated":1,"link":null,"locked":false},{"id":"t1","type":"text","x":130,"y":132,"width":60,"height":25,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"solid","strokeWidth":2,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":null,"seed":1,"version":1,"versionNonce":1,"isDeleted":false,"boundElements":null,"updated":1,"link":null,"locked":false,"text":"Human","fontSize":20,"fontFamily":1,"textAlign":"left","verticalAlign":"top","containerId":null,"originalText":"Human","lineHeight":1.25,"baseline":18}],"appState":{"viewBackgroundColor":"#fffef9"},"files":{}}}
+        ```
+      MARKDOWN
+    end
 
     def document_creation_rate_limits
       rate_limits(

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -144,7 +144,8 @@ class AgentGuide
               }
             },
             example: markdown_sketch_example,
-            recognition: %(A recognized sketch renders in plain_text as "Sketch: <description> - <labels>". If plain_text instead echoes the raw scene JSON, the fence was not recognized; the create response then reports normalized: true with a warning.)
+            recognition: %(A recognized sketch renders in plain_text as "Sketch: <description> - <labels>". If plain_text instead echoes the raw scene JSON, the fence was not recognized; the create response then reports normalized: true with a warning.),
+            reference: "Excalidraw scene/element format and drawing semantics: https://docs.excalidraw.com/docs/codebase/json-schema"
           },
           html_source: "A trusted figure[data-thinkroom-sketch] snapshot; external HTML cannot set reserved sketch attributes.",
           rendered_context: "plain_text emits the sketch description and text labels instead of raw scene JSON.",
@@ -258,7 +259,9 @@ class AgentGuide
         content_contract.sketches.markdown_source (formatVersion, id,
         description, height, and a full excalidraw scene). When recognized,
         plain_text reads "Sketch: <description> — <labels>"; raw scene JSON in
-        plain_text means it was not recognized.
+        plain_text means it was not recognized. The Excalidraw scene/element
+        format and drawing semantics are documented at
+        https://docs.excalidraw.com/docs/codebase/json-schema.
 
         #{html_contract_text(document, base_url)}
         ## Participate

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -124,7 +124,7 @@ class AgentGuide
         normalization: {
           response_field: "normalized",
           warning_field: "warning",
-          meaning: "When normalized is true, unsupported or unsafe source was removed or rewritten."
+          meaning: "When normalized is true, unsupported or unsafe source was removed or rewritten, or an excalidraw block was not recognized as a valid sketch and was kept as a code block. The warning field explains what happened."
         },
         sketches: {
           purpose: "Inline Excalidraw sketches remain editable in the human UI and expose text semantics to agents.",

--- a/app/services/document_plain_text.rb
+++ b/app/services/document_plain_text.rb
@@ -1,5 +1,9 @@
 class DocumentPlainText
   BLOCK_SEPARATOR = " "
+  # The canonical Commonmarker plugin set for rendering document markdown to the
+  # text projection agents read. MarkdownSketchAudit renders with the same set
+  # so its create-time recognition signal matches what this projection produces.
+  MARKDOWN_PLUGINS = { table: true, strikethrough: true, tasklist: true }.freeze
 
   class << self
     def call(format:, content:)
@@ -7,10 +11,7 @@ class DocumentPlainText
       html = if format == "html"
         source
       else
-        Commonmarker.to_html(
-          source,
-          plugins: { table: true, strikethrough: true, tasklist: true }
-        )
+        Commonmarker.to_html(source, plugins: MARKDOWN_PLUGINS)
       end
 
       fragment = Nokogiri::HTML5.fragment(html)
@@ -38,15 +39,11 @@ class DocumentPlainText
         end
       else
         fragment.css('pre[lang="excalidraw"] > code').each do |node|
-          payload = JSON.parse(node.text)
-          replace_with_semantics(
-            node.parent,
-            scene: JSON.generate(payload.fetch("scene")),
-            description: payload["description"],
-            format_version: payload["formatVersion"]
-          )
-        rescue JSON::ParserError, KeyError
-          # Leave malformed source visible instead of hiding data.
+          # A malformed body (unparseable, non-Hash, missing scene, or a value
+          # that can't be re-encoded) returns nil and is left visible instead of
+          # raising — the same outcome MarkdownSketchAudit reports as unrecognized.
+          parsed = ThinkroomSketch.parse_markdown_fence(node.text)
+          node.parent.replace(Nokogiri::XML::Text.new(parsed.semantic_text, node.parent.document)) if parsed
         end
       end
     end

--- a/app/services/document_preview_html.rb
+++ b/app/services/document_preview_html.rb
@@ -4,9 +4,9 @@
 # it is ready; because both render the same content into the same prose styles,
 # the swap is seamless. See app/frontend/pages/documents/show.tsx (doc-editor-stack).
 class DocumentPreviewHtml
-  DEFAULT_SKETCH_HEIGHT = 448
-  MIN_SKETCH_HEIGHT = 180
-  MAX_SKETCH_HEIGHT = 1200
+  DEFAULT_SKETCH_HEIGHT = ThinkroomSketch::DEFAULT_HEIGHT
+  MIN_SKETCH_HEIGHT = ThinkroomSketch::MIN_HEIGHT
+  MAX_SKETCH_HEIGHT = ThinkroomSketch::MAX_HEIGHT
 
   class << self
     def call(format:, content:)

--- a/app/services/markdown_sketch_audit.rb
+++ b/app/services/markdown_sketch_audit.rb
@@ -1,0 +1,49 @@
+# Reports whether a markdown document's inline excalidraw fences were
+# recognized as sketches. Recognition mirrors DocumentPlainText exactly — same
+# Commonmarker render, same `pre[lang="excalidraw"] > code` selector, same
+# ThinkroomSketch.parse arguments — so a "kept as a code block" warning on the
+# create response fires precisely when plain_text would echo raw scene JSON.
+class MarkdownSketchAudit
+  Result = Data.define(:fence_count, :unrecognized_count) do
+    def unrecognized? = unrecognized_count.positive?
+  end
+
+  class << self
+    def call(content)
+      source = content.to_s
+      return Result.new(fence_count: 0, unrecognized_count: 0) if source.blank?
+
+      html = Commonmarker.to_html(
+        source,
+        plugins: { table: true, strikethrough: true, tasklist: true }
+      )
+      fragment = Nokogiri::HTML5.fragment(html)
+
+      fence_count = 0
+      unrecognized_count = 0
+      fragment.css('pre[lang="excalidraw"] > code').each do |node|
+        fence_count += 1
+        unrecognized_count += 1 unless recognized?(node.text)
+      end
+
+      Result.new(fence_count:, unrecognized_count:)
+    end
+
+    private
+
+    # True only when the fence parses to the same Sketch ThinkroomSketch.parse
+    # would accept — the single recognition authority shared with the renderer.
+    def recognized?(source)
+      payload = JSON.parse(source)
+      return false unless payload.is_a?(Hash)
+
+      ThinkroomSketch.parse(
+        JSON.generate(payload.fetch("scene")),
+        description: payload["description"],
+        format_version: payload["formatVersion"]
+      ).present?
+    rescue JSON::ParserError, JSON::NestingError, KeyError
+      false
+    end
+  end
+end

--- a/app/services/markdown_sketch_audit.rb
+++ b/app/services/markdown_sketch_audit.rb
@@ -6,6 +6,19 @@
 class MarkdownSketchAudit
   Result = Data.define(:fence_count, :unrecognized_count) do
     def unrecognized? = unrecognized_count.positive?
+
+    # The agent-facing warning for unrecognized fences, or nil when every fence
+    # parsed. Lives next to the count so each API surface (create, suggestions)
+    # reports the same message without duplicating the pluralization.
+    def warning_message
+      return unless unrecognized?
+
+      if unrecognized_count == 1
+        "An excalidraw block was not a valid sketch and was kept as a code block."
+      else
+        "#{unrecognized_count} excalidraw blocks were not valid sketches and were kept as code blocks."
+      end
+    end
   end
 
   class << self

--- a/app/services/markdown_sketch_audit.rb
+++ b/app/services/markdown_sketch_audit.rb
@@ -13,37 +13,20 @@ class MarkdownSketchAudit
       source = content.to_s
       return Result.new(fence_count: 0, unrecognized_count: 0) if source.blank?
 
-      html = Commonmarker.to_html(
-        source,
-        plugins: { table: true, strikethrough: true, tasklist: true }
-      )
+      html = Commonmarker.to_html(source, plugins: DocumentPlainText::MARKDOWN_PLUGINS)
       fragment = Nokogiri::HTML5.fragment(html)
 
       fence_count = 0
       unrecognized_count = 0
       fragment.css('pre[lang="excalidraw"] > code').each do |node|
         fence_count += 1
-        unrecognized_count += 1 unless recognized?(node.text)
+        # ThinkroomSketch.parse_markdown_fence is the single recognition
+        # authority the renderer also uses, so a fence counts as unrecognized
+        # here exactly when DocumentPlainText would leave its raw JSON visible.
+        unrecognized_count += 1 unless ThinkroomSketch.parse_markdown_fence(node.text)
       end
 
       Result.new(fence_count:, unrecognized_count:)
-    end
-
-    private
-
-    # True only when the fence parses to the same Sketch ThinkroomSketch.parse
-    # would accept — the single recognition authority shared with the renderer.
-    def recognized?(source)
-      payload = JSON.parse(source)
-      return false unless payload.is_a?(Hash)
-
-      ThinkroomSketch.parse(
-        JSON.generate(payload.fetch("scene")),
-        description: payload["description"],
-        format_version: payload["formatVersion"]
-      ).present?
-    rescue JSON::ParserError, JSON::NestingError, KeyError
-      false
     end
   end
 end

--- a/app/services/thinkroom_sketch.rb
+++ b/app/services/thinkroom_sketch.rb
@@ -45,6 +45,26 @@ class ThinkroomSketch
       nil
     end
 
+    # Parse one markdown excalidraw fence body (the JSON inside a ```excalidraw
+    # block) into a Parsed sketch, or nil when the body is not a recognizable
+    # sketch. Centralizes the parse + rescue so the renderer (DocumentPlainText)
+    # and the create-time audit (MarkdownSketchAudit) recognize identically —
+    # and so a malformed body (non-Hash JSON, a value that can't be re-encoded,
+    # a missing scene) is reported as unrecognized rather than raising and
+    # 500ing the request that renders or audits it.
+    def parse_markdown_fence(code_text)
+      payload = JSON.parse(code_text.to_s)
+      return unless payload.is_a?(Hash)
+
+      parse(
+        JSON.generate(payload.fetch("scene")),
+        description: payload["description"],
+        format_version: payload["formatVersion"]
+      )
+    rescue JSON::ParserError, JSON::NestingError, JSON::GeneratorError, KeyError
+      nil
+    end
+
     private
 
     def valid_scene?(scene)

--- a/app/services/thinkroom_sketch.rb
+++ b/app/services/thinkroom_sketch.rb
@@ -4,6 +4,12 @@ class ThinkroomSketch
   MAX_DESCRIPTION_LENGTH = 500
   MAX_ELEMENTS = 500
   MAX_POINTS = 20_000
+  # Render-hint bounds for a sketch's reserved height. Enforced TS-side by
+  # normalizeSketchData; mirrored here as the single Ruby source of truth so the
+  # agent contract and the preview skeleton clamp cannot drift apart.
+  DEFAULT_HEIGHT = 448
+  MIN_HEIGHT = 180
+  MAX_HEIGHT = 1200
   ELEMENT_TYPES = %w[
     rectangle diamond ellipse line arrow freedraw text frame
   ].freeze

--- a/docs/plans/2026-06-25-001-fix-agent-api-sketch-docs-silent-failure-plan.md
+++ b/docs/plans/2026-06-25-001-fix-agent-api-sketch-docs-silent-failure-plan.md
@@ -1,0 +1,213 @@
+---
+title: "fix: Document agent API markdown sketch schema and surface silent fence failures"
+type: fix
+date: 2026-06-25
+origin: https://github.com/kieranklaassen/thinkroom/issues/55
+---
+
+# Document agent API markdown sketch schema and surface silent fence failures
+
+## Summary
+
+The agent-facing document API lets agents author inline Excalidraw sketches by embedding a fenced ` ```excalidraw ` block in markdown source. Two problems make this nearly unusable for agents: (1) the self-documenting `content_contract` describes the sketch payload with a one-line summary that is vague *and wrong* on every key field, and (2) when an `excalidraw` fence fails validation, the create response is `201` with `normalized: false` and `warning: null` — byte-for-byte identical to a successful sketch. An agent has no way to know it failed except by noticing that `plain_text` echoes raw scene JSON instead of the sketch's semantic summary.
+
+This plan delivers the three fixes the issue requests: replace the contract's `markdown_source` string with the real `SketchData` schema plus a copy-pasteable example; make a failed markdown sketch fence non-silent by setting `normalized: true` with an explanatory `warning`; and document the recognition signal (`plain_text` shows `Sketch: <description> — <labels>` when recognized, raw JSON when not).
+
+This is a documentation + observability fix. It does **not** change sketch *validation* rules (`ThinkroomSketch.parse` and the TS `normalizeSketchData` stay as they are) — it makes the existing, correct validation legible to the agents that depend on it.
+
+---
+
+## Problem frame
+
+Per `STRATEGY.md`, Thinkroom is an "agent-native data and UI layer" where "external agents bring work in." The self-documenting API (`AgentGuide`) is the entire contract surface an agent gets from a share link — "everything it needs to participate, with no special knowledge beyond the link itself." When that contract lies about the sketch schema and hides validation failures, the agent-native promise breaks at exactly the authoring step.
+
+Today, for a markdown `POST /api/docs`:
+
+- `AgentGuide.content_contract` (`app/services/agent_guide.rb:131`) documents the sketch source as a single string: *"A fenced excalidraw block containing versioned JSON with id, description, and scene."* The real contract (enforced by `ThinkroomSketch.parse` server-side and `normalizeSketchData` in `app/frontend/editor/sketch/scene.ts`) differs on every point: the top-level version key is `formatVersion` (not `version`), there is a `height` render hint (clamped 180–1200), and `scene` must be a full Excalidraw export object (`type: "excalidraw"`, `version > 0`, allowlisted `appState`, `files: {}`), not a `{ id, description, scene }` wrapper.
+- `Api::DocsController#create` (`app/controllers/api/docs_controller.rb:35`) only computes `normalization` for HTML (`HtmlDocumentSanitizer.external`). For markdown, `normalization` is `nil`, so the response always sends `normalized: false` and `warning: nil` — even when an embedded `excalidraw` fence failed to parse and was silently kept as a dead code block.
+
+The recognition machinery already exists and works: `DocumentPlainText.call` (`app/services/document_plain_text.rb:40`) finds `pre[lang="excalidraw"] > code`, calls `ThinkroomSketch.parse`, and replaces a recognized fence with its semantic text — leaving raw JSON visible when parsing fails. The create response just never reports that outcome back to the caller. The fix is to audit the markdown at create time using the same `ThinkroomSketch.parse` path and report the result.
+
+---
+
+## Requirements
+
+Traced directly to the issue's three suggested fixes.
+
+- **R1.** The `content_contract.sketches.markdown_source` field must describe the real `SketchData` schema — `formatVersion`, `id` pattern, `description`, `height` range/default, and the full `scene` shape (`type`, `version`, `appState`, `files`) — and include a copy-pasteable working example an agent can drop straight into a fence. (Issue fix #1)
+- **R2.** When a markdown create includes an `excalidraw` fence that does not pass `ThinkroomSketch.parse`, the create response must signal the failure: `normalized: true` and a `warning` explaining that an excalidraw block was not a valid sketch and was kept as a code block. A valid sketch (or no sketch) must continue to return `normalized: false`, `warning: null`. (Issue fix #2)
+- **R3.** The contract/notes must document the recognition signal: a recognized sketch renders in `plain_text` as `Sketch: <description> — <labels>`; raw scene JSON in `plain_text` means the fence was not recognized. (Issue fix #3, nice-to-have)
+
+Success criteria: an agent reading only the JSON guide can author a valid markdown sketch on the first attempt, and an agent that submits an invalid one receives an unambiguous failure signal in the same response.
+
+---
+
+## High-Level Technical Design
+
+The create path gains one markdown-only audit step. The key invariant: **the create-time warning must fire exactly when `plain_text` would echo raw JSON** — both must be driven by the same `ThinkroomSketch.parse` call so the response can never disagree with the rendered document.
+
+```mermaid
+flowchart TD
+    A[POST /api/docs, format=markdown] --> B[Document.create! with seed_content = source]
+    B --> C{MarkdownSketchAudit.call(content)}
+    C -->|finds pre lang=excalidraw fences| D[For each fence: ThinkroomSketch.parse scene/description/formatVersion]
+    D --> E{any fence present but unrecognized?}
+    E -->|yes| F[normalized: true + warning: excalidraw block kept as code block]
+    E -->|no / no fences| G[normalized: false, warning: nil]
+    F --> H[Response also carries plain_text]
+    G --> H
+    H --> I[plain_text via DocumentPlainText — same ThinkroomSketch.parse path]
+    style D fill:#d3f9d8
+    style I fill:#d3f9d8
+```
+
+Both green nodes call `ThinkroomSketch.parse` with the same arguments (`scene` = `JSON.generate(payload["scene"])`, `description` = `payload["description"]`, `format_version` = `payload["formatVersion"]`). Centralizing recognition in `ThinkroomSketch.parse` — which `DocumentPlainText`, `DocumentPreviewHtml`, and the new audit all already funnel through — is what keeps the response signal and the rendered `plain_text` in lockstep without a shared rendering pass.
+
+*Directional guidance for the reviewer — not implementation specification.*
+
+---
+
+## Key technical decisions
+
+- **KTD-1 — Overload `normalized: true` for unrecognized sketches, and broaden the documented meaning to match.** The issue explicitly requests `normalized: true` + `warning` for a failed fence, even though the stored markdown source is unchanged (the fence is kept verbatim as a code block, not removed or rewritten). This slightly stretches the current contract meaning ("source was removed or rewritten"). We accept the overload because it gives agents a *single boolean* to check — consistent with how HTML normalization already works — and we keep the contract honest by broadening `content_contract.normalization.meaning` to: source was removed, rewritten, **or a sketch block was not recognized and kept as a code block**. *Alternative rejected:* a dedicated `sketch_warning` field or a warning-only signal (`normalized: false`, `warning != null`) — both add asymmetry with the HTML path and force agents to check two signals.
+- **KTD-2 — Recognition is `ThinkroomSketch.parse`, mirrored from `DocumentPlainText`.** The create-time audit renders the markdown with the same `Commonmarker.to_html(..., plugins: { table: true, strikethrough: true, tasklist: true })` call as `DocumentPlainText`, selects `pre[lang="excalidraw"] > code`, and calls `ThinkroomSketch.parse` with identical arguments. This guarantees the warning fires iff `plain_text` echoes raw JSON. *Alternative rejected:* regex-scanning raw markdown for fences — fragile against indented/tilde fences and would drift from the renderer's actual recognition.
+- **KTD-3 — Do not change validation behavior; only document and report.** `ThinkroomSketch.parse` (Ruby) intentionally does **not** validate `id` or `height` — those are enforced TS-side by `normalizeSketchData` when the live editor mounts the scene. We leave both validators exactly as they are. The contract documents the *full* TS shape (what the editor requires: `id` pattern, `height` range) so agents author correctly, while the create-time warning mirrors the *Ruby* recognition that drives `plain_text`. The narrow gap (a fence with a bad/missing `id` or `height` is recognized server-side but may be re-normalized by the editor) is documented, not closed — see Scope Boundaries.
+- **KTD-4 — A single Ruby source of truth for sketch height bounds.** Add `DEFAULT_HEIGHT`/`MIN_HEIGHT`/`MAX_HEIGHT` constants to `ThinkroomSketch` (mirroring the existing `MAX_*`/`ELEMENT_TYPES` constants already surfaced in the contract) and reference them from both the contract and `DocumentPreviewHtml` (which currently hard-codes the same three literals). This keeps the documented height range and the preview's skeleton clamp from drifting.
+
+---
+
+## Scope boundaries
+
+**In scope**
+- Rewrite `content_contract.sketches.markdown_source` into a structured schema + example (R1).
+- Update the markdown sketch guidance in `AgentGuide.notes` and the plain-text `AgentGuide.text` guide to reference the real shape and recognition signal (R1, R3).
+- Add a markdown sketch audit and wire it into the markdown branch of `Api::DocsController#create` (R2).
+- Broaden `content_contract.normalization.meaning` to cover the unrecognized-sketch case (R2).
+- Add Ruby height constants and dedupe `DocumentPreviewHtml`'s local copies (KTD-4).
+
+**Out of scope (true non-goals)**
+- Changing sketch validation rules in `ThinkroomSketch.parse` or `normalizeSketchData` (`app/frontend/editor/sketch/scene.ts`). Behavior stays identical.
+- HTML-document sketch authoring. The contract already states external HTML cannot set reserved sketch attributes; markdown remains the only agent authoring path and is the entire focus here.
+- Any change to how sketches render in the editor or preview.
+
+### Deferred to follow-up work
+- **Ruby/TS recognition parity for `id` and `height`.** Today a fence whose payload omits or malforms `id`/`height` is recognized by `ThinkroomSketch.parse` (so no create-time warning) but may be rejected/normalized when the TS editor mounts it. Tightening Ruby parse to also require `id`/`height` would close the gap but risks reclassifying already-stored sketches as invalid; it needs its own migration-safety pass. Documented now (KTD-3), deferred as behavior change.
+
+---
+
+## Implementation units
+
+### U1. Rewrite the sketch contract and agent guidance to the real schema
+
+**Goal:** Replace the misleading one-line `markdown_source` description with the true `SketchData` schema plus a copy-pasteable example, document the recognition signal, and establish Ruby height constants as the single source of truth.
+
+**Requirements:** R1, R3 (and KTD-4).
+
+**Dependencies:** none.
+
+**Files:**
+- `app/services/thinkroom_sketch.rb` — add `DEFAULT_HEIGHT = 448`, `MIN_HEIGHT = 180`, `MAX_HEIGHT = 1200` constants (mirroring the existing `MAX_SCENE_BYTES`/`ELEMENT_TYPES` style).
+- `app/services/agent_guide.rb` — rewrite the `sketches.markdown_source` entry in `content_contract` from a `String` to a structured object (schema + example + recognition note); update the `markdown_source` reference and add a recognition line to the sketch entry in `notes`; tighten the sketch paragraph in the `text` plain-text guide to reference the real shape and recognition signal.
+- `app/services/document_preview_html.rb` — replace the local `DEFAULT_SKETCH_HEIGHT`/`MIN_SKETCH_HEIGHT`/`MAX_SKETCH_HEIGHT` literals with the new `ThinkroomSketch` constants (no behavior change).
+- `test/integration/agent_discovery_test.rb` — update the existing contract assertion (currently `assert_includes body.dig("content_contract", "sketches", "markdown_source"), "excalidraw"`, which assumes a String) to the new object shape, and assert the example + recognition signal are present.
+- `test/services/document_preview_html_test.rb` — confirm skeleton height behavior is unchanged after the constant swap.
+
+**Approach:** The new `markdown_source` object should carry: a `format` note (a fenced ` ```excalidraw ` block whose body is a single JSON object), the field schema (`formatVersion` must equal 1; `id` matches `^[a-zA-Z0-9_-]{1,100}$`; `description` string ≤ `MAX_DESCRIPTION_LENGTH`; `height` integer in `MIN_HEIGHT..MAX_HEIGHT`, default `DEFAULT_HEIGHT`; `scene` is a full Excalidraw export with `type: "excalidraw"`, `version > 0`, allowlisted `appState` whose `viewBackgroundColor` matches the safe-color regex, and `files: {}`), a `recognition` note (`plain_text` shows `Sketch: <description> — <labels>` when recognized; raw scene JSON means it was not recognized), and an `example` string containing the working fence from the issue. Keep the existing `supported_elements` and `limits` keys. Reference `ThinkroomSketch` constants (`FORMAT_VERSION`, `ELEMENT_TYPES`, height constants, `MAX_*`) rather than hard-coding values, so the contract tracks the validator.
+
+**Patterns to follow:** the existing `html:` sub-contract in `content_contract` (`app/services/agent_guide.rb:147`) already composes a structured object that references sanitizer constants — mirror that style. The `SAFE_COLOR` and `ELEMENT_TYPES` constants in `ThinkroomSketch` are the authoritative regex/list to cite.
+
+**Test scenarios:**
+- `content_contract("markdown", base_url)` returns `sketches.markdown_source` as a Hash (not a String) containing keys for the schema, an `example`, and a `recognition` note. *(Covers R1, R3.)*
+- The `markdown_source` schema reports `formatVersion` required `== 1`, the `id` pattern, the `height` default/min/max matching `ThinkroomSketch` constants, and a `scene` description naming `type: "excalidraw"`, `version`, `appState`, and `files: {}`.
+- The `example` value is a non-empty fenced `excalidraw` block whose JSON, when parsed through `ThinkroomSketch.parse` (with its `scene`/`description`/`formatVersion`), is recognized — i.e., the documented example actually works. *(Guards against the example drifting from the validator.)*
+- The agent discovery share URL (`GET /d/:slug` plain-text guide) mentions the real recognition signal text. *(Covers R3.)*
+- `DocumentPreviewHtml` produces identical skeleton heights before/after the constant swap (default when height absent, clamped within `MIN_HEIGHT..MAX_HEIGHT`). *(Regression guard for KTD-4.)*
+
+**Verification:** the contract test suite passes with the new object shape; the documented `example` round-trips through `ThinkroomSketch.parse` as recognized.
+
+### U2. Add a markdown sketch audit service
+
+**Goal:** Provide a focused service that, given markdown content, reports how many `excalidraw` fences are present and how many failed recognition, using the exact `ThinkroomSketch.parse` path that drives `plain_text`.
+
+**Requirements:** R2.
+
+**Dependencies:** none (U3 consumes it).
+
+**Files:**
+- `app/services/markdown_sketch_audit.rb` — new service. `MarkdownSketchAudit.call(content)` returns a small result (e.g. a `Data.define(:fence_count, :unrecognized_count)` with an `unrecognized?` predicate). It renders the content via the same `Commonmarker.to_html(content, plugins: { table: true, strikethrough: true, tasklist: true })` call `DocumentPlainText` uses, selects `pre[lang="excalidraw"] > code`, parses each code body as JSON, and runs `ThinkroomSketch.parse(JSON.generate(payload["scene"]), description: payload["description"], format_version: payload["formatVersion"])`. A fence is "unrecognized" when JSON parsing fails, the `scene` key is missing, or `ThinkroomSketch.parse` returns `nil`.
+- `test/services/markdown_sketch_audit_test.rb` — new test.
+
+**Approach:** Mirror the markdown branch of `DocumentPlainText.replace_sketches` (`app/services/document_plain_text.rb:40-51`) for fence selection and parse-argument construction so recognition stays identical. Do not reimplement validation — delegate entirely to `ThinkroomSketch.parse`. The service is pure/stateless and does not touch the database.
+
+**Patterns to follow:** `DocumentPlainText` (rendering + Nokogiri fragment + `ThinkroomSketch.parse`) and the `Data.define` result style already used by `HtmlDocumentSanitizer::Result` (`content`, `changed?`) and `ThinkroomSketch::Parsed`.
+
+**Test scenarios:**
+- Content with a single valid `excalidraw` fence (the issue's working example) → `fence_count: 1`, `unrecognized_count: 0`, `unrecognized?` false. *(Covers R2 happy path.)*
+- Content with a fence using the *documented-but-wrong* old shape (`version` instead of `formatVersion`, `scene` lacking `type: "excalidraw"`) → `unrecognized_count: 1`, `unrecognized?` true. *(Covers R2 failure path — the exact case from the issue.)*
+- Content with malformed JSON inside the fence → counted unrecognized (JSON parse error handled, not raised).
+- Content with a fence missing the `scene` key → counted unrecognized (KeyError handled).
+- A plain ` ```json ` or ` ```ruby ` code block that happens to contain a `scene`-like object → `fence_count: 0` (only `pre[lang="excalidraw"]` fences count), `unrecognized?` false. *(Guards against false positives on ordinary code blocks.)*
+- Content with two fences, one valid and one invalid → `fence_count: 2`, `unrecognized_count: 1`.
+- Content with no fences (or blank content) → `fence_count: 0`, `unrecognized?` false.
+
+**Verification:** the service returns `unrecognized?` true for exactly the inputs where `DocumentPlainText.call` would leave raw scene JSON in the output.
+
+### U3. Surface the audit in the create response and broaden the contract meaning
+
+**Goal:** Make a failed markdown sketch fence non-silent in `POST /api/docs`, and update the contract's normalization meaning to honestly describe the new signal.
+
+**Requirements:** R2.
+
+**Dependencies:** U2 (uses `MarkdownSketchAudit`); coordinates with U1 (both touch `content_contract` — U1 edits the `sketches` sub-hash, U3 edits the `normalization` sub-hash; no overlap, but land U1 first to avoid an edit conflict).
+
+**Files:**
+- `app/controllers/api/docs_controller.rb` — in `create`, for the markdown branch run `MarkdownSketchAudit.call(content)`; when `unrecognized?`, set `normalized: true` and a `warning` (e.g. `"An excalidraw block was not a valid sketch and was kept as a code block."`, pluralized when `unrecognized_count > 1`). Leave the HTML branch (`HtmlDocumentSanitizer`-driven) untouched. The audit runs on the submitted `content` (markdown source is not server-normalized, so `source == content`).
+- `app/services/agent_guide.rb` — broaden `content_contract.normalization.meaning` to include the unrecognized-sketch-kept-as-code-block case.
+- `test/integration/agent_api_test.rb` — new create-response tests.
+
+**Approach:** Keep the response assembly in `create` minimal — compute `normalized`/`warning` from the audit for markdown, from `normalization&.changed?` for HTML (existing behavior). A clean shape is to resolve `normalized`/`warning` once before building the response hash so the markdown and HTML paths read symmetrically. Do not alter `seed_content` — the fence stays verbatim in the stored source, consistent with the "kept as a code block" warning text.
+
+**Patterns to follow:** the existing HTML normalization wiring in the same action (`app/controllers/api/docs_controller.rb:35,67-68`) and its tests in `agent_api_test.rb` ("agent creates sanitized HTML…" asserting `body["normalized"]` and `assert_includes body["warning"], "normalized"`).
+
+**Test scenarios:**
+- Markdown create with **no** sketch (`markdown: "# From an agent"`) → `normalized: false`, `warning: nil`. *(Regression guard — existing create tests must stay green.)*
+- Markdown create with a **valid** sketch fence (issue's working example) → `201`, `normalized: false`, `warning: nil`, and `plain_text` contains `"Sketch: <description> — <labels>"` (recognized). *(Covers R2 success + recognition signal.)*
+- Markdown create with an **invalid** sketch fence (old documented shape) → `201`, `normalized: true`, `warning` mentions the excalidraw block being kept as a code block, and `plain_text` echoes the raw scene JSON (the documented failure signal). *(Covers R2 failure path; ties response to recognition.)*
+- Markdown create with two fences, one valid + one invalid → `normalized: true`, pluralized warning.
+- HTML create with unsupported markup → unchanged: `normalized: true`, existing `"…normalized…"` warning. *(Confirms HTML path untouched.)*
+- `content_contract.normalization.meaning` text now covers the unrecognized-sketch case.
+
+**Verification:** an agent submitting the issue's failing payload now receives `normalized: true` + a warning in the same `201` response; the valid payload still returns a clean success; HTML behavior is unchanged.
+
+---
+
+## Risks & dependencies
+
+- **Recognition drift between the audit and `plain_text`.** Mitigated by KTD-2: both paths call `ThinkroomSketch.parse` with identical arguments, and U3's test asserts the response signal and `plain_text` agree on the same payload. If `DocumentPlainText`'s fence selection ever changes, the audit must change with it — the shared `ThinkroomSketch.parse` contract is the seam that keeps them honest.
+- **Existing contract test couples to a String.** `agent_discovery_test.rb` currently asserts `markdown_source` includes `"excalidraw"` as a String; changing it to a Hash will break that line. Explicitly updated in U1 — not a surprise regression.
+- **`normalized` semantics overload.** Setting `normalized: true` without mutating source is a deliberate stretch (KTD-1); the contract `meaning` is broadened in U3 so the documentation never contradicts the behavior.
+- **Performance:** the audit adds one extra `Commonmarker` render of the submitted markdown per create. Document creation is rate-limited and low-frequency; the cost is the same order as the `plain_text` render already performed on the new document. Acceptable.
+- **No new dependencies, migrations, or env/config changes.** Pure Ruby service + controller + documentation strings.
+
+---
+
+## Acceptance
+
+The issue is resolved when:
+1. An agent reading only `GET /api/docs/:slug` (or the share-URL guide) can author a valid markdown sketch on the first attempt from the documented schema + example. (R1)
+2. Submitting an `excalidraw` fence that fails validation returns `201` with `normalized: true` and an explanatory `warning`, distinguishable from success. (R2)
+3. The contract documents that recognized sketches appear in `plain_text` as `Sketch: <description> — <labels>`, and raw scene JSON signals non-recognition. (R3)
+4. Valid sketches and sketch-free documents still return `normalized: false`, `warning: null`; HTML normalization is unchanged.
+
+---
+
+## Sources & research
+
+- Origin issue: https://github.com/kieranklaassen/thinkroom/issues/55 (includes the verified working fence used as the documented example and in tests).
+- `app/services/agent_guide.rb` — `content_contract`, `notes`, `text` (the self-documenting agent contract).
+- `app/controllers/api/docs_controller.rb` — `create` (where `normalized`/`warning` are emitted; markdown currently never normalizes).
+- `app/services/thinkroom_sketch.rb` — `ThinkroomSketch.parse` and validation constants (server-side recognition source of truth).
+- `app/frontend/editor/sketch/scene.ts` — `normalizeSketchData` / `normalizeSketchScene` (TS validation: `id` pattern, `height` 180–1200, full scene shape).
+- `app/services/document_plain_text.rb` — the recognition path the audit mirrors (`pre[lang="excalidraw"] > code` → `ThinkroomSketch.parse`).
+- `app/services/document_preview_html.rb` — duplicate height constants consolidated in KTD-4.
+- `test/integration/agent_api_test.rb`, `test/integration/agent_discovery_test.rb`, `test/services/document_plain_text_test.rb` — existing patterns for create-response and contract assertions.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -366,4 +366,71 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_response :not_found
     assert_includes response.parsed_body["error"], "slug"
   end
+
+  test "markdown create with a valid sketch fence reports clean success" do
+    post "/api/docs",
+         params: { title: "Sketch Doc", markdown: "Intro\n\n#{valid_sketch_fence}" },
+         headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal false, body["normalized"]
+    assert_nil body["warning"]
+    # The recognized sketch shows as semantic text, not raw scene JSON.
+    assert_includes body["plain_text"], "Sketch: Approval flow — Draft"
+    refute_includes body["plain_text"], "formatVersion"
+  end
+
+  test "markdown create with an unrecognized sketch fence is non-silent" do
+    # The documented-but-wrong shape from issue #55: top-level `version` and a
+    # scene that is not a full excalidraw export. Previously this returned a 201
+    # byte-for-byte identical to success.
+    bad = sketch_fence({ version: 1, id: "x", scene: { elements: [] } })
+    post "/api/docs", params: { title: "Broken Sketch", markdown: bad },
+         headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal true, body["normalized"]
+    assert_includes body["warning"], "excalidraw block"
+    assert_includes body["warning"], "code block"
+    # The recognition signal the issue calls out: raw scene JSON in plain_text.
+    assert_includes body["plain_text"], %("version")
+    refute_includes body["plain_text"], "Sketch:"
+    # The broadened contract documents this outcome.
+    assert_includes body.dig("content_contract", "normalization", "meaning"), "excalidraw"
+  end
+
+  test "markdown create pluralizes the warning for multiple bad fences" do
+    bad = sketch_fence({ version: 1, scene: {} })
+    post "/api/docs",
+         params: { title: "Two Broken", markdown: "#{bad}\n\nBetween\n\n#{bad}" },
+         headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal true, body["normalized"]
+    assert_includes body["warning"], "2 excalidraw blocks"
+  end
+
+  test "plain markdown create stays unnormalized" do
+    post "/api/docs", params: { markdown: "# Just text, no sketch" }, headers: AGENT, as: :json
+
+    assert_response :created
+    assert_equal false, response.parsed_body["normalized"]
+    assert_nil response.parsed_body["warning"]
+  end
+
+  private
+
+  def valid_sketch_fence
+    sketch_fence({
+      id: "flow1", formatVersion: 1, description: "Approval flow", height: 260,
+      scene: { type: "excalidraw", version: 2, elements: [ { type: "text", text: "Draft" } ] }
+    })
+  end
+
+  def sketch_fence(payload)
+    "```excalidraw\n#{JSON.generate(payload)}\n```"
+  end
 end

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -421,6 +421,32 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_nil response.parsed_body["warning"]
   end
 
+  test "a malformed sketch fence body returns 201 with a warning, not a 500" do
+    # Valid JSON but not a Hash, and an unencodable number: these used to raise
+    # while building plain_text, 500ing the request after the doc was persisted.
+    [ "[1,2,3]", "42", %({"formatVersion":1,"scene":{"type":"excalidraw","version":2,"elements":[],"x":1e309}}) ].each do |body|
+      assert_difference -> { Document.count }, 1 do
+        post "/api/docs", params: { markdown: "```excalidraw\n#{body}\n```" }, headers: AGENT, as: :json
+      end
+      assert_response :created
+      body_json = response.parsed_body
+      assert body_json["slug"].present?, "agent must receive a slug, not an orphaned doc"
+      assert_equal true, body_json["normalized"]
+      assert_includes body_json["warning"], "excalidraw block"
+    end
+  end
+
+  test "an unrecognized sketch via the content field also reports the warning" do
+    bad = sketch_fence({ version: 1, id: "x", scene: { elements: [] } })
+    post "/api/docs", params: { format: "markdown", content: bad }, headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal "markdown", body["content_format"]
+    assert_equal true, body["normalized"]
+    assert_includes body["warning"], "excalidraw block"
+  end
+
   private
 
   def valid_sketch_fence

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -81,7 +81,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal body["content"], doc.seed_content
     assert_equal "agent", doc.seed_author_kind
     contract = body["content_contract"]
-    assert_equal 1, contract["version"]
+    assert_equal 2, contract["version"]
     assert_equal "html", contract["content_format"]
     assert_equal "content", contract["canonical_source_field"]
     assert_equal "plain_text", contract["rendered_text_field"]
@@ -151,6 +151,33 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert body["normalized"]
     assert_includes body["warning"], "normalized"
     assert_equal "<p>Better</p>", document.suggestions.last.body
+  end
+
+  test "markdown suggestion with an unrecognized sketch fence reports a warning" do
+    bad = sketch_fence({ version: 1, id: "x", scene: { elements: [] } })
+    post "/api/docs/#{@document.slug}/suggestions", params: { body: bad }, headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal true, body["normalized"]
+    assert_includes body["warning"], "excalidraw block"
+  end
+
+  test "markdown suggestion with a valid sketch fence reports clean success" do
+    post "/api/docs/#{@document.slug}/suggestions", params: { body: valid_sketch_fence }, headers: AGENT, as: :json
+
+    assert_response :created
+    body = response.parsed_body
+    assert_equal false, body["normalized"]
+    assert_nil body["warning"]
+  end
+
+  test "plain markdown suggestion stays unnormalized" do
+    post "/api/docs/#{@document.slug}/suggestions", params: { body: "A tighter intro." }, headers: AGENT, as: :json
+
+    assert_response :created
+    assert_equal false, response.parsed_body["normalized"]
+    assert_nil response.parsed_body["warning"]
   end
 
   test "explicit format validates content and legacy field compatibility" do

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -54,6 +54,7 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert body["notes"].any? { |n| n.include?("creation permits no header") }
     assert body["notes"].any? { |n| n.include?("content is canonical Markdown source") }
     assert body["notes"].any? { |n| n.include?("unique quote from plain_text") }
+    assert_equal 2, body.dig("content_contract", "version") # bumped when markdown_source became an object
     assert_equal "markdown", body.dig("content_contract", "suggestion_body_format")
     markdown_source = body.dig("content_contract", "sketches", "markdown_source")
     assert_includes markdown_source["format"], "excalidraw"

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -62,6 +62,7 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert_includes markdown_source.dig("schema", "height"), ThinkroomSketch::DEFAULT_HEIGHT.to_s
     assert_equal %(must equal "excalidraw".), markdown_source.dig("schema", "scene", "type").split("(required) ").last
     assert_includes markdown_source["recognition"], "Sketch:"
+    assert_includes markdown_source["reference"], "docs.excalidraw.com"
     assert_includes markdown_source["example"], "```excalidraw"
     # The documented example must actually pass server-side recognition, or the
     # contract is teaching agents a payload the API would silently reject.

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -55,7 +55,23 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert body["notes"].any? { |n| n.include?("content is canonical Markdown source") }
     assert body["notes"].any? { |n| n.include?("unique quote from plain_text") }
     assert_equal "markdown", body.dig("content_contract", "suggestion_body_format")
-    assert_includes body.dig("content_contract", "sketches", "markdown_source"), "excalidraw"
+    markdown_source = body.dig("content_contract", "sketches", "markdown_source")
+    assert_includes markdown_source["format"], "excalidraw"
+    assert_includes markdown_source.dig("schema", "formatVersion"), ThinkroomSketch::FORMAT_VERSION.to_s
+    assert_includes markdown_source.dig("schema", "id"), "a-zA-Z0-9"
+    assert_includes markdown_source.dig("schema", "height"), ThinkroomSketch::DEFAULT_HEIGHT.to_s
+    assert_equal %(must equal "excalidraw".), markdown_source.dig("schema", "scene", "type").split("(required) ").last
+    assert_includes markdown_source["recognition"], "Sketch:"
+    assert_includes markdown_source["example"], "```excalidraw"
+    # The documented example must actually pass server-side recognition, or the
+    # contract is teaching agents a payload the API would silently reject.
+    payload = JSON.parse(markdown_source["example"][/```excalidraw\n(.*?)\n```/m, 1])
+    parsed = ThinkroomSketch.parse(
+      JSON.generate(payload.fetch("scene")),
+      description: payload["description"], format_version: payload["formatVersion"]
+    )
+    assert parsed, "documented markdown_source.example must be recognized by ThinkroomSketch.parse"
+    assert_includes parsed.semantic_text, "Sketch: Human and AI agent edit the same Yjs room"
     assert_equal false, body.dig("content_contract", "sketches", "limits", "embedded_images")
     assert body["notes"].any? { |n| n.include?("inline Excalidraw") }
     refute body.dig("content_contract").key?("html")

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -62,6 +62,8 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert_includes markdown_source.dig("schema", "height"), ThinkroomSketch::DEFAULT_HEIGHT.to_s
     assert_equal %(must equal "excalidraw".), markdown_source.dig("schema", "scene", "type").split("(required) ").last
     assert_includes markdown_source["recognition"], "Sketch:"
+    assert_includes markdown_source["recognition"], "—" # matches semantic_text's em-dash
+    assert_includes markdown_source["enforcement"], "id" # the editor-vs-create signal boundary
     assert_includes markdown_source["reference"], "docs.excalidraw.com"
     assert_includes markdown_source["example"], "```excalidraw"
     # The documented example must actually pass server-side recognition, or the

--- a/test/services/document_plain_text_test.rb
+++ b/test/services/document_plain_text_test.rb
@@ -58,4 +58,20 @@ class DocumentPlainTextTest < ActiveSupport::TestCase
     assert_equal "Before Sketch: Approval flow — Draft, Review After",
                  DocumentPlainText.call(format: "html", content: html)
   end
+
+  test "leaves a malformed excalidraw fence body visible instead of raising" do
+    # Valid JSON but not a recognizable sketch: a bare array/number/string, and
+    # a number that overflows to Infinity (unencodable). Previously these raised
+    # TypeError/NoMethodError/JSON::GeneratorError and 500'd any request that
+    # rendered the document (create response, state read).
+    [
+      "```excalidraw\n[1,2,3]\n```",
+      "```excalidraw\n42\n```",
+      %(```excalidraw\n"hi"\n```),
+      %(```excalidraw\n{"formatVersion":1,"scene":{"type":"excalidraw","version":2,"elements":[],"x":1e309}}\n```)
+    ].each do |content|
+      result = assert_nothing_raised { DocumentPlainText.call(format: "markdown", content:) }
+      refute_includes result, "Sketch:" # not recognized as a sketch
+    end
+  end
 end

--- a/test/services/markdown_sketch_audit_test.rb
+++ b/test/services/markdown_sketch_audit_test.rb
@@ -78,6 +78,14 @@ class MarkdownSketchAuditTest < ActiveSupport::TestCase
     assert result.unrecognized?
   end
 
+  test "warning_message is nil, singular, or pluralized by count" do
+    assert_nil MarkdownSketchAudit::Result.new(fence_count: 1, unrecognized_count: 0).warning_message
+    assert_includes MarkdownSketchAudit::Result.new(fence_count: 1, unrecognized_count: 1).warning_message,
+                    "An excalidraw block"
+    assert_includes MarkdownSketchAudit::Result.new(fence_count: 3, unrecognized_count: 2).warning_message,
+                    "2 excalidraw blocks"
+  end
+
   test "reports nothing for content with no fences or blank content" do
     assert_equal 0, MarkdownSketchAudit.call("# Just prose\n\nNo sketches here.").fence_count
     refute MarkdownSketchAudit.call("# Just prose").unrecognized?

--- a/test/services/markdown_sketch_audit_test.rb
+++ b/test/services/markdown_sketch_audit_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class MarkdownSketchAuditTest < ActiveSupport::TestCase
+  # A SketchData wrapper that ThinkroomSketch.parse recognizes (a real
+  # excalidraw scene with a text label).
+  def valid_fence(description: "Approval flow", label: "Draft")
+    payload = {
+      id: "flow1", formatVersion: 1, description:, height: 260,
+      scene: { type: "excalidraw", version: 2, elements: [ { type: "text", text: label } ] }
+    }
+    "```excalidraw\n#{JSON.generate(payload)}\n```"
+  end
+
+  test "recognizes a valid sketch fence" do
+    result = MarkdownSketchAudit.call("Before\n\n#{valid_fence}\n\nAfter")
+
+    assert_equal 1, result.fence_count
+    assert_equal 0, result.unrecognized_count
+    refute result.unrecognized?
+  end
+
+  test "flags the documented-but-wrong shape as unrecognized" do
+    # The exact failure from the issue: top-level `version` (not formatVersion)
+    # and a scene that is not a full excalidraw export.
+    payload = { version: 1, id: "x", description: "nope", scene: { elements: [] } }
+    fence = "```excalidraw\n#{JSON.generate(payload)}\n```"
+
+    result = MarkdownSketchAudit.call(fence)
+
+    assert_equal 1, result.fence_count
+    assert_equal 1, result.unrecognized_count
+    assert result.unrecognized?
+  end
+
+  test "treats malformed JSON in the fence as unrecognized" do
+    result = MarkdownSketchAudit.call("```excalidraw\n{not valid json\n```")
+
+    assert_equal 1, result.fence_count
+    assert result.unrecognized?
+  end
+
+  test "treats a fence missing the scene key as unrecognized" do
+    fence = "```excalidraw\n#{JSON.generate({ formatVersion: 1, id: "x" })}\n```"
+
+    result = MarkdownSketchAudit.call(fence)
+
+    assert_equal 1, result.fence_count
+    assert result.unrecognized?
+  end
+
+  test "ignores a non-excalidraw code block that merely holds a scene key" do
+    fence = "```json\n#{JSON.generate({ formatVersion: 1, scene: { type: "excalidraw" } })}\n```"
+
+    result = MarkdownSketchAudit.call(fence)
+
+    assert_equal 0, result.fence_count
+    refute result.unrecognized?
+  end
+
+  test "counts each fence independently when valid and invalid are mixed" do
+    bad = "```excalidraw\n#{JSON.generate({ version: 1, scene: {} })}\n```"
+    content = "#{valid_fence}\n\nText between\n\n#{bad}"
+
+    result = MarkdownSketchAudit.call(content)
+
+    assert_equal 2, result.fence_count
+    assert_equal 1, result.unrecognized_count
+    assert result.unrecognized?
+  end
+
+  test "reports nothing for content with no fences or blank content" do
+    assert_equal 0, MarkdownSketchAudit.call("# Just prose\n\nNo sketches here.").fence_count
+    refute MarkdownSketchAudit.call("# Just prose").unrecognized?
+
+    blank = MarkdownSketchAudit.call("")
+    assert_equal 0, blank.fence_count
+    refute blank.unrecognized?
+    refute MarkdownSketchAudit.call(nil).unrecognized?
+  end
+
+  test "recognition matches what DocumentPlainText renders" do
+    # The audit's contract: unrecognized? is true exactly when plain_text would
+    # leave raw scene JSON visible instead of the semantic summary.
+    good = valid_fence
+    bad = "```excalidraw\n#{JSON.generate({ version: 1, scene: {} })}\n```"
+
+    refute MarkdownSketchAudit.call(good).unrecognized?
+    assert_includes DocumentPlainText.call(format: "markdown", content: good), "Sketch: Approval flow"
+
+    assert MarkdownSketchAudit.call(bad).unrecognized?
+    bad_plain_text = DocumentPlainText.call(format: "markdown", content: bad)
+    assert_includes bad_plain_text, %("version") # raw scene JSON leaks through
+    refute_includes bad_plain_text, "Sketch:"
+  end
+end

--- a/test/services/markdown_sketch_audit_test.rb
+++ b/test/services/markdown_sketch_audit_test.rb
@@ -48,6 +48,16 @@ class MarkdownSketchAuditTest < ActiveSupport::TestCase
     assert result.unrecognized?
   end
 
+  test "treats valid-JSON-but-non-Hash and unencodable bodies as unrecognized without raising" do
+    # These bodies make DocumentPlainText's old code raise; the audit must agree
+    # (unrecognized) and never raise, since both run on the create request.
+    [ "[1,2,3]", "42", %("hi"), %({"formatVersion":1,"scene":{"type":"excalidraw","version":2,"elements":[],"x":1e309}}) ].each do |body|
+      result = assert_nothing_raised { MarkdownSketchAudit.call("```excalidraw\n#{body}\n```") }
+      assert_equal 1, result.fence_count, "body #{body.inspect} should be seen as a fence"
+      assert result.unrecognized?, "body #{body.inspect} should be unrecognized"
+    end
+  end
+
   test "ignores a non-excalidraw code block that merely holds a scene key" do
     fence = "```json\n#{JSON.generate({ formatVersion: 1, scene: { type: "excalidraw" } })}\n```"
 


### PR DESCRIPTION
## Summary

Agents authoring inline Excalidraw sketches through the markdown document API were effectively locked out. The self-documenting contract described the sketch payload as *"a fenced excalidraw block containing versioned JSON with id, description, and scene"* — wrong on every load-bearing field (the real wrapper uses `formatVersion`, a `height` hint, and a full Excalidraw `scene` export). Worse, a sketch that failed validation came back as a `201` that was **byte-for-byte identical to success** (`normalized: false`, `warning: null`); the only signal was that `plain_text` quietly echoed raw scene JSON. An agent had no way to know it had failed, and burned round-trips guessing the schema from source.

Now the contract publishes the real `SketchData` schema with a copy-pasteable, test-verified example and a link to Excalidraw's own JSON-schema docs, and an unrecognized fence reports `normalized: true` with an explanatory warning. Resolves kieranklaassen/thinkroom#55.

## What changed

- **The contract tells the truth.** `content_contract.sketches.markdown_source` is now a structured schema (`formatVersion`, `id` pattern, `description`, `height` range, and the full `scene` shape — `type`/`version`/`appState`/`files`), plus a working `example`, a `recognition` note, and a `reference` to https://docs.excalidraw.com/docs/codebase/json-schema. The example is parsed back through the real validator in a test, so the docs can't drift from what the API accepts. `content_contract.version` bumps to `2` so consumers can detect the shape change.
- **Silent failures are now loud, on both write paths.** `POST /api/docs` and `POST /api/docs/:slug/suggestions` audit markdown sketch fences and return `normalized: true` + a warning when one isn't recognized (pluralized for multiple), instead of a response indistinguishable from success.

| Markdown create/suggestion input | Before | After |
|---|---|---|
| Valid sketch fence | `201`, `normalized:false` | unchanged |
| Unrecognized fence (e.g. issue's documented-but-wrong shape) | `201`, `normalized:false`, `warning:null` | `201`, `normalized:true`, warning |
| Malformed fence body (`[1,2,3]`, `1e309`) | **500 + orphaned document** | `201`, `normalized:true`, warning |

- **Hardening surfaced by code review (P1).** A fence whose body is valid JSON but not an object (`[1,2,3]`), or contains a number that overflows to `Infinity`, used to raise `TypeError`/`NoMethodError`/`JSON::GeneratorError` inside `DocumentPlainText` — and because the create response builds `plain_text` *after* `Document.create!`, the request 500'd and orphaned the just-persisted document (the agent never got a slug, so retries duplicated). Recognition is now centralized in `ThinkroomSketch.parse_markdown_fence`, used by the renderer, the create audit, and the suggestions audit, so these inputs are reported as unrecognized rather than crashing the request — and the paths can no longer disagree.

## Design notes

- **`normalized: true` for a kept-as-code-block sketch** is a deliberate overload (the source isn't rewritten) requested in the issue; the contract's `normalization.meaning` is broadened to stay honest. A single boolean keeps the markdown path symmetric with the existing HTML normalization signal.
- **Recognition vs. editor enforcement.** The create-time signal validates the scene *shape*; `id` and `height` are enforced by the editor (TS `normalizeSketchData`), not at create. That boundary is now documented in an `enforcement` note so agents follow the full schema rather than trusting the absence of a warning. Tightening server-side recognition to also enforce `id`/`height` is deferred (it would reclassify already-stored sketches).

## Verification

- Full Rails suite: **318 runs, 0 failures**; RuboCop clean.
- Live smoke test against the dev server confirmed the regression fix end-to-end: `GET /api/docs/:slug` state for a `[1,2,3]` fence returns `200` (was `500`); `/d/:slug` pages for valid + malformed docs both paint with no error UI.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8-D97757?logo=claude&logoColor=white)
