### PR TITLE
feat(api): PATCH /api/docs/:slug — let agents revise documents in place

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -32,21 +32,14 @@ module Api
         }, status: :content_too_large
       end
 
-      normalization = format == "html" ? HtmlDocumentSanitizer.external(content) : nil
-      source = normalization&.content || content || Document::DEFAULT_SEED
-      # Authorship is recorded only for agent-supplied source: the seeding
-      # client attributes that text as AI prose. DEFAULT_SEED boilerplate
-      # stays unattributed — placeholder text must never be claimed as AI.
-      # Gate on the normalized name so a whitespace-only header can never
-      # produce kind "agent" with a blank author.
-      agent_name = Document.normalize_display_name(current_agent)
-      agent_authored = agent_name.present? && content.present?
+      source, normalized, warning = normalized_source_and_signal(format, content, fallback: Document::DEFAULT_SEED)
+      kind, name = agent_seed_attribution(content)
       doc = Document.create!(
         title: params[:title].presence || "Untitled",
         content_format: format,
         seed_content: source,
-        seed_author_kind: agent_authored ? "agent" : nil,
-        seed_author_name: agent_authored ? agent_name : nil
+        seed_author_kind: kind,
+        seed_author_name: name
       )
       DocumentAsset.claim_from_html!(document: doc, source:) if doc.html?
 
@@ -57,11 +50,30 @@ module Api
         )
       end
 
-      # Markdown isn't server-normalized, but an excalidraw fence that fails
-      # ThinkroomSketch.parse is silently kept as a dead code block. Audit the
-      # stored source (== plain_text's source) so the response can report it
-      # instead of looking byte-for-byte identical to a recognized sketch.
-      sketch_audit = format == "html" ? nil : MarkdownSketchAudit.call(doc.seed_content)
+      render json: agent_document_response(doc, normalized:, warning:), status: :created
+    end
+
+    # GET /api/docs/:slug — the document's full live state.
+    def show
+      touch_presence
+      render json: AgentGuide.state(document, request.base_url)
+    end
+
+    private
+
+    # Normalize agent-supplied source for a format and compute the
+    # create/update normalization signal (normalized + warning) in one place,
+    # so both actions report it identically. HTML is sanitized to the editable
+    # schema; Markdown isn't server-normalized, but an excalidraw fence that
+    # fails ThinkroomSketch.parse is silently kept as a dead code block — audit
+    # the stored source so the response can report it instead of looking
+    # byte-for-byte identical to a recognized sketch. `fallback` seeds the
+    # source when no content was supplied (create's DEFAULT_SEED); callers with
+    # guaranteed content omit it.
+    def normalized_source_and_signal(format, content, fallback: nil)
+      normalization = format == "html" ? HtmlDocumentSanitizer.external(content) : nil
+      source = normalization&.content || content || fallback
+      sketch_audit = format == "html" ? nil : MarkdownSketchAudit.call(source)
       normalized = normalization&.changed? || sketch_audit&.unrecognized? || false
       warning =
         if normalization&.changed?
@@ -69,13 +81,31 @@ module Api
         else
           sketch_audit&.warning_message
         end
+      [ source, normalized, warning ]
+    end
 
+    # Authorship is recorded only for agent-supplied source: the seeding client
+    # attributes that text as AI prose. Blank/boilerplate content stays
+    # unattributed — placeholder text must never be claimed as AI. Gate on the
+    # normalized name so a whitespace-only header can never produce kind
+    # "agent" with a blank author. Returns [kind, name].
+    def agent_seed_attribution(content)
+      name = Document.normalize_display_name(current_agent)
+      return [ nil, nil ] unless name.present? && content.present?
+
+      [ "agent", name ]
+    end
+
+    # The create/update success payload: one shape so an agent revising a
+    # document sees the same fields — and the same normalization signal — it
+    # saw on create.
+    def agent_document_response(doc, normalized:, warning:)
       response = {
         slug: doc.slug,
         title: doc.title,
         share_url: document_page_url(doc.slug),
         content_format: doc.content_format,
-        content: doc.seed_content,
+        content: doc.current_content,
         plain_text: doc.plain_text,
         normalized: normalized,
         warning: warning,
@@ -83,14 +113,8 @@ module Api
         content_contract: AgentGuide.content_contract(doc.content_format, request.base_url),
         api: AgentGuide.endpoints(doc, request.base_url)
       }
-      response[:markdown] = doc.seed_content if doc.content_format == "markdown"
-      render json: response, status: :created
-    end
-
-    # GET /api/docs/:slug — the document's full live state.
-    def show
-      touch_presence
-      render json: AgentGuide.state(document, request.base_url)
+      response[:markdown] = doc.current_content if doc.content_format == "markdown"
+      response
     end
   end
 end

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class DocsController < BaseController
     rate_limit_document_creation
+    rate_limit_document_update
 
     # POST /api/docs — create a typed source document, get back its slug.
     def create
@@ -59,7 +60,88 @@ module Api
       render json: AgentGuide.state(document, request.base_url)
     end
 
+    # PATCH/PUT /api/docs/:slug — revise a document's seed in place while it is
+    # still seed-stage. Same slug, same share URL, so the link the agent already
+    # shared keeps working. Once an editor has taken over (yjs_state present)
+    # the Yjs document is authoritative and the seed is no longer read — a seed
+    # write there would 200 while changing nothing a human sees, so this returns
+    # 409 and points the agent at suggestions instead of lying about success.
+    def update
+      return render_collaborative_conflict if document.yjs_state.present?
+
+      if params.key?(:content) && params.key?(:markdown)
+        return render json: { error: "Send content or legacy markdown, not both." },
+                      status: :unprocessable_entity
+      end
+
+      requested_format = request.request_parameters["format"].presence
+      if requested_format && requested_format != document.content_format
+        return render json: {
+          error: "content_format is immutable; this document is #{document.content_format}.",
+          content_format: document.content_format
+        }, status: :unprocessable_entity
+      end
+
+      legacy_markdown = params[:markdown].presence
+      if legacy_markdown && document.content_format != "markdown"
+        return render json: { error: "The markdown field can only update Markdown documents." },
+                      status: :unprocessable_entity
+      end
+
+      content = params[:content].presence || legacy_markdown
+      new_title = params[:title].presence
+      if content.blank? && new_title.blank?
+        return render json: { error: "Send a title or content to update." },
+                      status: :unprocessable_entity
+      end
+      if content.to_s.bytesize > Document::MAX_CONTENT_BYTES
+        return render json: {
+          error: "content is too long.",
+          max_bytes: Document::MAX_CONTENT_BYTES
+        }, status: :content_too_large
+      end
+
+      normalized = false
+      warning = nil
+      if content.present?
+        source, normalized, warning = normalized_source_and_signal(document.content_format, content)
+        document.seed_content = source
+        # Only (re)attribute when an agent identifies itself; an anonymous
+        # update preserves the original seed authorship rather than erasing it.
+        kind, name = agent_seed_attribution(content)
+        if kind
+          document.seed_author_kind = kind
+          document.seed_author_name = name
+        end
+        DocumentAsset.claim_from_html!(document:, source:) if document.html?
+      end
+      document.title = new_title if new_title.present?
+      document.save!
+
+      if current_agent
+        Activity.log!(
+          document:, actor_name: current_agent, actor_kind: "agent",
+          action: "updated_document", detail: document.title
+        )
+      end
+
+      render json: agent_document_response(document, normalized:, warning:), status: :ok
+    end
+
     private
+
+    # A well-formed request that conflicts with the document's current state:
+    # collaboration has begun, so teach the agent the correct next action
+    # rather than failing opaquely.
+    def render_collaborative_conflict
+      render json: {
+        error: "This document is being edited collaboratively and can no longer be updated in place.",
+        how_to_revise: "A human has started editing, so the Yjs document is now authoritative. " \
+                       "Propose your change as a suggestion — it appears live in the editor, " \
+                       "attributed to you, for a human to accept.",
+        propose_suggestion: "#{request.base_url}/api/docs/#{document.slug}/suggestions"
+      }, status: :conflict
+    end
 
     # Normalize agent-supplied source for a format and compute the
     # create/update normalization signal (normalized + warning) in one place,

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -5,19 +5,9 @@ module Api
 
     # POST /api/docs — create a typed source document, get back its slug.
     def create
-      if params.key?(:content) && params.key?(:markdown)
-        return render json: { error: "Send content or legacy markdown, not both." },
-                      status: :unprocessable_entity
-      end
-
-      legacy_markdown = params[:markdown].presence
+      content = params[:content].presence
       requested_format = request.request_parameters["format"].presence
       format = requested_format || "markdown"
-      if legacy_markdown && format != "markdown"
-        return render json: { error: "The markdown field can only create Markdown documents." },
-                      status: :unprocessable_entity
-      end
-      content = params[:content].presence || legacy_markdown
       if requested_format && content.blank?
         return render json: { error: "content is required when format is provided." },
                       status: :unprocessable_entity
@@ -26,12 +16,7 @@ module Api
         return render json: { error: "format must be markdown or html." },
                       status: :unprocessable_entity
       end
-      if content.to_s.bytesize > Document::MAX_CONTENT_BYTES
-        return render json: {
-          error: "content is too long.",
-          max_bytes: Document::MAX_CONTENT_BYTES
-        }, status: :content_too_large
-      end
+      return if reject_oversized_content(content)
 
       source, normalized, warning = normalized_source_and_signal(format, content, fallback: Document::DEFAULT_SEED)
       kind, name = agent_seed_attribution(content)
@@ -61,18 +46,14 @@ module Api
     end
 
     # PATCH/PUT /api/docs/:slug — revise a document's seed in place while it is
-    # still seed-stage. Same slug, same share URL, so the link the agent already
-    # shared keeps working. Once an editor has taken over (yjs_state present)
-    # the Yjs document is authoritative and the seed is no longer read — a seed
-    # write there would 200 while changing nothing a human sees, so this returns
-    # 409 and points the agent at suggestions instead of lying about success.
+    # still an unclaimed draft. Same slug, same share URL, so the link the agent
+    # already shared keeps working. The moment a human gets involved — claiming
+    # the document, or opening it so an editor snapshot / live CRDT exists — the
+    # live document is authoritative and the seed is no longer what readers see.
+    # A seed write there would 200 while changing nothing, so this returns 409
+    # and points the agent at suggestions instead of lying about success.
     def update
-      return render_collaborative_conflict if document.yjs_state.present?
-
-      if params.key?(:content) && params.key?(:markdown)
-        return render json: { error: "Send content or legacy markdown, not both." },
-                      status: :unprocessable_entity
-      end
+      return render_update_conflict unless document.seed_stage? && document.claimable?
 
       requested_format = request.request_parameters["format"].presence
       if requested_format && requested_format != document.content_format
@@ -82,27 +63,17 @@ module Api
         }, status: :unprocessable_entity
       end
 
-      legacy_markdown = params[:markdown].presence
-      if legacy_markdown && document.content_format != "markdown"
-        return render json: { error: "The markdown field can only update Markdown documents." },
-                      status: :unprocessable_entity
-      end
-
-      content = params[:content].presence || legacy_markdown
+      content = params[:content].presence
       new_title = params[:title].presence
       if content.blank? && new_title.blank?
         return render json: { error: "Send a title or content to update." },
                       status: :unprocessable_entity
       end
-      if content.to_s.bytesize > Document::MAX_CONTENT_BYTES
-        return render json: {
-          error: "content is too long.",
-          max_bytes: Document::MAX_CONTENT_BYTES
-        }, status: :content_too_large
-      end
+      return if reject_oversized_content(content)
 
       normalized = false
       warning = nil
+      source = nil
       if content.present?
         source, normalized, warning = normalized_source_and_signal(document.content_format, content)
         document.seed_content = source
@@ -113,10 +84,12 @@ module Api
           document.seed_author_kind = kind
           document.seed_author_name = name
         end
-        DocumentAsset.claim_from_html!(document:, source:) if document.html?
       end
       document.title = new_title if new_title.present?
       document.save!
+      # Claim assets only after the content that references them is persisted,
+      # so a failed save never binds assets to content that was never stored.
+      DocumentAsset.claim_from_html!(document:, source:) if source && document.html?
 
       if current_agent
         Activity.log!(
@@ -130,17 +103,28 @@ module Api
 
     private
 
-    # A well-formed request that conflicts with the document's current state:
-    # collaboration has begun, so teach the agent the correct next action
-    # rather than failing opaquely.
-    def render_collaborative_conflict
+    # A well-formed request that conflicts with the document's current state: a
+    # human has claimed or started editing it, so the live document — not the
+    # seed — is authoritative. Teach the agent the correct next action rather
+    # than failing opaquely or silently no-opping a seed write.
+    def render_update_conflict
       render json: {
-        error: "This document is being edited collaboratively and can no longer be updated in place.",
-        how_to_revise: "A human has started editing, so the Yjs document is now authoritative. " \
-                       "Propose your change as a suggestion — it appears live in the editor, " \
-                       "attributed to you, for a human to accept.",
+        error: "This document is no longer an unclaimed draft — a human has claimed or started editing it, so its live state is authoritative.",
+        how_to_revise: "Propose your change as a suggestion — it appears live in the editor, " \
+                       "attributed to you, for a human to accept. See api.propose_suggestion in " \
+                       "the state payload (GET this document) for the full request shape.",
         propose_suggestion: "#{request.base_url}/api/docs/#{document.slug}/suggestions"
       }, status: :conflict
+    end
+
+    # Shared byte-cap guard (used by create and update). Renders an error and
+    # returns true when it fires, so callers `return if reject_oversized_content`.
+    def reject_oversized_content(content)
+      return false unless content.to_s.bytesize > Document::MAX_CONTENT_BYTES
+
+      render json: { error: "content is too long.", max_bytes: Document::MAX_CONTENT_BYTES },
+             status: :content_too_large
+      true
     end
 
     # Normalize agent-supplied source for a format and compute the

--- a/app/controllers/concerns/write_rate_limited.rb
+++ b/app/controllers/concerns/write_rate_limited.rb
@@ -27,6 +27,18 @@ module WriteRateLimited
                  only: :create
     end
 
+    # Updating a seed-stage document is a contribution-class write (a revision),
+    # not a new-document event — share the contribution limits, scoped to the
+    # update action.
+    def rate_limit_document_update
+      rate_limit to: CONTRIBUTION_BURST_LIMIT, within: 10.minutes, by: -> { request.remote_ip },
+                 with: :render_write_rate_limit, store: STORE, name: "document-update-burst",
+                 only: :update
+      rate_limit to: CONTRIBUTION_DAILY_LIMIT, within: 1.day, by: -> { request.remote_ip },
+                 with: :render_write_rate_limit, store: STORE, name: "document-update-daily",
+                 only: :update
+    end
+
     def rate_limit_authentication
       rate_limit to: AUTHENTICATION_BURST_LIMIT, within: 10.minutes, by: -> { request.remote_ip },
                  with: :render_write_rate_limit, store: STORE, name: "authentication-burst",

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -72,6 +72,15 @@ class Document < ApplicationRecord
     content_snapshot.nil? ? seed_content : content_snapshot
   end
 
+  # True while the seed is still what every reader sees: no editor has pushed a
+  # snapshot (content_snapshot nil) and no live CRDT exists (yjs_state blank).
+  # This is the only state where overwriting the seed actually changes what
+  # humans and agents read — once either is set, current_content shadows the
+  # seed, so a seed write would be a silent no-op.
+  def seed_stage?
+    content_snapshot.nil? && yjs_state.blank?
+  end
+
   def plain_text
     DocumentPlainText.call(format: content_format, content: current_content)
   end

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -108,7 +108,20 @@ class AgentGuide
                                       content_format: "Immutable markdown or html", content: "Canonical source",
                                       plain_text: "Rendered text", normalized: "Whether source changed during normalization",
                                       content_contract: "Machine-readable source, HTML, CSS, and image rules" },
-                           purpose: "Create a new shared document. X-Agent-Name is recommended for seed attribution but creation also permits an unattributed request." }
+                           purpose: "Create a new shared document. X-Agent-Name is recommended for seed attribution but creation also permits an unattributed request." },
+        update_document: { method: "PATCH", url: api_base,
+                           headers: { "X-Agent-Name": "recommended", "Content-Type": "application/json" },
+                           success_status: 200,
+                           conflict_status: 409,
+                           rate_limits: contribution_rate_limits,
+                           body: { title: "(optional) replacement title",
+                                   format: "(optional) must equal this document's immutable content_format",
+                                   content: "(optional) replacement canonical #{source_name} source; send title and/or content" },
+                           limits: { content_max_bytes: Document::MAX_CONTENT_BYTES },
+                           returns: { slug: "Unchanged identifier", share_url: "Unchanged share URL",
+                                      content: "Updated canonical source", plain_text: "Updated rendered text",
+                                      normalized: "Whether source changed during normalization", warning: "Normalization detail" },
+                           purpose: "Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has opened it to edit). Once a human starts editing, the live collaborative document is authoritative: this returns 409, and you propose a suggestion instead." }
       }
     end
 
@@ -199,6 +212,7 @@ class AgentGuide
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
         "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
+        "Updating: PATCH /api/docs/:slug rewrites your document's seed in place — same slug, same share URL — so revisions stay at the link you already shared, as long as no human has started editing. Once an editor takes over you get a 409: from then on, propose suggestions, which is how every edit to a live document works.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported. To author one in Markdown, embed a fenced excalidraw block following content_contract.sketches.markdown_source (formatVersion, id, description, height, and a full excalidraw scene with type/version/appState/files) — copy its example to start. A recognized sketch shows in plain_text as \"Sketch: <description> — <labels>\"; raw scene JSON in plain_text means the block was not recognized, and the create response then returns normalized: true with a warning.",
@@ -211,7 +225,7 @@ class AgentGuide
       ]
       if document.html?
         notes.insert(
-          8,
+          9,
           "HTML normalization: semantic body HTML is supported, not arbitrary page HTML/CSS. Scripts, embedded content, full-page metadata, <style> blocks, classes, remote images, and inline styles other than table-cell text alignment are removed. Upload images through api.upload_image and use the returned src exactly."
         )
       end
@@ -326,6 +340,18 @@ class AgentGuide
 
         4. Propose edits and comments through the endpoints in that state
            payload, poll events while waiting for review, then sign off.
+
+        ## Revise a document you created
+        While no human has opened the document to edit it, you can rewrite it
+        in place — same slug, same share URL, so the link you shared keeps
+        working. Send a new title, content, or both:
+           curl -X PATCH #{base_url}/api/docs/RETURNED_SLUG \\
+             -H "X-Agent-Name: YOUR_NAME" -H "Content-Type: application/json" \\
+             -d '{"title": "Revised", "content": "..."}'
+        format is immutable; omit it or send the document's existing format.
+        Once a human starts editing, the live collaborative document becomes
+        authoritative and PATCH returns 409 — from then on, propose a
+        suggestion instead.
 
         HTML is sanitized and normalized to Thinkroom's editable schema. Create and
         suggestion responses include normalized=true plus a warning when

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -361,8 +361,7 @@ class AgentGuide
         tables, and uploaded images. CSS is removed except text-align
         left/center/right on th and td. <style>, class/id hooks, scripts,
         embeds, SVG, remote images, data: images, and page metadata are removed.
-        For Markdown, send format="markdown" and Markdown in content. Legacy
-        clients may still send a top-level "markdown" field.
+        For Markdown, send Markdown in content (format defaults to "markdown").
 
         ## Ownership
         A human can claim a document in their browser; the claimed owner shows

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     post "uploads", to: "uploads#create"
     post "docs", to: "docs#create"
     get "docs/:slug", to: "docs#show", as: :doc
+    match "docs/:slug", to: "docs#update", via: [ :patch, :put ]
     post "docs/:slug/suggestions", to: "suggestions#create", as: :doc_suggestions
     post "docs/:slug/comments", to: "comments#create", as: :doc_comments
     post "docs/:slug/comments/:id/resolve", to: "comments#resolve", as: :doc_resolve_comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
     post "uploads", to: "uploads#create"
     post "docs", to: "docs#create"
     get "docs/:slug", to: "docs#show", as: :doc
-    match "docs/:slug", to: "docs#update", via: [ :patch, :put ]
+    patch "docs/:slug", to: "docs#update"
     post "docs/:slug/suggestions", to: "suggestions#create", as: :doc_suggestions
     post "docs/:slug/comments", to: "comments#create", as: :doc_comments
     post "docs/:slug/comments/:id/resolve", to: "comments#resolve", as: :doc_resolve_comment

--- a/docs/plans/2026-06-25-002-feat-patch-api-docs-update-plan.md
+++ b/docs/plans/2026-06-25-002-feat-patch-api-docs-update-plan.md
@@ -1,0 +1,266 @@
+---
+title: "feat: Add PATCH /api/docs/:slug for updating existing documents"
+type: feat
+status: active
+date: 2026-06-25
+origin: https://github.com/kieranklaassen/thinkroom/issues/57
+---
+
+# feat: Add PATCH /api/docs/:slug for updating existing documents
+
+## Summary
+
+Agents can create a document (`POST /api/docs`) but cannot revise it — `PATCH /api/docs/:slug` 404s, so every revision spawns a new document with a new share URL, breaking the "open it and collaborate live" promise. This plan adds an update endpoint that overwrites a document's seed title/content **while it is still in its pre-collaboration seed stage**, and makes that capability discoverable to agents the way every other endpoint already is (the `api` block in the create response and live state payload, the `notes`, and the plain-text guide).
+
+The load-bearing decision is what "update" means in a CRDT-backed editor. Once a human opens the share URL, the Yjs document (`yjs_state`) becomes authoritative and the seed is no longer read — so a seed overwrite at that point would be silently invisible. The endpoint therefore updates the seed only while no editor has taken over, and returns an instructive `409 Conflict` (pointing the agent at suggestions) once collaboration has begun. This keeps the API honest and consistent with the project's "agents propose, humans review — no side channel" philosophy.
+
+---
+
+## Problem Frame
+
+**Who:** AI agents that author and iterate on Thinkroom documents over the plain-HTTP API.
+
+**What's broken:** There is no update path. An agent that wants to fix a typo or regenerate a draft it just shared must `POST` a brand-new document, producing a duplicate share URL. The user who was handed the first URL never sees the revision.
+
+**Why it matters:** The product's core loop is "agent creates a doc, shares one stable URL, human opens it and collaborates." Forcing a new document per revision breaks the stability of that URL and the collaborative loop (see origin issue).
+
+**The constraint that shapes the solution:** A Thinkroom document has three content layers (see `app/models/document.rb`):
+- `seed_markdown` (the seed the creator wrote),
+- `content_markdown` (the latest editor-pushed snapshot),
+- `yjs_state` (the authoritative binary CRDT once an editor session exists).
+
+`Document#current_content` reads the snapshot if present, else the seed. `try_claim_seed` stops seeding once `yjs_state.present?`. So the seed is authoritative **only until the first editor hydrates the Yjs document**. After that, writing the seed changes nothing a human or agent will ever read. The update endpoint must respect this boundary rather than pretend a seed write is a live edit.
+
+---
+
+## Requirements
+
+- **R1.** `PATCH /api/docs/:slug` updates an existing seed-stage document's `title` and/or `content` in place and returns the updated record (origin: "Expected" behavior).
+- **R2.** The endpoint accepts the same JSON body shape as create (`title`, `content`, `format`) and the legacy top-level `markdown` field, for symmetry with `POST /api/docs`.
+- **R3.** `content_format` is immutable: a `format` that differs from the document's stored format is rejected with a clear error; a matching or omitted `format` is accepted (enforced today by `attr_readonly :content_format` and `content_format_is_immutable`).
+- **R4.** When the document has progressed past the seed stage (an editor has taken over — `yjs_state` present), the endpoint does **not** silently no-op or corrupt CRDT state; it returns an instructive `409 Conflict` telling the agent to propose a suggestion instead.
+- **R5.** Updated content runs through the same normalization and sketch-audit signal as create, so the response reports `normalized`/`warning` identically (HTML sanitize for HTML docs; markdown sketch-fence audit for markdown docs).
+- **R6.** The update is attributed: when an `X-Agent-Name` is present and content is supplied, seed authorship is re-recorded as that agent (consistent with create), and an `Activity` is logged.
+- **R7.** Update writes are rate-limited per source IP, like every other write endpoint.
+- **R8.** The update capability is discoverable to agents without out-of-band knowledge: it appears in `AgentGuide.endpoints` (so it surfaces in both the create response's `api` block and the live `GET` state payload), in `AgentGuide.notes`, and in the plain-text `AgentGuide.text` guide.
+- **R9.** A `404` is returned for an unknown slug, matching the existing `BaseController` convention.
+
+---
+
+## Key Technical Decisions
+
+### KTD-1 — Seed-stage update, not a live-content overwrite (the core decision)
+
+PATCH overwrites the **seed** (`seed_markdown` + `title` + seed attribution) and is allowed **only while `yjs_state` is blank** (no editor has hydrated the CRDT). This is the only layer a write can safely change without a CRDT side channel.
+
+- **Why:** `current_content` and every reader fall back to the seed only until an editor session exists; after that the Yjs CRDT is authoritative (`try_claim_seed` returns false once `yjs_state.present?`; `AgentGuide.notes` states "the Yjs CRDT state is always authoritative"). Writing the seed post-takeover would return `200` while changing nothing any human sees — a silent lie.
+- **The issue's real use case is the pre-takeover window:** an agent revising the doc it *just* created and shared, before a human has opened it. That is exactly the seed stage, so seed-stage update fully resolves the reported pain.
+- **Detection signal:** `document.yjs_state.blank?` is the gate. (Secondary signals — `content_markdown` present, `seed_state == "claimed"` — are downstream of an editor session; `yjs_state` is the cleanest single predicate and the same one `try_claim_seed` trusts.)
+- **Alternative rejected:** Always overwrite `content_markdown`/`yjs_state`. This requires synthesizing or destroying CRDT state from the server, contradicts "there is no side channel: you propose, humans review," and risks clobbering live human edits. Out of scope and against the product's identity.
+
+### KTD-2 — `409 Conflict` with a route-out to suggestions (not `200`, not `403`)
+
+When `yjs_state` is present, return `409` with a body that names the reason and points to the suggestions endpoint (mirroring the instructive-error style of `BaseController#require_agent!`).
+
+- **Why `409`:** the request is well-formed but conflicts with the resource's current state (collaboration has begun). `403` implies a permissions problem; `422` implies malformed input; `200` would hide the no-op. `409` is the honest status and teaches the correct next action.
+
+### KTD-3 — Reuse create's normalization/attribution path rather than duplicate it
+
+The content pipeline (mutual-exclusion of `content`/`markdown`, format check, byte-size cap, HTML sanitize vs. markdown sketch audit, seed re-attribution, `normalized`/`warning` response fields) is extracted from `#create` into shared private helpers (or a small PORO) so `#update` and `#create` stay in lockstep. The response shape for update mirrors the create response (`slug`, `title`, `share_url`, `content_format`, `content`, `plain_text`, `normalized`, `warning`, `content_contract`, `api`, and `markdown` alias for markdown docs).
+
+- **Why:** the sketch-audit contract and HTML normalization are subtle and were recently hardened (see `MarkdownSketchAudit`, `HtmlDocumentSanitizer`, contract v2). Two divergent copies would drift. Update must report normalization the same way create does (R5).
+
+### KTD-4 — Discoverability is mostly free via `AgentGuide.endpoints`
+
+Because both the create response (`docs_controller.rb:84`) and the state payload (`AgentGuide.state`) render `AgentGuide.endpoints`, adding an `update_document` entry there surfaces it in both places automatically. The remaining edits are the human-facing `notes` array and the plain-text `text` guide.
+
+- **Decision on `content_contract.version`:** adding an endpoint does **not** change the `content_contract` (the source/sketch/HTML rules are unchanged), so the `version: 2` field stays as-is. Endpoint discovery is not versioned by that field. Do not bump it.
+
+### KTD-5 — Route both `PATCH` and `PUT`
+
+Map the action to both verbs (`match ... via: [:patch, :put]` or Rails' `patch`+`put`), since the issue and REST convention both apply and agents may send either. The action is a full replace of the seed, which is idempotent — consistent with `PUT` semantics and fine under `PATCH`.
+
+---
+
+## High-Level Technical Design
+
+Request lifecycle for `PATCH /api/docs/:slug` — the branching gate is the design's substance:
+
+```mermaid
+flowchart TD
+    A[PATCH /api/docs/:slug] --> B{slug exists?}
+    B -- no --> B404[404 No document with that slug]
+    B -- yes --> C{yjs_state blank?<br/>still seed stage}
+    C -- no, editor took over --> CFLICT[409 Conflict<br/>"This document is now collaborative.<br/>Propose a suggestion instead." + suggestions URL]
+    C -- yes --> D{format given and<br/>differs from stored?}
+    D -- yes --> D422[422 format is immutable]
+    D -- no --> E{content + markdown<br/>both sent?}
+    E -- yes --> E422[422 send one, not both]
+    E -- no --> F{content within<br/>MAX_CONTENT_BYTES?}
+    F -- no --> F413[413 content too long]
+    F -- yes --> G[Normalize: HTML sanitize OR markdown sketch audit]
+    G --> H[Update seed_markdown + title,<br/>re-attribute seed author if agent + content]
+    H --> I[Log Activity: updated_document]
+    I --> J[200 OK: create-shaped response<br/>with normalized / warning / api / content_contract]
+```
+
+Content-layer model (why the gate at C exists):
+
+```mermaid
+flowchart LR
+    seed[seed_markdown<br/>seed stage] -->|editor hydrates| yjs[yjs_state CRDT<br/>authoritative]
+    yjs -->|editor pushes snapshot| snap[content_markdown<br/>snapshot]
+    seed -. current_content reads seed<br/>only while snapshot nil .-> reader[(readers / agents)]
+    snap -. once present, reader sees snapshot .-> reader
+```
+
+PATCH writes `seed_markdown`. It is meaningful only on the left edge (before the `editor hydrates` transition), which is exactly what gate C enforces.
+
+---
+
+## Implementation Units
+
+### U1. Extract shared seed-content pipeline from `#create`
+
+**Goal:** Factor the content-normalization, validation, attribution, and response-building logic out of `Api::DocsController#create` into reusable private helpers (or a small `app/services` PORO such as `AgentDocumentWrite`) so `#update` can reuse it without duplication. No behavior change to create.
+
+**Requirements:** R5, R3 (shared), R6 (shared)
+
+**Dependencies:** none
+
+**Files:**
+- `app/controllers/api/docs_controller.rb` (refactor `#create`)
+- (optional) `app/services/agent_document_write.rb` (new, only if a PORO reads cleaner than private methods)
+- `test/integration/agent_api_test.rb` (existing create tests are the characterization net)
+
+**Approach:**
+- Identify the shared steps in `#create`: content/markdown mutual-exclusion check, `requested_format` resolution + `CONTENT_FORMATS` validation, `MAX_CONTENT_BYTES` guard, `HtmlDocumentSanitizer.external` vs. `MarkdownSketchAudit.call` branch producing `normalized`/`warning`, agent-attribution gating (`Document.normalize_display_name`, `agent_authored`), and the create-shaped response hash builder (including the `markdown` alias and `content_contract`/`api` blocks).
+- Keep create's create-specific bits (DEFAULT_SEED fallback, `DocumentAsset.claim_from_html!`, `status: :created`) in `#create`.
+- Extract the rest so both actions call the same code. Prefer private controller methods unless a PORO is clearly cleaner.
+
+**Patterns to follow:** Existing service POROs under `app/services/` (e.g., `AgentGuide`, `MarkdownSketchAudit`, `HtmlDocumentSanitizer`) — class methods, single responsibility.
+
+**Execution note:** Characterization-first. Run the full `test/integration/agent_api_test.rb` suite before and after; the refactor is correct only if every existing create/normalization/sketch test stays green with no edits.
+
+**Test scenarios:**
+- Test expectation: covered by existing create suite — the refactor must leave all `agent_api_test.rb` create, normalization, sketch-audit, and attribution tests green unchanged. If a PORO is introduced, no new behavior tests are required at this unit (behavior is unchanged); behavior tests land in U2.
+
+**Verification:** `bin/rails test test/integration/agent_api_test.rb` passes with zero edits to existing assertions.
+
+---
+
+### U2. Add `PATCH/PUT /api/docs/:slug` update action with seed-stage semantics
+
+**Goal:** Implement the update endpoint: route, `Api::DocsController#update`, seed-stage gate, immutability enforcement, attribution, activity logging, rate limiting, and the create-shaped response.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R9
+
+**Dependencies:** U1
+
+**Files:**
+- `config/routes.rb` (add `patch`/`put` `docs/:slug` → `docs#update`)
+- `app/controllers/api/docs_controller.rb` (`#update`)
+- `app/controllers/concerns/write_rate_limited.rb` (add an update/contribution rate-limit macro, or extend an existing one to cover `:update`)
+- `test/integration/agent_api_test.rb` (new tests)
+
+**Approach:**
+- **Route:** add to the `namespace :api` block, e.g. `match "docs/:slug", to: "docs#update", via: [:patch, :put]` (or paired `patch`/`put`). Keep the existing `get docs/:slug` and `post docs` lines intact.
+- **Gate order** (mirror the HTD flowchart): resolve `document` (the `find_by!` raises → `BaseController` renders the shared 404, satisfying R9) → check `yjs_state.blank?`; if not, render `409` with an instructive body and the suggestions URL (`AgentGuide.endpoints(document, base_url)[:propose_suggestion][:url]` or build it inline) → run the shared validation/normalization from U1 → assign `seed_content` + `title`, re-attribute seed author when `current_agent` + content present → `save!` → log `Activity` `updated_document` → render the create-shaped response with `status: :ok`.
+- **Immutability (R3):** if a `format` is supplied that differs from `document.content_format`, return `422` with a clear message before writing. (Belt-and-suspenders: `content_format_is_immutable` + `attr_readonly` already block the column change, but the API should reject explicitly rather than silently ignore.)
+- **Empty body:** a PATCH with neither `title` nor `content` should be a clean no-op success (`200`) or a `422` — choose `422 "Send a title or content to update."` for honesty; decide and test.
+- **Rate limiting (R7):** add `rate_limit_document_update` (or reuse contribution limits) scoped `only: :update` and invoke the macro in `DocsController`. Pick limits consistent with `CONTRIBUTION_*` (an update is a contribution-class write, not a doc-creation event).
+- **Attribution (R6):** reuse U1's agent-attribution logic; on update set `seed_author_kind`/`seed_author_name` to the agent when content is supplied, leaving them untouched on a title-only update.
+
+**Patterns to follow:** `#create` for response shape and attribution; `BaseController#require_agent!` for instructive-error bodies; `Activity.log!` calls in `#create`; `claim!`'s transaction discipline if the activity + save should commit together.
+
+**Execution note:** Start with a failing integration test for the happy-path seed update contract, then the 409 collaborative-state test, before implementing.
+
+**Test scenarios (all in `test/integration/agent_api_test.rb`):**
+- **Happy path (markdown):** create a doc, PATCH new `title` + `content`; expect `200`, response reflects new title/content, `current_content` updated, `share_url`/`slug` unchanged. *Covers R1.*
+- **Happy path (title only):** PATCH only `title`; expect `200`, content unchanged, seed authorship untouched.
+- **Happy path (content only):** PATCH only `content`; expect `200`, title unchanged.
+- **Stable URL:** PATCH does not change `slug` or `share_url` (the whole point of the issue). *Covers R1.*
+- **Immutable format rejected:** create markdown doc, PATCH with `format: "html"`; expect `422` with format-immutable message; document unchanged. *Covers R3.*
+- **Matching format accepted:** PATCH with `format` equal to stored format; expect `200`.
+- **Collaborative conflict:** set `yjs_state` on the doc (simulate editor takeover), PATCH content; expect `409` with a body that names the conflict and includes the suggestions URL; seed unchanged. *Covers R4.*
+- **content + markdown both sent:** expect `422` "send one, not both" (parity with create). *Covers R2.*
+- **Oversized content:** PATCH content over `MAX_CONTENT_BYTES`; expect `413` with `max_bytes`. *Covers R5 guard.*
+- **HTML normalization signal:** PATCH an HTML doc with unsupported markup; expect `200` with `normalized: true` + warning, sanitized content stored. *Covers R5.*
+- **Markdown unrecognized sketch:** PATCH markdown with a bad excalidraw fence; expect `200` with `normalized: true` + sketch warning (parity with create sketch-audit tests). *Covers R5.*
+- **Attribution:** PATCH content with `X-Agent-Name: Scout`; expect seed authorship re-recorded as Scout and an `updated_document` activity logged. *Covers R6.*
+- **No X-Agent-Name:** PATCH content without the header; decide policy — update permitted (like create) but records no agent attribution; assert behavior matches the chosen policy.
+- **Empty update body:** PATCH with neither field; expect the chosen `422` (or no-op `200`) — assert the decided behavior.
+- **Unknown slug:** PATCH a nonexistent slug; expect `404` "No document with that slug." *Covers R9.*
+- **Rate limit:** exceed the update burst limit; expect `429` with the standard write-rate-limit body. *Covers R7.*
+
+**Verification:** New tests pass; `current_content` returns the patched seed for a seed-stage doc and the 409 path leaves `seed_markdown` and `yjs_state` untouched.
+
+---
+
+### U3. Make `update_document` discoverable to agents
+
+**Goal:** Advertise the update endpoint everywhere agents look, so no out-of-band knowledge is needed — the second half of the issue's intent ("make it more clear to the agent to update"). This is what stops agents from defaulting to "create a new doc."
+
+**Requirements:** R8
+
+**Dependencies:** U2
+
+**Files:**
+- `app/services/agent_guide.rb` (`endpoints`, `notes`, `text`)
+- `test/integration/agent_api_test.rb` and/or `test/integration/agent_discovery_test.rb` (assert the endpoint is advertised)
+
+**Approach:**
+- **`endpoints`:** add an `update_document` entry (method `PATCH`, url `#{api_base}` i.e. `/api/docs/:slug`, headers `X-Agent-Name: recommended` + `Content-Type: application/json`, `success_status: 200`, `rate_limits`, `body: { title, format (must equal current), content }`, `limits: { content_max_bytes }`, and a `purpose` that states the seed-stage rule plainly: *"Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has started editing). Once collaboration begins this returns 409; propose a suggestion instead."*). Because both the create response and `AgentGuide.state` render `endpoints`, this surfaces in both for free (R8, KTD-4).
+- **`notes`:** add a one-line note explaining update semantics and the seed-stage boundary, near the create/source-contract notes — e.g. *"Updating: PATCH /api/docs/:slug rewrites your document's seed in place (same URL) until a human starts editing; after that, switch to suggestions (you'll get a 409)."*
+- **`text` guide:** add a short "Update your document" step in the plain-text guide (the create-your-own-doc section is the natural home), with a `curl -X PATCH` example mirroring the create example.
+- **Do not** bump `content_contract.version` (KTD-4) — the source/sketch/HTML contract is unchanged.
+
+**Patterns to follow:** the existing `create_document` entry in `endpoints`, the existing `notes` voice, and the numbered `curl` steps in `text`.
+
+**Test scenarios:**
+- **Create response advertises update:** `POST /api/docs` response's `api` block includes `update_document` with method `PATCH` and the seed-stage purpose. *Covers R8.*
+- **State payload advertises update:** `GET /api/docs/:slug` (`AgentGuide.state`) `api` block includes `update_document`. *Covers R8.*
+- **Notes mention update:** the `notes` array contains the update/seed-stage guidance string.
+- **Plain-text guide mentions update:** `AgentGuide.text` (served to non-browser fetchers of the share URL) includes a PATCH example. (If `agent_discovery_test.rb` already asserts guide shape, extend it there.)
+
+**Verification:** Discovery tests pass; an agent reading only the create response or the state payload can find the update endpoint and its seed-stage rule without external docs.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- `PATCH/PUT /api/docs/:slug` updating seed-stage documents (title + content), with normalization parity, attribution, rate limiting, immutability enforcement, and the 409 collaborative-state guard.
+- Full agent discoverability of the new endpoint.
+
+**Outside this product's identity (do not build):**
+- Server-side mutation of live CRDT / `yjs_state` to "push" an agent edit into an open editor. The product is suggestion-based: agents propose, humans review. A direct live-content overwrite is a side channel the design deliberately forbids.
+
+### Deferred to Follow-Up Work
+- **Agent-authored edits to collaborative docs** beyond suggestions (e.g., an "agent revision proposed as a bulk suggestion"): if the 409 path proves too limiting in practice, a follow-up could let PATCH on a collaborative doc create a full-document replacement *suggestion* rather than erroring. Out of scope here; the 409 + suggestions route-out is the v1 answer.
+- **`DELETE /api/docs/:slug`** for agents: deletion remains owner/browser-only by design; not part of this issue.
+- **Optimistic concurrency** (`If-Match`/updated_at precondition) for racing PATCHes against the same seed: low value while seed-stage and single-author; revisit only if multi-agent seed editing becomes real.
+
+---
+
+## Risks & Dependencies
+
+- **Risk — silent no-op if the seed-stage gate is wrong.** If `#update` writes the seed on a doc whose editor has already taken over, the agent gets `200` but nothing changes. *Mitigation:* gate strictly on `yjs_state.blank?` (the same predicate `try_claim_seed` trusts) and cover the 409 path with a test that sets `yjs_state` (U2). This is the highest-value test in the plan.
+- **Risk — refactor regression in `#create` (U1).** Extracting shared logic could subtly change create's normalization or attribution. *Mitigation:* characterization-first — the existing `agent_api_test.rb` create/sketch/HTML suite must stay green unedited.
+- **Risk — rate-limit macro miswiring.** Rails `rate_limit ... only:` filters must target `:update`; a copy-paste from the `:create` macro that leaves `only: :create` would leave update unthrottled. *Mitigation:* explicit `429` test in U2.
+- **Risk — immutability bypass.** If `#update` permits-lists `format` into the model write, the `content_format_is_immutable` validation will reject it as a `RecordInvalid` (rendered `422` by `BaseController`) — acceptable, but the explicit pre-check gives a clearer message. *Mitigation:* explicit format-diff check (U2) plus the existing model guard as backstop.
+
+**Dependencies / prerequisites:** none external. All touched code (`Api::DocsController`, `AgentGuide`, `WriteRateLimited`, `Document`) is in-repo. Tests run under `bin/rails test`.
+
+---
+
+## Sources & Research
+
+- Origin issue: https://github.com/kieranklaassen/thinkroom/issues/57
+- `app/controllers/api/docs_controller.rb` — `#create` (the pattern `#update` mirrors), response shape, normalization/sketch-audit usage.
+- `app/controllers/api/base_controller.rb` — shared 404/422 rescues, `document` finder, `current_agent`, instructive-error style (`require_agent!`).
+- `app/models/document.rb` — `current_content`, `seed_content`, `try_claim_seed` (the `yjs_state.present?` boundary), `content_format_is_immutable`, `attr_readonly :slug, :content_format`.
+- `app/services/agent_guide.rb` — `endpoints`/`state`/`notes`/`text` (discovery surface; `endpoints` rendered in both create response and state).
+- `app/controllers/concerns/write_rate_limited.rb` — rate-limit macros and limits.
+- `db/schema.rb` — documents table (`yjs_state binary`, `seed_markdown`, `content_markdown`, `seed_state`).
+- `test/integration/agent_api_test.rb`, `test/integration/agent_discovery_test.rb` — test patterns to mirror.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -6,6 +6,9 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   AGENT = { "X-Agent-Name" => "Scout" }.freeze
 
   setup do
+    # Rate-limit counters live in a process-wide store; clear it so per-test
+    # write volume can't bleed across tests (mirrors WriteRateLimitTest).
+    WriteRateLimited::STORE.clear
     @document = Document.create!(title: "Shared Doc", seed_markdown: "# Hello\n\nA paragraph about provenance.")
   end
 
@@ -472,6 +475,209 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "markdown", body["content_format"]
     assert_equal true, body["normalized"]
     assert_includes body["warning"], "excalidraw block"
+  end
+
+  # --- PATCH /api/docs/:slug (seed-stage update) ---
+
+  test "agent updates a seed-stage document in place keeping its slug" do
+    post "/api/docs", params: { title: "Draft", content: "# First cut" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+    share_url = response.parsed_body["share_url"]
+
+    patch "/api/docs/#{slug}",
+          params: { title: "Revised", content: "# Second cut\n\nBetter now." },
+          headers: AGENT, as: :json
+
+    assert_response :ok
+    body = response.parsed_body
+    assert_equal slug, body["slug"], "slug must stay stable — the whole point of update"
+    assert_equal share_url, body["share_url"]
+    assert_equal "Revised", body["title"]
+    assert_includes body["content"], "Second cut"
+
+    doc = Document.find_by!(slug: slug)
+    assert_equal "Revised", doc.title
+    assert_includes doc.current_content, "Second cut"
+    assert_equal "updated_document", doc.activities.last.action
+    assert_equal "Scout", doc.activities.last.actor_name
+  end
+
+  test "update on a collaborative document returns 409 with a route to suggestions" do
+    @document.update!(yjs_state: "binary-crdt-state")
+
+    patch "/api/docs/#{@document.slug}",
+          params: { content: "# Trying to overwrite" },
+          headers: AGENT, as: :json
+
+    assert_response :conflict
+    body = response.parsed_body
+    assert_includes body["error"].downcase, "collaborativ"
+    assert_includes body["propose_suggestion"], "/api/docs/#{@document.slug}/suggestions"
+
+    @document.reload
+    assert_equal "# Hello\n\nA paragraph about provenance.", @document.seed_markdown,
+                 "seed must be untouched when the editor has taken over"
+  end
+
+  test "title-only update leaves content and seed authorship untouched" do
+    post "/api/docs", params: { title: "Draft", content: "# Body stays" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+    doc_before = Document.find_by!(slug: slug)
+
+    patch "/api/docs/#{slug}", params: { title: "Renamed" }, headers: AGENT, as: :json
+
+    assert_response :ok
+    doc = Document.find_by!(slug: slug)
+    assert_equal "Renamed", doc.title
+    assert_equal doc_before.seed_content, doc.current_content
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal "Scout", doc.seed_author_name
+  end
+
+  test "content-only update leaves the title untouched" do
+    post "/api/docs", params: { title: "Keep Me", content: "# Old" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}", params: { content: "# New" }, headers: AGENT, as: :json
+
+    assert_response :ok
+    doc = Document.find_by!(slug: slug)
+    assert_equal "Keep Me", doc.title
+    assert_includes doc.current_content, "New"
+  end
+
+  test "update rejects a format that differs from the immutable stored format" do
+    post "/api/docs", params: { content: "# Markdown doc" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}",
+          params: { format: "html", content: "<h1>nope</h1>" },
+          headers: AGENT, as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body["error"], "immutable"
+    assert_equal "# Markdown doc", Document.find_by!(slug: slug).seed_content
+  end
+
+  test "update accepts a format that matches the stored format" do
+    post "/api/docs", params: { content: "# Markdown doc" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}",
+          params: { format: "markdown", content: "# Still markdown" },
+          headers: AGENT, as: :json
+
+    assert_response :ok
+    assert_includes Document.find_by!(slug: slug).current_content, "Still markdown"
+  end
+
+  test "update with both content and markdown is rejected" do
+    patch "/api/docs/#{@document.slug}",
+          params: { content: "# a", markdown: "# b" },
+          headers: AGENT, as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body["error"], "not both"
+  end
+
+  test "update with neither title nor content is rejected" do
+    patch "/api/docs/#{@document.slug}", params: {}, headers: AGENT, as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body["error"], "title or content"
+  end
+
+  test "update rejects content larger than the byte cap" do
+    post "/api/docs", params: { content: "# small" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}",
+          params: { content: "x" * (Document::MAX_CONTENT_BYTES + 1) },
+          headers: AGENT, as: :json
+
+    assert_response :content_too_large
+    assert_equal Document::MAX_CONTENT_BYTES, response.parsed_body["max_bytes"]
+  end
+
+  test "update reports HTML normalization the same way create does" do
+    post "/api/docs",
+         params: { format: "html", content: "<h1>Clean</h1>" },
+         headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}",
+          params: { content: '<h1 onclick="bad()">Hi</h1><script>evil()</script>' },
+          headers: AGENT, as: :json
+
+    assert_response :ok
+    body = response.parsed_body
+    assert body["normalized"]
+    assert_includes body["warning"], "normalized"
+    refute_match(/onclick|script/, body["content"])
+  end
+
+  test "update with an unrecognized markdown sketch fence reports a warning" do
+    post "/api/docs", params: { content: "# fine" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
+    bad = sketch_fence({ version: 1, id: "x", scene: { elements: [] } })
+
+    patch "/api/docs/#{slug}", params: { content: bad }, headers: AGENT, as: :json
+
+    assert_response :ok
+    body = response.parsed_body
+    assert_equal true, body["normalized"]
+    assert_includes body["warning"], "excalidraw block"
+  end
+
+  test "update re-attributes seed authorship to the updating agent" do
+    post "/api/docs", params: { content: "# v1" }, headers: { "X-Agent-Name" => "Author" }, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}",
+          params: { content: "# v2" },
+          headers: { "X-Agent-Name" => "Editor" }, as: :json
+
+    assert_response :ok
+    doc = Document.find_by!(slug: slug)
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal "Editor", doc.seed_author_name
+    assert_equal "updated_document", doc.activities.last.action
+    assert_equal "Editor", doc.activities.last.actor_name
+  end
+
+  test "anonymous content update preserves the original seed authorship" do
+    post "/api/docs", params: { content: "# v1" }, headers: { "X-Agent-Name" => "Author" }, as: :json
+    slug = response.parsed_body["slug"]
+
+    patch "/api/docs/#{slug}", params: { content: "# v2" }, as: :json
+
+    assert_response :ok
+    doc = Document.find_by!(slug: slug)
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal "Author", doc.seed_author_name
+  end
+
+  test "update of an unknown slug returns a clean 404" do
+    patch "/api/docs/does-not-exist", params: { content: "# x" }, headers: AGENT, as: :json
+
+    assert_response :not_found
+    assert_includes response.parsed_body["error"], "No document with that slug."
+  end
+
+  test "update writes are rate limited per source IP" do
+    headers = AGENT.merge("REMOTE_ADDR" => "192.0.2.243")
+    post "/api/docs", params: { content: "# seed" }, headers:, as: :json
+    slug = response.parsed_body["slug"]
+
+    WriteRateLimited::CONTRIBUTION_BURST_LIMIT.times do
+      patch "/api/docs/#{slug}", params: { content: "# rev" }, headers:, as: :json
+      assert_response :ok
+    end
+
+    patch "/api/docs/#{slug}", params: { content: "# rev" }, headers:, as: :json
+
+    assert_response :too_many_requests
+    assert_includes response.parsed_body["error"], "rate limit"
   end
 
   private

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -14,7 +14,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
   test "agent creates a document from markdown and gets a shareable slug" do
     post "/api/docs",
-         params: { title: "Agent Doc", markdown: "# From an agent" },
+         params: { title: "Agent Doc", content: "# From an agent" },
          headers: AGENT, as: :json
 
     assert_response :created
@@ -183,21 +183,12 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_nil response.parsed_body["warning"]
   end
 
-  test "explicit format validates content and legacy field compatibility" do
+  test "explicit format validates content and rejects unknown formats" do
     assert_no_difference -> { Document.count } do
       post "/api/docs", params: { format: "html" }, headers: AGENT, as: :json
     end
     assert_response :unprocessable_entity
     assert_includes response.parsed_body["error"], "content is required"
-
-    assert_no_difference -> { Document.count } do
-      post "/api/docs",
-           params: { format: "html", markdown: "# Wrong field" },
-           headers: AGENT,
-           as: :json
-    end
-    assert_response :unprocessable_entity
-    assert_includes response.parsed_body["error"], "markdown field"
 
     assert_no_difference -> { Document.count } do
       post "/api/docs",
@@ -210,7 +201,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   end
 
   test "doc created without X-Agent-Name records no seed authorship" do
-    post "/api/docs", params: { markdown: "# Anonymous" }, as: :json
+    post "/api/docs", params: { content: "# Anonymous" }, as: :json
 
     assert_response :created
     doc = Document.find_by!(slug: response.parsed_body["slug"])
@@ -220,7 +211,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
   test "oversized agent name is capped at 255 chars in seed authorship" do
     post "/api/docs",
-         params: { markdown: "# Big name" },
+         params: { content: "# Big name" },
          headers: { "X-Agent-Name" => "A" * 300 }, as: :json
 
     assert_response :created
@@ -265,7 +256,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   end
 
   test "cold read reports agent-seeded docs as unreviewed AI with authorship" do
-    post "/api/docs", params: { markdown: "# From an agent" }, headers: AGENT, as: :json
+    post "/api/docs", params: { content: "# From an agent" }, headers: AGENT, as: :json
     slug = response.parsed_body["slug"]
 
     get "/api/docs/#{slug}", headers: AGENT
@@ -399,7 +390,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
   test "markdown create with a valid sketch fence reports clean success" do
     post "/api/docs",
-         params: { title: "Sketch Doc", markdown: "Intro\n\n#{valid_sketch_fence}" },
+         params: { title: "Sketch Doc", content: "Intro\n\n#{valid_sketch_fence}" },
          headers: AGENT, as: :json
 
     assert_response :created
@@ -416,7 +407,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     # scene that is not a full excalidraw export. Previously this returned a 201
     # byte-for-byte identical to success.
     bad = sketch_fence({ version: 1, id: "x", scene: { elements: [] } })
-    post "/api/docs", params: { title: "Broken Sketch", markdown: bad },
+    post "/api/docs", params: { title: "Broken Sketch", content: bad },
          headers: AGENT, as: :json
 
     assert_response :created
@@ -434,7 +425,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   test "markdown create pluralizes the warning for multiple bad fences" do
     bad = sketch_fence({ version: 1, scene: {} })
     post "/api/docs",
-         params: { title: "Two Broken", markdown: "#{bad}\n\nBetween\n\n#{bad}" },
+         params: { title: "Two Broken", content: "#{bad}\n\nBetween\n\n#{bad}" },
          headers: AGENT, as: :json
 
     assert_response :created
@@ -444,7 +435,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   end
 
   test "plain markdown create stays unnormalized" do
-    post "/api/docs", params: { markdown: "# Just text, no sketch" }, headers: AGENT, as: :json
+    post "/api/docs", params: { content: "# Just text, no sketch" }, headers: AGENT, as: :json
 
     assert_response :created
     assert_equal false, response.parsed_body["normalized"]
@@ -456,7 +447,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     # while building plain_text, 500ing the request after the doc was persisted.
     [ "[1,2,3]", "42", %({"formatVersion":1,"scene":{"type":"excalidraw","version":2,"elements":[],"x":1e309}}) ].each do |body|
       assert_difference -> { Document.count }, 1 do
-        post "/api/docs", params: { markdown: "```excalidraw\n#{body}\n```" }, headers: AGENT, as: :json
+        post "/api/docs", params: { content: "```excalidraw\n#{body}\n```" }, headers: AGENT, as: :json
       end
       assert_response :created
       body_json = response.parsed_body
@@ -511,12 +502,40 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
     assert_response :conflict
     body = response.parsed_body
-    assert_includes body["error"].downcase, "collaborativ"
+    assert_includes body["error"], "no longer an unclaimed draft"
     assert_includes body["propose_suggestion"], "/api/docs/#{@document.slug}/suggestions"
 
     @document.reload
     assert_equal "# Hello\n\nA paragraph about provenance.", @document.seed_markdown,
                  "seed must be untouched when the editor has taken over"
+  end
+
+  test "update returns 409 once an editor snapshot shadows the seed even if yjs_state is blank" do
+    # A markdown snapshot can persist content_snapshot with no yjs_state. The
+    # seed is then no longer what readers see, so a seed overwrite would 200
+    # while changing nothing — block it instead of silently no-opping.
+    @document.update!(content_snapshot: "# Snapshot the editor pushed")
+
+    patch "/api/docs/#{@document.slug}",
+          params: { content: "# would be invisible" },
+          headers: AGENT, as: :json
+
+    assert_response :conflict
+    @document.reload
+    assert_equal "# Hello\n\nA paragraph about provenance.", @document.seed_markdown
+  end
+
+  test "update returns 409 once a human has claimed the document" do
+    @document.update!(owner_token: SecureRandom.hex(8), owner_name: "Owner")
+
+    patch "/api/docs/#{@document.slug}",
+          params: { content: "# not yours to overwrite" },
+          headers: AGENT, as: :json
+
+    assert_response :conflict
+    @document.reload
+    assert_equal "# Hello\n\nA paragraph about provenance.", @document.seed_markdown,
+                 "a claimed document's seed must not be overwritable through the agent API"
   end
 
   test "title-only update leaves content and seed authorship untouched" do
@@ -571,13 +590,17 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_includes Document.find_by!(slug: slug).current_content, "Still markdown"
   end
 
-  test "update with both content and markdown is rejected" do
-    patch "/api/docs/#{@document.slug}",
-          params: { content: "# a", markdown: "# b" },
-          headers: AGENT, as: :json
+  test "clean HTML update reports no normalization" do
+    post "/api/docs", params: { format: "html", content: "<h1>Clean</h1>" }, headers: AGENT, as: :json
+    slug = response.parsed_body["slug"]
 
-    assert_response :unprocessable_entity
-    assert_includes response.parsed_body["error"], "not both"
+    patch "/api/docs/#{slug}", params: { content: "<h1>Still clean</h1><p>Body.</p>" }, headers: AGENT, as: :json
+
+    assert_response :ok
+    body = response.parsed_body
+    assert_equal false, body["normalized"]
+    assert_nil body["warning"]
+    assert_includes body["content"], "Still clean"
   end
 
   test "update with neither title nor content is rejected" do

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -657,6 +657,34 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "Author", doc.seed_author_name
   end
 
+  test "create response advertises the update endpoint to agents" do
+    post "/api/docs", params: { content: "# hi" }, headers: AGENT, as: :json
+
+    assert_response :created
+    update = response.parsed_body.dig("api", "update_document")
+    assert_equal "PATCH", update["method"]
+    assert_equal 409, update["conflict_status"]
+    assert_includes update["url"], "/api/docs/#{response.parsed_body['slug']}"
+    assert_includes update["purpose"], "seed-stage"
+  end
+
+  test "state payload advertises the update endpoint and explains it in notes" do
+    get "/api/docs/#{@document.slug}", headers: AGENT, as: :json
+
+    assert_response :success
+    assert_equal "PATCH", response.parsed_body.dig("api", "update_document", "method")
+    assert response.parsed_body["notes"].any? { |n| n.include?("PATCH /api/docs/:slug") }
+  end
+
+  test "plain-text share guide documents updating a created document" do
+    get "/d/#{@document.slug}", headers: { "User-Agent" => "curl/8.6.0" }
+
+    assert_response :success
+    assert_equal "text/plain", response.media_type
+    assert_includes response.body, "Revise a document you created"
+    assert_includes response.body, "-X PATCH"
+  end
+
   test "update of an unknown slug returns a clean 404" do
     patch "/api/docs/does-not-exist", params: { content: "# x" }, headers: AGENT, as: :json
 


### PR DESCRIPTION
Closes #57.

## What & why

Agents could create a document (`POST /api/docs`) but had no way to revise one — `PATCH /api/docs/:slug` 404'd. Every edit meant a brand-new document with a new share URL, which broke the "open it and collaborate live" promise on the link the agent already shared. This adds the update endpoint and makes it discoverable to agents.

## How it works

`PATCH /api/docs/:slug` rewrites a document's seed **title and/or content in place** — same slug, same share URL — while the document is still an unclaimed draft. The moment a human gets involved (claims it, or opens it so an editor snapshot / live CRDT exists), the live document is authoritative, so the endpoint returns **409** and routes the agent to suggestions instead of silently overwriting nothing.

The seed-stage gate is the crux. A seed write only changes what readers see when `Document#seed_stage?` (no editor snapshot **and** no Yjs state) and the document is unclaimed. Gating on `yjs_state` alone — the original plan — had two holes the code review caught: a markdown snapshot can set `content_snapshot` with no `yjs_state`, and a claim establishes ownership with no `yjs_state`. Both now correctly return 409 rather than a misleading `200`.

- Content runs through the same HTML-sanitize / markdown sketch-audit pipeline as create, reporting `normalized` / `warning` identically.
- `content_format` stays immutable; a differing `format` is rejected.
- Per-IP, contribution-class rate limiting.
- Discoverable everywhere agents look: the create response and live state payload (`api.update_document`), the `notes`, and the plain-text share guide.

```bash
curl -X PATCH https://thinkroom.kieranklaassen.com/api/docs/SLUG \
  -H "X-Agent-Name: Scout" -H "Content-Type: application/json" \
  -d '{"title": "Revised", "content": "# Second draft"}'
```

## Also in this PR

- **Removed the legacy top-level `markdown` request field.** `content` (+ optional `format`) is the only input now — this is a new app with no legacy clients to support.
- Code-review hardening: dropped `PUT` (partial-update semantics don't fit PUT's full-replace contract), claim HTML assets only after `save!` so a failed save never binds assets to unpersisted content, and extracted the shared byte-cap guard.

## Testing

18 PATCH integration tests cover the happy paths (title-only / content-only / both), the 409 gate (live CRDT, snapshot-shadows-seed, claimed), format immutability, normalization parity, attribution, rate limiting, 404, and all four discovery surfaces. Full suite green (338 runs, 0 failures); RuboCop clean.

## Notes for the reviewer

- The seed-stage + unclaimed gate intentionally narrows the plan's original `yjs_state`-only rule (see plan KTD-1) after the review surfaced the snapshot/claim windows.
- The `markdown` *response* alias on the state payload is kept (it's the current markdown read model, not legacy) — only the legacy *request* field was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
