### PR TITLE
fix(api): make claimed-document revision flow explicit

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -108,12 +108,15 @@ module Api
     # seed — is authoritative. Teach the agent the correct next action rather
     # than failing opaquely or silently no-opping a seed write.
     def render_update_conflict
+      revision_workflow = AgentGuide.revision_workflow(document, request.base_url)
+      steps = revision_workflow.fetch(:steps).index_by { |step| step.fetch(:action) }
       render json: {
         error: "This document is no longer an unclaimed draft — a human has claimed or started editing it, so its live state is authoritative.",
-        how_to_revise: "Propose your change as a suggestion — it appears live in the editor, " \
-                       "attributed to you, for a human to accept. See api.propose_suggestion in " \
-                       "the state payload (GET this document) for the full request shape.",
-        propose_suggestion: "#{request.base_url}/api/docs/#{document.slug}/suggestions"
+        how_to_revise: "#{revision_workflow[:guidance]} #{revision_workflow[:when_no_open_comments]}",
+        read_state: steps.fetch("read_open_comments").fetch(:url),
+        propose_suggestion: steps.fetch("propose_targeted_suggestion").fetch(:url),
+        resolve_comment: steps.fetch("resolve_addressed_comment").fetch(:url),
+        revision_workflow:
       }, status: :conflict
     end
 

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -7,6 +7,8 @@ class AgentGuide
     # share URL's JSON representation — same document, same truth).
     def state(document, base_url)
       content = document.current_content
+      open_comments = document.comments.open.order(:created_at).map(&:as_props)
+      revision_workflow = revision_workflow(document, base_url) if open_comments.any?
       payload = {
         slug: document.slug,
         title: document.title,
@@ -28,18 +30,63 @@ class AgentGuide
           summary: document.provenance_summary
         },
         pending_suggestions: document.suggestions.pending.order(:created_at).map(&:as_props),
-        open_comments: document.comments.open.order(:created_at).map(&:as_props),
+        open_comments:,
         agents_present: document.agent_presences.active.map(&:as_props),
         recent_activity: document.activities.recent.map(&:as_props),
         content_contract: content_contract(document.content_format, base_url),
         api: endpoints(document, base_url),
-        notes: notes(document)
+        notes: notes(document, revision_workflow:)
       }
+      payload[:revision_workflow] = revision_workflow if revision_workflow
       if document.content_format == "markdown"
         payload[:markdown] = content
         payload[:plain_markdown] = document.plain_markdown.presence || document.seed_markdown
       end
       payload
+    end
+
+    def revision_workflow(document, base_url)
+      api_base = "#{base_url}/api/docs/#{document.slug}"
+      source_name = document.html? ? "HTML" : "Markdown"
+      {
+        kind: "claimed_document_comments",
+        guidance: "Read open_comments, then for each comment you can address, propose one " \
+                  "targeted suggestion using its anchor_text as replaces and the replacement " \
+                  "source fragment as body. Resolve that comment only after the suggestion " \
+                  "is successfully created. Leave comments open when targeting or suggestion " \
+                  "creation fails.",
+        when_no_open_comments: "If open_comments is empty, propose the change as a normal " \
+                               "suggestion; no comment resolution is required.",
+        steps: [
+          {
+            step: 1,
+            action: "read_open_comments",
+            method: "GET",
+            url: api_base,
+            reads: "open_comments (id, body, anchor_text)",
+            guidance: "Use each comment's body as the requested change and anchor_text as its target."
+          },
+          {
+            step: 2,
+            action: "propose_targeted_suggestion",
+            method: "POST",
+            url: "#{api_base}/suggestions",
+            body: {
+              replaces: "comment.anchor_text",
+              body: "replacement #{source_name} source fragment",
+              intent: "one-line summary of how the revision addresses the comment"
+            },
+            guidance: "Create one suggestion per comment you address; do not create a replacement document."
+          },
+          {
+            step: 3,
+            action: "resolve_addressed_comment",
+            method: "POST",
+            url: "#{api_base}/comments/:id/resolve",
+            guidance: "Resolve the matching comment only after its suggestion is successfully created."
+          }
+        ]
+      }
     end
 
     def endpoints(document, base_url)
@@ -204,7 +251,7 @@ class AgentGuide
       )
     end
 
-    def notes(document)
+    def notes(document, revision_workflow: nil)
       source_name = document.html? ? "HTML" : "Markdown"
       notes = [
         "Identity: send an X-Agent-Name header on every request. Suggestions, comments, presence, and event writes require it; document creation permits no header but then records no agent seed attribution. The name flows through suggestion attribution, provenance, presence, and activity.",
@@ -223,6 +270,13 @@ class AgentGuide
         "A claimed document can be deleted by its owner, after which every endpoint here returns 404. Treat a 404 on a previously-working slug as deletion, not an outage to retry.",
         "Document creation, suggestion, and comment writes are rate-limited per source IP. A 429 response means retry later; inspect each endpoint's rate_limits field for the current windows."
       ]
+      if revision_workflow
+        notes.insert(
+          6,
+          "Revising a claimed document: #{revision_workflow[:guidance]} " \
+          "#{revision_workflow[:when_no_open_comments]}"
+        )
+      end
       if document.html?
         notes.insert(
           9,

--- a/docs/plans/2026-06-25-004-fix-claimed-document-revision-workflow-plan.md
+++ b/docs/plans/2026-06-25-004-fix-claimed-document-revision-workflow-plan.md
@@ -1,0 +1,182 @@
+---
+title: "fix: Make claimed-document revision workflow explicit"
+type: fix
+date: 2026-06-25
+---
+
+# fix: Make claimed-document revision workflow explicit
+
+## Summary
+
+Teach agents that a claimed or collaboratively edited document must be revised in place by reading open comments, proposing one targeted suggestion per addressed comment, and resolving those comment threads. Expose the same workflow through both the PATCH conflict response and the document state contract.
+
+---
+
+## Problem Frame
+
+The existing `PATCH /api/docs/:slug` conflict correctly prevents an agent from overwriting a live document, but it only points at the suggestions endpoint. An agent can therefore understand that PATCH is unavailable while still missing the intended multi-endpoint workflow and creating replacement documents instead. Issue #61 records this failure across three attempts even though `open_comments`, `api.propose_suggestion`, and `api.resolve_comment` were already individually discoverable.
+
+---
+
+## Requirements
+
+**Conflict guidance**
+
+- R1. A claimed-document PATCH conflict must tell the agent to read `open_comments`, propose one suggestion per addressed comment, and resolve each addressed comment only after the suggestion is created.
+- R2. The conflict response must provide document-specific URLs for reading state, proposing suggestions, and resolving a comment by ID.
+- R3. The guidance must tell agents to use each comment's `anchor_text` as the suggestion's `replaces` target and the replacement source fragment as its `body`.
+
+**State discovery**
+
+- R4. A document state with open comments must expose the combined revision workflow alongside the existing endpoint contracts and notes.
+- R5. A document state without open comments must not imply that comment resolution is required for an unrelated suggestion.
+
+**Compatibility**
+
+- R6. Existing suggestion and comment endpoint request shapes, attribution, rate limits, and human review behavior must remain unchanged.
+- R7. Integration coverage must verify the workflow steps, document-specific URLs, and conditional state exposure.
+
+---
+
+## Assumptions
+
+- The safest interpretation of issue #61 is to cover both error-driven agents and state-reading agents rather than choosing only one of the issue's proposed discovery surfaces.
+- A structured `revision_workflow` object is preferable to prose alone because agents can inspect its ordered steps and endpoint URLs without parsing a long note.
+- Open comments without usable `anchor_text` should remain open until the agent can create a correctly targeted suggestion; the workflow must not encourage resolving feedback that was not addressed.
+
+---
+
+## Key Technical Decisions
+
+- **Use one workflow contract in `AgentGuide`:** Build the ordered revision guidance and URLs in one service method, then reuse it in the state payload and PATCH conflict response so wording and routes stay aligned.
+- **Expose the state workflow only when relevant:** Add `revision_workflow` when `open_comments` is non-empty, while preserving the existing top-level endpoint catalog for all documents.
+- **Keep the 409 response self-sufficient:** Return the expanded instruction and route fields directly because the observed agent stopped at the error instead of re-reading state.
+- **Resolve after proposal creation, not after human acceptance:** Resolving records that the agent addressed the feedback; accepting or rejecting the resulting suggestion remains human-gated.
+- **Do not add a new endpoint:** This is a discoverability and orchestration contract over existing APIs, not a bulk mutation operation.
+
+---
+
+## High-Level Technical Design
+
+The external workflow is an ordered loop over the current document's open comments:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant D as Document state
+    participant S as Suggestions API
+    participant C as Comments API
+    A->>D: PATCH live document
+    D-->>A: 409 with revision workflow and URLs
+    A->>D: GET current state
+    D-->>A: open comments with id, body, and anchor text
+    loop Each comment the agent can address
+        A->>S: Propose replacement source fragment for anchor text
+        S-->>A: Suggestion created
+        A->>C: Resolve addressed comment by id
+        C-->>A: Comment resolved
+    end
+```
+
+An agent must not resolve a comment when suggestion creation fails or when its replacement target is unusable.
+
+---
+
+## Implementation Units
+
+### U1. Define and expose the claimed-document revision workflow
+
+**Goal:** Add a shared, document-specific workflow contract and surface it in state only when open comments make the combined flow relevant.
+
+**Requirements:** R3, R4, R5, R6
+
+**Dependencies:** none
+
+**Files:**
+
+- `app/services/agent_guide.rb`
+- `test/integration/agent_api_test.rb`
+- `test/integration/agent_discovery_test.rb`
+
+**Approach:**
+
+- Add an `AgentGuide` workflow builder that returns the read-state, suggestion, and comment-resolution routes plus ordered instructions.
+- Include the workflow as a top-level state field when `document.comments.open` contains feedback.
+- When open comments exist, add a concise note that repeats the combined flow in the orientation channel agents already inspect, including the rule to leave untargetable or failed revisions unresolved.
+- Keep `api.propose_suggestion` and `api.resolve_comment` unchanged; the workflow composes their existing contracts.
+
+**Patterns to follow:** `AgentGuide.endpoints` for absolute document-specific URLs, `AgentGuide.state` for conditional format-specific fields, and existing integration assertions for machine-readable discovery metadata.
+
+**Test scenarios:**
+
+1. Given a document with an anchored open comment, GET state returns a `revision_workflow` whose steps direct the agent from `open_comments` to a suggestion using `replaces`, then to the matching resolve route.
+2. The workflow's state, suggestion, and resolve URLs all contain the current document slug, and the resolve URL retains its comment-ID placeholder.
+3. The notes array for a document with open comments describes the same ordered workflow and warns against resolving an unaddressed comment.
+4. Given a document with no open comments, GET state omits `revision_workflow` while the existing suggestion and resolve endpoint contracts remain present.
+5. Existing Markdown and HTML state payload tests remain green, proving the workflow is source-format agnostic and no discovery contract regressed.
+
+**Verification:** An agent reading only document state can identify the exact ordered actions for every open comment without inferring how the existing endpoints fit together.
+
+### U2. Make PATCH conflicts return the complete next action
+
+**Goal:** Expand the conflict response so an agent that reads only the 409 can execute the correct revision workflow on the original document.
+
+**Requirements:** R1, R2, R3, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- `app/controllers/api/docs_controller.rb`
+- `test/integration/agent_api_test.rb`
+
+**Approach:**
+
+- Reuse the `AgentGuide` workflow contract from `render_update_conflict` instead of maintaining separate route strings and abbreviated prose.
+- Preserve the existing error and `propose_suggestion` compatibility fields while adding `read_state`, `resolve_comment`, and the structured ordered workflow.
+- State that each successfully addressed comment maps to one targeted suggestion and one resolve request; failed or ambiguous targets remain open.
+
+**Patterns to follow:** The current instructive 409 response in `Api::DocsController` and the shared agent-contract generation already used for create and state responses.
+
+**Test scenarios:**
+
+1. A PATCH against a collaborative document returns 409 with the original conflict error plus read-state, suggestion, and comment-resolution URLs for the same slug.
+2. The 409 workflow explicitly names `open_comments`, `anchor_text`, `replaces`, suggestion `body`, and resolving each addressed comment.
+3. With an open comment present, the conflict workflow matches the workflow returned by state for the same document, preventing divergent route or step guidance.
+4. The conflict leaves seed and collaborative state untouched, preserving the existing safety guarantee.
+5. A conflict on a document with no open comments still directs a normal suggestion but does not falsely claim that comment resolution is required.
+
+**Verification:** The 409 response alone makes creating a replacement document an unnecessary and contradictory next action; all existing agent API integration tests continue to pass.
+
+---
+
+## Scope Boundaries
+
+**In scope:** Agent-facing response metadata, notes, and integration tests for orchestrating existing suggestion and comment-resolution endpoints.
+
+**Out of scope:** Automatically generating suggestions from comments, accepting or rejecting suggestions, bulk-resolving comments, changing live CRDT content, or preventing document creation at the API level.
+
+### Deferred to Follow-Up Work
+
+- A bulk endpoint that turns every open comment into a suggestion is unnecessary unless improved guidance still proves unreliable in real agent sessions.
+- Telemetry that detects replacement-document creation after a 409 would require a separate cross-request product signal.
+
+---
+
+## Risks & Dependencies
+
+- **Guidance drift:** Duplicated prose or route construction could make the 409 and state payload disagree. Reusing one workflow builder and asserting equality in tests mitigates this.
+- **Premature resolution:** An agent could resolve a comment even when suggestion targeting failed. The ordered contract must make successful proposal creation the precondition for resolution.
+- **Payload noise:** A workflow shown on every document could distract agents doing unrelated edits. Conditional state exposure keeps it tied to open feedback, while the conflict remains self-sufficient.
+
+There are no external dependencies or data migrations.
+
+---
+
+## Sources & Research
+
+- GitHub issue #61: `https://github.com/kieranklaassen/thinkroom/issues/61`
+- `app/controllers/api/docs_controller.rb` — existing conflict response and safety gate.
+- `app/services/agent_guide.rb` — state, endpoint, notes, and plain-text discovery contracts.
+- `test/integration/agent_api_test.rb` — PATCH conflict and state discovery coverage.
+- `test/integration/comment_flow_test.rb` — agent comment-resolution behavior and attribution.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -237,7 +237,12 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   test "state read returns content, provenance, suggestions, comments" do
     @document.update!(provenance_spans: [ { "kind" => "ai", "state" => "pending", "chars" => 10 } ])
     @document.suggestions.create!(author_name: "Gemini", author_kind: "ai", body: "Pending one")
-    @document.comments.create!(author_name: "A", author_kind: "human", body: "Open one")
+    @document.comments.create!(
+      author_name: "A",
+      author_kind: "human",
+      body: "Tighten this claim.",
+      anchor_text: "A paragraph about provenance."
+    )
 
     get "/api/docs/#{@document.slug}", headers: AGENT
 
@@ -248,6 +253,36 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal 1, body["open_comments"].length
     assert body["provenance"]["summary"]["ai_pct"].positive?
     assert body["api"].keys.size >= 6
+
+    workflow = body["revision_workflow"]
+    assert_equal "claimed_document_comments", workflow["kind"]
+    assert_equal %w[read_open_comments propose_targeted_suggestion resolve_addressed_comment],
+                 workflow["steps"].pluck("action")
+    assert_equal "/api/docs/#{@document.slug}", URI(workflow.dig("steps", 0, "url")).path
+    assert_equal "/api/docs/#{@document.slug}/suggestions",
+                 URI(workflow.dig("steps", 1, "url")).path
+    assert_equal "/api/docs/#{@document.slug}/comments/:id/resolve",
+                 URI(workflow.dig("steps", 2, "url")).path
+    assert_equal "comment.anchor_text", workflow.dig("steps", 1, "body", "replaces")
+    assert_includes workflow.dig("steps", 1, "body", "body"), "replacement"
+    assert_includes workflow.dig("steps", 2, "guidance"), "successfully created"
+    assert body["notes"].any? { |note| note.include?("Revising a claimed document") }
+  end
+
+  test "state omits the comment revision workflow when no comments are open" do
+    resolved = @document.comments.create!(
+      author_name: "A", author_kind: "human", body: "Already handled"
+    )
+    resolved.resolve!
+
+    get "/api/docs/#{@document.slug}", headers: AGENT
+
+    assert_response :success
+    body = response.parsed_body
+    refute body.key?("revision_workflow")
+    refute body["notes"].any? { |note| note.include?("Revising a claimed document") }
+    assert body.dig("api", "propose_suggestion").present?
+    assert body.dig("api", "resolve_comment").present?
   end
 
   test "state read falls back to seed markdown before any editor session" do
@@ -532,6 +567,12 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
   test "update on a collaborative document returns 409 with a route to suggestions" do
     @document.update!(yjs_state: "binary-crdt-state")
+    @document.comments.create!(
+      author_name: "Editor",
+      author_kind: "human",
+      body: "Make this more concrete.",
+      anchor_text: "A paragraph about provenance."
+    )
 
     patch "/api/docs/#{@document.slug}",
           params: { content: "# Trying to overwrite" },
@@ -540,11 +581,31 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_response :conflict
     body = response.parsed_body
     assert_includes body["error"], "no longer an unclaimed draft"
+    assert_equal "/api/docs/#{@document.slug}", URI(body["read_state"]).path
     assert_includes body["propose_suggestion"], "/api/docs/#{@document.slug}/suggestions"
+    assert_equal "/api/docs/#{@document.slug}/comments/:id/resolve",
+                 URI(body["resolve_comment"]).path
+    assert_equal AgentGuide.revision_workflow(@document, request.base_url).as_json,
+                 body["revision_workflow"]
+    assert_includes body["how_to_revise"], "open_comments"
+    assert_includes body["how_to_revise"], "anchor_text"
+    assert_includes body["how_to_revise"], "replaces"
+    assert_match(/resolve/i, body["how_to_revise"])
 
     @document.reload
     assert_equal "# Hello\n\nA paragraph about provenance.", @document.seed_markdown,
                  "seed must be untouched when the editor has taken over"
+  end
+
+  test "update conflict does not require comment resolution when there are no open comments" do
+    @document.update!(yjs_state: "binary-crdt-state")
+
+    patch "/api/docs/#{@document.slug}",
+          params: { content: "# Trying to overwrite" },
+          headers: AGENT, as: :json
+
+    assert_response :conflict
+    assert_includes response.parsed_body["how_to_revise"], "If open_comments is empty"
   end
 
   test "update returns 409 once an editor snapshot shadows the seed even if yjs_state is blank" do


### PR DESCRIPTION
## Summary

Agents that hit a claimed-document PATCH conflict previously learned only that they could not overwrite the live document, leaving them to infer the rest of the revision flow and sometimes create replacement documents. The conflict now returns a complete, document-specific path: read open comments, create one targeted suggestion per addressed comment, then resolve each thread after its suggestion succeeds.

Document state exposes the same ordered workflow whenever open feedback exists, while keeping the existing suggestion and comment endpoint contracts intact. If there are no open comments, the response explicitly says that a normal suggestion is sufficient and no comment resolution is required.

Closes #61.

## Validation

- `bin/rails test` — 342 tests, 1,627 assertions, 0 failures
- `bin/rubocop app/services/agent_guide.rb app/controllers/api/docs_controller.rb test/integration/agent_api_test.rb` — no offenses
- `npm run check` — TypeScript checks pass
- Browser scope — no UI routes affected; behavior is covered through full-stack request tests

## Post-Deploy Monitoring & Validation

- Search Rails request logs for `PATCH /api/docs/` responses with `409 Conflict`; sample responses should include `read_state`, `propose_suggestion`, `resolve_comment`, and `revision_workflow`.
- Watch 5xx rates for document state and PATCH endpoints; the expected healthy signal is unchanged error volume with richer 409 payloads.
- Validate one claimed document with an open comment during the first 24 hours after deploy and confirm its state payload exposes the ordered workflow.
- Roll back commit `6ea2455` if document-state or PATCH requests begin returning 5xx responses or existing `propose_suggestion` consumers lose their compatibility field.
- Owner: repository maintainer during the first post-deploy day.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
