### PR TITLE
feat(documents): add owner-controlled editing lock

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,18 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    attr_reader :owner_token
+
+    def connect
+      @owner_token = cookies.signed[:owner_token]
+      user_id = request.session[:user_id]
+      unless user_id
+        session_key = Rails.application.config.session_options.fetch(:key)
+        session_data = cookies.encrypted[session_key] || {}
+        user_id = session_data["user_id"] || session_data[:user_id]
+      end
+      self.current_user = User.find_by(id: user_id)
+    end
   end
 end

--- a/app/channels/document_meta_channel.rb
+++ b/app/channels/document_meta_channel.rb
@@ -13,4 +13,10 @@ class DocumentMetaChannel < ApplicationCable::Channel
   def self.broadcast_event(document, event, **payload)
     broadcast_to(document, { event: event.to_s, **payload })
   end
+
+  def self.broadcast_event_after_commit(document, event, **payload)
+    ActiveRecord.after_all_transactions_commit do
+      broadcast_event(document, event, **payload)
+    end
+  end
 end

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -93,11 +93,18 @@ class SyncChannel < ApplicationCable::Channel
   end
 
   def persist_and_broadcast(message, update)
-    YjsPersistence.merge(@document, update)
+    YjsPersistence.merge(
+      @document,
+      update,
+      token: (connection.owner_token if connection.respond_to?(:owner_token)),
+      user: (connection.current_user if connection.respond_to?(:current_user))
+    )
     # A peer seeing an edit means the server has made it durable. This
     # ordering also prevents clients from accepting a frame that failed
     # persistence and would disappear on reload.
     self.class.broadcast_to(@document, message)
+  rescue Document::EditingLockedError
+    transmit({ type: "write-denied", locked: true })
   rescue StandardError => e
     Rails.logger.warn("SyncChannel: merge failed: #{e.class}: #{e.message}")
   end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -13,6 +13,14 @@ module Api
       render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
 
+    rescue_from Document::EditingLockedError do
+      render json: {
+        error: "This document is read-only. Only its owner can make changes.",
+        editing_locked: true,
+        next_action: "Wait for the browser owner to turn off Read only for others, then retry."
+      }, status: :locked
+    end
+
     private
 
     def render_write_rate_limit
@@ -38,6 +46,10 @@ module Api
                             "provenance marks when humans accept your text, and the activity feed.",
         example: participation_example
       }, status: :unprocessable_entity
+    end
+
+    def with_document_write_access(&block)
+      document.with_write_access(&block)
     end
 
     def participation_example

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -6,14 +6,17 @@ module Api
 
     # POST /api/docs/:slug/comments — leave a comment anchored to text.
     def create
-      comment = Comment.post!(
-        document:,
-        author_name: current_agent,
-        author_kind: "agent",
-        body: params.require(:body),
-        anchor_text: params[:anchor_text].presence
-      )
-      touch_presence(location: comment.anchor_text)
+      comment = with_document_write_access do
+        posted = Comment.post!(
+          document:,
+          author_name: current_agent,
+          author_kind: "agent",
+          body: params.require(:body),
+          anchor_text: params[:anchor_text].presence
+        )
+        touch_presence(location: posted.anchor_text)
+        posted
+      end
 
       render json: { comment: comment.as_props }, status: :created
     rescue ActionController::ParameterMissing
@@ -24,14 +27,17 @@ module Api
     # The web UI resolves over a CSRF-protected Inertia request; agents get the
     # same capability here over plain HTTP, attributed via X-Agent-Name.
     def resolve
-      comment = document.comments.find(params[:id])
-      comment.resolve!
-      Activity.log!(
-        document:, actor_name: current_agent, actor_kind: "agent",
-        action: "resolved_comment", detail: comment.body.truncate(80)
-      )
+      comment = with_document_write_access do
+        found = document.comments.find(params[:id])
+        found.resolve!
+        Activity.log!(
+          document:, actor_name: current_agent, actor_kind: "agent",
+          action: "resolved_comment", detail: found.body.truncate(80)
+        )
+        touch_presence(location: found.anchor_text)
+        found
+      end
       DocumentMetaChannel.broadcast_event(document, :comments)
-      touch_presence(location: comment.anchor_text)
 
       render json: { comment: comment.as_props }
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/suggestions_controller.rb
+++ b/app/controllers/api/suggestions_controller.rb
@@ -7,17 +7,20 @@ module Api
     # POST /api/docs/:slug/suggestions — propose an edit. It appears live in
     # every connected editor as a pending, agent-attributed suggestion.
     def create
-      touch_presence(location: params[:anchor_text].presence || params[:replaces].presence)
-      suggestion = Suggestion.propose!(
-        document:,
-        author_name: current_agent,
-        author_kind: "agent",
-        body: params.require(:body),
-        intent: params[:intent].presence,
-        anchor_text: params[:anchor_text].presence,
-        replaces: params[:replaces].presence
-      )
-      DocumentAsset.claim_from_html!(document:, source: suggestion.body) if document.html?
+      suggestion = with_document_write_access do
+        touch_presence(location: params[:anchor_text].presence || params[:replaces].presence)
+        proposed = Suggestion.propose!(
+          document:,
+          author_name: current_agent,
+          author_kind: "agent",
+          body: params.require(:body),
+          intent: params[:intent].presence,
+          anchor_text: params[:anchor_text].presence,
+          replaces: params[:replaces].presence
+        )
+        DocumentAsset.claim_from_html!(document:, source: proposed.body) if document.html?
+        proposed
+      end
 
       # A markdown suggestion can carry an excalidraw sketch fence; audit it so a
       # malformed sketch is reported here rather than discovered only when a

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,15 +1,18 @@
 class CommentsController < InertiaController
+  include DocumentWriteAuthorization
   rate_limit_contributions
 
   def create
     document = Document.find_by!(slug: params[:slug])
-    Comment.post!(
-      document:,
-      author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
-      author_kind: "human",
-      body: params[:body],
-      anchor_text: params[:anchor_text].presence
-    )
+    with_document_write_access(document) do
+      Comment.post!(
+        document:,
+        author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
+        author_kind: "human",
+        body: params[:body],
+        anchor_text: params[:anchor_text].presence
+      )
+    end
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid => e
@@ -24,16 +27,17 @@ class CommentsController < InertiaController
 
   def resolve
     comment = Comment.find(params[:id])
-    comment.resolve!
-
     document = comment.document
-    Activity.log!(
-      document:,
-      actor_name: preferred_name(params[:by], fallback: "Someone"),
-      actor_kind: "human",
-      action: "resolved_comment",
-      detail: comment.body.truncate(80)
-    )
+    with_document_write_access(document) do
+      comment.resolve!
+      Activity.log!(
+        document:,
+        actor_name: preferred_name(params[:by], fallback: "Someone"),
+        actor_kind: "human",
+        action: "resolved_comment",
+        detail: comment.body.truncate(80)
+      )
+    end
     DocumentMetaChannel.broadcast_event(document, :comments)
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other

--- a/app/controllers/concerns/document_write_authorization.rb
+++ b/app/controllers/concerns/document_write_authorization.rb
@@ -1,0 +1,25 @@
+module DocumentWriteAuthorization
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from Document::EditingLockedError, with: :render_document_read_only
+  end
+
+  private
+
+  def with_document_write_access(document, &block)
+    @write_document = document
+    document.with_write_access(token: owner_token, user: current_user, &block)
+  end
+
+  def render_document_read_only
+    document = @write_document
+    if request.format.json?
+      render json: { error: "This document is read-only. Only its owner can make changes." },
+             status: :locked
+    else
+      redirect_back fallback_location: document ? document_page_path(document.slug) : root_path,
+                    inertia: { errors: { document: "This document is read-only" } }
+    end
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,4 +1,5 @@
 class DocumentsController < InertiaController
+  include DocumentWriteAuthorization
   rate_limit_document_creation
 
   # SSR is scoped to the read-only document surfaces — #show (shell, header,
@@ -154,6 +155,34 @@ class DocumentsController < InertiaController
     redirect_to root_path, status: :see_other
   end
 
+  LOCK_VALUES = {
+    true => true, false => false,
+    "true" => true, "false" => false,
+    "1" => true, "0" => false,
+    1 => true, 0 => false
+  }.freeze
+
+  def update_editing_lock
+    document = Document.find_by!(slug: params[:slug])
+    raw_locked = params[:locked]
+    unless LOCK_VALUES.key?(raw_locked)
+      return redirect_back fallback_location: document_page_path(document.slug), status: :see_other,
+                           inertia: { errors: { editing_lock: "Choose whether others can edit" } }
+    end
+
+    document.set_editing_locked!(
+      locked: LOCK_VALUES.fetch(raw_locked),
+      token: owner_token,
+      user: current_user
+    )
+    redirect_back fallback_location: document_page_path(document.slug), status: :see_other
+  rescue Document::NotOwnerError
+    redirect_back fallback_location: document_page_path(params[:slug]), status: :see_other,
+                  inertia: { errors: { editing_lock: "Only the owner can change editing access" } }
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, status: :see_other
+  end
+
   # Owners only. The broadcast goes out after a successful destroy — the
   # stream name derives from the record's retained id, so it still reaches
   # every subscriber, and clients are only evicted when the delete actually
@@ -188,6 +217,8 @@ class DocumentsController < InertiaController
 
   def snapshot
     document = Document.find_by!(slug: params[:slug])
+    @write_document = document
+    document.assert_write_access!(token: owner_token, user: current_user)
     if params.key?(:content) && params.key?(:markdown)
       return render json: { error: "Send content or legacy markdown, not both." },
                     status: :unprocessable_entity
@@ -217,7 +248,9 @@ class DocumentsController < InertiaController
       state_vector_b64: state_vector.presence,
       content:,
       spans:,
-      title:
+      title:,
+      token: owner_token,
+      user: current_user
     )
     return render json: { error: "Snapshot is stale; retry from current document state." },
                   status: :conflict unless persisted
@@ -233,11 +266,13 @@ class DocumentsController < InertiaController
   # makes the same CRDT update durable and relays it to any connected clients.
   def sync_update
     document = Document.find_by!(slug: params[:slug])
+    @write_document = document
+    document.assert_write_access!(token: owner_token, user: current_user)
     update = params[:update].to_s
     decoded = Base64.strict_decode64(update)
     return head :content_too_large if decoded.bytesize > MAX_SYNC_UPDATE_BYTES
 
-    YjsPersistence.merge(document, update)
+    YjsPersistence.merge(document, update, token: owner_token, user: current_user)
     SyncChannel.broadcast_to(document, {
       type: "update",
       update:,
@@ -263,7 +298,9 @@ class DocumentsController < InertiaController
         state_vector_b64: state_vector,
         content:,
         spans:,
-        title:
+        title:,
+        token: owner_token,
+        user: current_user
       )
       return render json: { error: "Snapshot is stale; retry from current document state." },
                     status: :conflict unless persisted

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -1,4 +1,5 @@
 class SuggestionsController < InertiaController
+  include DocumentWriteAuthorization
   rate_limit_contributions
 
   before_action :set_suggestion, only: [ :accept, :reopen, :reject ]
@@ -10,15 +11,17 @@ class SuggestionsController < InertiaController
   # and the live broadcast stay uniform with the agent path.
   def create
     document = Document.find_by!(slug: params[:slug])
-    Suggestion.propose!(
-      document:,
-      author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
-      author_kind: "human",
-      body: params[:body].to_s,
-      intent: (params[:intent].presence if params[:intent].is_a?(String)),
-      anchor_text: (params[:anchor_text].presence if params[:anchor_text].is_a?(String)),
-      replaces: (params[:replaces].presence if params[:replaces].is_a?(String))
-    )
+    with_document_write_access(document) do
+      Suggestion.propose!(
+        document:,
+        author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
+        author_kind: "human",
+        body: params[:body].to_s,
+        intent: (params[:intent].presence if params[:intent].is_a?(String)),
+        anchor_text: (params[:anchor_text].presence if params[:anchor_text].is_a?(String)),
+        replaces: (params[:replaces].presence if params[:replaces].is_a?(String))
+      )
+    end
 
     redirect_back fallback_location: document_page_path(document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid => e
@@ -45,18 +48,20 @@ class SuggestionsController < InertiaController
     # One name for both resolved_by and the activity row — two lookups with
     # different fallbacks silently diverge when no session name is set.
     by = preferred_name(params[:by], fallback: "Someone")
-    accepted = Suggestion.accept_all!(document:, by:)
-
-    if accepted.any?
-      Activity.log!(
-        document:,
-        actor_name: by,
-        actor_kind: "human",
-        action: "accepted_suggestion",
-        detail: "accepted #{accepted.size} suggestions in one batch"
-      )
-      DocumentMetaChannel.broadcast_event(document, :suggestions)
+    accepted = with_document_write_access(document) do
+      winners = Suggestion.accept_all!(document:, by:)
+      if winners.any?
+        Activity.log!(
+          document:,
+          actor_name: by,
+          actor_kind: "human",
+          action: "accepted_suggestion",
+          detail: "accepted #{winners.size} suggestions in one batch"
+        )
+      end
+      winners
     end
+    DocumentMetaChannel.broadcast_event(document, :suggestions) if accepted.any?
 
     render json: { accepted: accepted.map(&:as_props) }
   rescue ActiveRecord::RecordNotFound
@@ -65,8 +70,11 @@ class SuggestionsController < InertiaController
   end
 
   def accept
-    @suggestion.accept!(by: preferred_name(params[:by], fallback: "human"))
-    log_and_broadcast("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
+    with_document_write_access(@suggestion.document) do
+      @suggestion.accept!(by: preferred_name(params[:by], fallback: "human"))
+      log_suggestion_activity("accepted_suggestion", "accepted “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
+    end
+    DocumentMetaChannel.broadcast_event(@suggestion.document, :suggestions)
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
     # No `status:` on error-bag redirects — see create's rescue.
@@ -76,14 +84,16 @@ class SuggestionsController < InertiaController
 
   def reopen
     by = preferred_name(params[:by], fallback: "human")
-    @suggestion.reopen_after_failed_apply!(by:)
-    Activity.log!(
-      document: @suggestion.document,
-      actor_name: by,
-      actor_kind: "human",
-      action: "reopened_suggestion",
-      detail: "returned a suggestion to pending after its target changed"
-    )
+    with_document_write_access(@suggestion.document) do
+      @suggestion.reopen_after_failed_apply!(by:)
+      Activity.log!(
+        document: @suggestion.document,
+        actor_name: by,
+        actor_kind: "human",
+        action: "reopened_suggestion",
+        detail: "returned a suggestion to pending after its target changed"
+      )
+    end
     DocumentMetaChannel.broadcast_event(@suggestion.document, :suggestions)
     render json: { suggestion: @suggestion.as_props }
   rescue ActiveRecord::RecordInvalid
@@ -91,8 +101,11 @@ class SuggestionsController < InertiaController
   end
 
   def reject
-    @suggestion.reject!(by: preferred_name(params[:by], fallback: "human"))
-    log_and_broadcast("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
+    with_document_write_access(@suggestion.document) do
+      @suggestion.reject!(by: preferred_name(params[:by], fallback: "human"))
+      log_suggestion_activity("rejected_suggestion", "rejected “#{@suggestion.intent.presence || 'a suggestion'}” from #{@suggestion.author_name}")
+    end
+    DocumentMetaChannel.broadcast_event(@suggestion.document, :suggestions)
     redirect_back fallback_location: document_page_path(@suggestion.document.slug), status: :see_other
   rescue ActiveRecord::RecordInvalid
     # No `status:` on error-bag redirects — see create's rescue.
@@ -116,7 +129,7 @@ class SuggestionsController < InertiaController
     end
   end
 
-  def log_and_broadcast(action, detail)
+  def log_suggestion_activity(action, detail)
     document = @suggestion.document
     Activity.log!(
       document:,
@@ -125,6 +138,5 @@ class SuggestionsController < InertiaController
       action:,
       detail:
     )
-    DocumentMetaChannel.broadcast_event(document, :suggestions)
   end
 end

--- a/app/frontend/components/header_menu.tsx
+++ b/app/frontend/components/header_menu.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Link } from '@inertiajs/react'
+import { Link, router } from '@inertiajs/react'
 import { useMediaQuery } from '../lib/use_media_query'
 import { useDismissable } from '../lib/use_dismissable'
 import { OwnershipChip, type OwnershipPayload } from './ownership_chip'
@@ -36,6 +36,8 @@ export function HeaderMenu({
   account,
 }: Props) {
   const [open, setOpen] = useState(false)
+  const [lockUpdating, setLockUpdating] = useState(false)
+  const [lockFailed, setLockFailed] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   // Same constraint as SharePopover: the sticky header's backdrop-filter is
@@ -45,6 +47,9 @@ export function HeaderMenu({
   useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
 
   const showOwnership = ownership.yours || ownership.claimed || ownership.claimable
+  let lockLabel = 'Read only for others'
+  if (lockUpdating) lockLabel = 'Updating access…'
+  else if (lockFailed) lockLabel = 'Could not update — retry'
 
   return (
     <div className="share-root header-menu-root" ref={rootRef}>
@@ -95,6 +100,47 @@ export function HeaderMenu({
               {showOwnership && (
                 <>
                   <div className="header-menu-sep" role="separator" />
+                  {ownership.yours && (
+                    <button
+                      className="header-menu-item"
+                      role="menuitemcheckbox"
+                      aria-checked={ownership.editing_locked}
+                      disabled={lockUpdating}
+                      onClick={() => {
+                        const locked = !ownership.editing_locked
+                        setLockUpdating(true)
+                        setLockFailed(false)
+                        router.optimistic((props: { ownership?: OwnershipPayload }) => ({
+                          ownership: {
+                            ...(props.ownership ?? ownership),
+                            editing_locked: locked,
+                            can_write: true,
+                          },
+                        })).patch(
+                          `/d/${slug}/editing_lock`,
+                          { locked },
+                          {
+                            only: ['ownership', 'activities'],
+                            preserveScroll: true,
+                            async: true,
+                            onError: () => setLockFailed(true),
+                            onFinish: () => setLockUpdating(false),
+                          },
+                        )
+                      }}
+                    >
+                      <span className="header-menu-check" aria-hidden>
+                        {ownership.editing_locked ? '✓' : ''}
+                      </span>
+                      {lockLabel}
+                    </button>
+                  )}
+                  {ownership.editing_locked && !ownership.yours && (
+                    <div className="header-menu-status" role="status">
+                      <span className="header-menu-check" aria-hidden>🔒</span>
+                      Read only — locked by owner
+                    </div>
+                  )}
                   <OwnershipChip slug={slug} ownership={ownership} claimerName={claimerName} />
                 </>
               )}

--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -22,6 +22,7 @@ interface Props {
   onChange: (mode: EditorMode) => void
   /** Demo doc: control renders but stays locked to Edit. */
   locked?: boolean
+  lockedReason?: string
 }
 
 /**
@@ -29,7 +30,7 @@ interface Props {
  * current mode, opening to the four modes with hints. Per-visitor UI state
  * only — switching never affects other collaborators.
  */
-export function ModeControl({ mode, onChange, locked = false }: Props) {
+export function ModeControl({ mode, onChange, locked = false, lockedReason }: Props) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
   useDismissable(open, () => setOpen(false), [rootRef])
@@ -41,7 +42,7 @@ export function ModeControl({ mode, onChange, locked = false }: Props) {
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={`Mode: ${MODE_LABELS[mode]}`}
-        title={locked ? 'Mode switching is disabled on the demo doc' : MODE_HINTS[mode]}
+        title={locked ? lockedReason ?? 'Mode switching is disabled on the demo doc' : MODE_HINTS[mode]}
         disabled={locked}
         onClick={() => setOpen((v) => !v)}
       >

--- a/app/frontend/components/ownership_chip.tsx
+++ b/app/frontend/components/ownership_chip.tsx
@@ -7,6 +7,8 @@ export interface OwnershipPayload {
   claimable: boolean
   owner_name: string | null
   yours: boolean
+  editing_locked: boolean
+  can_write: boolean
 }
 
 interface Props {

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -10,7 +10,7 @@ import {
 } from 'y-protocols/awareness'
 
 type SyncMessage = {
-  type: 'sync' | 'sync-reply' | 'update' | 'awareness' | 'awareness-query'
+  type: 'sync' | 'sync-reply' | 'update' | 'awareness' | 'awareness-query' | 'write-denied'
   update?: string
   sv?: string
   seed?: boolean
@@ -66,12 +66,18 @@ export class CableProvider {
   private updateSequence = 0
   private serverStateVector: Uint8Array | null = null
   private readonly slug: string
+  private readonly canWrite: boolean
 
-  constructor(doc: Y.Doc, slug: string, consumer?: Consumer) {
+  constructor(
+    doc: Y.Doc,
+    slug: string,
+    options?: { consumer?: Consumer; canWrite?: boolean; connectionIdentity?: string },
+  ) {
     this.doc = doc
     this.slug = slug
+    this.canWrite = options?.canWrite ?? true
     this.awareness = new Awareness(doc)
-    this.consumer = consumer ?? getConsumer()
+    this.consumer = options?.consumer ?? getConsumer(options?.connectionIdentity)
 
     this.subscription = this.consumer.subscriptions.create(
       { channel: 'SyncChannel', slug },
@@ -100,12 +106,12 @@ export class CableProvider {
     window.addEventListener('beforeunload', this.handleUnload)
   }
 
-  on(event: 'synced' | 'seed' | 'rejected', handler: () => void): void {
+  on(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
     if (!this.listeners.has(event)) this.listeners.set(event, new Set())
     this.listeners.get(event)!.add(handler as never)
   }
 
-  off(event: 'synced' | 'seed' | 'rejected', handler: () => void): void {
+  off(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
     this.listeners.get(event)?.delete(handler as never)
   }
 
@@ -147,6 +153,7 @@ export class CableProvider {
    * request finish when a click is immediately followed by navigation.
    */
   persistCurrentState = (snapshot: DurableSnapshotPayload): void => {
+    if (!this.canWrite) return
     const update = this.serverStateVector
       ? Y.encodeStateAsUpdate(this.doc, this.serverStateVector)
       : Y.encodeStateAsUpdate(this.doc)
@@ -189,7 +196,9 @@ export class CableProvider {
         const serverVector = fromBase64(data.sv!)
         this.serverStateVector = serverVector
         this.updateSequence = 0
-        this.sendUpdate('sync-reply', Y.encodeStateAsUpdate(this.doc, serverVector))
+        if (this.canWrite) {
+          this.sendUpdate('sync-reply', Y.encodeStateAsUpdate(this.doc, serverVector))
+        }
         const seedContent = data.seed_content ?? data.seed_markdown
         if (data.seed && seedContent) {
           // No one listens to 'seed' by design: the editor reads
@@ -226,12 +235,15 @@ export class CableProvider {
       case 'awareness-query':
         this.broadcastAwareness()
         break
+      case 'write-denied':
+        this.emit('write-denied')
+        break
     }
   }
 
   private handleDocUpdate = (update: Uint8Array, origin: unknown): void => {
     // Updates we applied from the wire carry `this` as origin — don't echo them.
-    if (origin === this || !this.synced) return
+    if (origin === this || !this.synced || !this.canWrite) return
     this.sendUpdate('update', update)
   }
 

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -117,6 +117,11 @@ interface EditorProps {
    *  mode-independent (a restored read-only mode must never burn the seed
    *  claim). Defaults to editable. */
   editable?: boolean
+  /** Server-authorized capability. Unlike `editable`, this gates every
+   * outgoing CRDT frame and durable snapshot while preserving inbound sync. */
+  canWrite?: boolean
+  /** Coarse server-known identity used to refresh Action Cable after auth changes. */
+  connectionIdentity?: string
   /** Suggest mode: typing is intercepted into tracked insertion/deletion
    *  marks. Synced into the suggest-changes plugin state only after the
    *  editor has started — seeding and initial sync always run with
@@ -212,6 +217,8 @@ interface CollabSession {
   provider: CableProvider
   refs: number
   destroyTimer: ReturnType<typeof setTimeout> | null
+  canWrite: boolean
+  connectionIdentity: string
 }
 
 // Sessions survive React StrictMode's mount→unmount→mount cycle. Without
@@ -223,9 +230,18 @@ const sessions = new Map<string, CollabSession>()
 function acquireSession(
   slug: string,
   identity: UserIdentity,
+  canWrite: boolean,
+  connectionIdentity: string,
   initialStateB64?: string | null,
 ): CollabSession {
   let session = sessions.get(slug)
+  if (session && (session.canWrite !== canWrite || session.connectionIdentity !== connectionIdentity)) {
+    if (session.destroyTimer) clearTimeout(session.destroyTimer)
+    session.provider.destroy()
+    session.ydoc.destroy()
+    sessions.delete(slug)
+    session = undefined
+  }
   if (!session) {
     const ydoc = new Y.Doc()
     // Hydrate from the server-rendered state the moment the doc exists, so
@@ -245,9 +261,9 @@ function acquireSession(
         // corrupt/stale prop — fall back to the wait-for-synced path
       }
     }
-    const provider = new CableProvider(ydoc, slug)
+    const provider = new CableProvider(ydoc, slug, { canWrite, connectionIdentity })
     provider.awareness.setLocalStateField('user', identity)
-    session = { ydoc, provider, refs: 0, destroyTimer: null }
+    session = { ydoc, provider, refs: 0, destroyTimer: null, canWrite, connectionIdentity }
     sessions.set(slug, session)
   }
   if (session.destroyTimer) {
@@ -335,6 +351,8 @@ function CollabEditor({
   seedGranted,
   seedAuthorKind,
   seedAuthorName,
+  canWrite = true,
+  connectionIdentity = 'guest',
   editable = true,
   suggesting = false,
   taskInteractive = editable,
@@ -358,6 +376,8 @@ function CollabEditor({
   suggestingRef.current = suggesting
   const taskInteractiveRef = useRef(taskInteractive)
   taskInteractiveRef.current = taskInteractive
+  const canWriteRef = useRef(canWrite)
+  canWriteRef.current = canWrite
   // Suggesting only syncs into plugin state after start() — the gate that
   // keeps seed/initial-sync transactions out of the dispatch transform.
   const startedRef = useRef(false)
@@ -462,13 +482,20 @@ function CollabEditor({
     const editor = get()
     if (!editor) return
 
-    const { ydoc, provider } = acquireSession(slug, identity, initialStateB64)
+    const { ydoc, provider } = acquireSession(
+      slug,
+      identity,
+      canWriteRef.current,
+      connectionIdentity,
+      initialStateB64,
+    )
     callbacksRef.current.onStatus?.('connecting')
 
     let snapshotTimer: ReturnType<typeof setTimeout> | null = null
     let snapshotRetryTimer: ReturnType<typeof setTimeout> | null = null
     let cancelled = false
     const pushSnapshot = (attempt = 0) => {
+      if (!canWriteRef.current) return
       editor.action((ctx) => {
         void postJSON(`/d/${slug}/snapshot`, buildSnapshotPayload(ctx, ydoc, contentFormat))
           .then((response) => {
@@ -602,7 +629,7 @@ function CollabEditor({
       releaseSession(slug)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, slug, contentFormat])
+  }, [loading, slug, contentFormat, canWrite, connectionIdentity])
 
   // ProseMirror caches editable at each state update; an empty transaction
   // makes it re-read the prop when the mode flips. Safe pre-bind: the action

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1854,6 +1854,7 @@ a:focus-visible {
 }
 
 .header-menu-item,
+.header-menu-status,
 .header-menu-popover .chrome-toggle,
 .header-menu-popover .feedback-button {
   display: flex;
@@ -1869,6 +1870,16 @@ a:focus-visible {
   color: var(--ink);
   text-align: left;
   cursor: pointer;
+}
+
+.header-menu-status {
+  cursor: default;
+  color: var(--ink-faint);
+}
+
+.header-menu-item:disabled {
+  cursor: wait;
+  opacity: 0.65;
 }
 
 .header-menu-item:hover,

--- a/app/frontend/lib/cable.ts
+++ b/app/frontend/lib/cable.ts
@@ -1,9 +1,15 @@
 import { createConsumer, type Consumer } from '@rails/actioncable'
 
 let consumer: Consumer | null = null
+let consumerIdentity: string | null = null
 
 /** One WebSocket per tab — Yjs sync and meta events share it. */
-export function getConsumer(): Consumer {
+export function getConsumer(identity = 'guest'): Consumer {
+  if (consumer && consumerIdentity !== identity) {
+    consumer.disconnect()
+    consumer = null
+  }
+  consumerIdentity = identity
   consumer ??= createConsumer()
   return consumer
 }

--- a/app/frontend/lib/use_meta_channel.ts
+++ b/app/frontend/lib/use_meta_channel.ts
@@ -13,6 +13,10 @@ interface MetaChannelOptions {
   onTitle?: (title: string) => void
   /** Fired when this live tab reconnects to a different deployed build. */
   onVersionAvailable?: (version: string) => void
+  /** Fired when the owner changes document write access. */
+  onEditingLock?: (locked: boolean) => void
+  /** Recreate the shared socket when guest/account authentication changes. */
+  connectionIdentity?: string
 }
 
 /**
@@ -35,6 +39,8 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
   onTitleRef.current = options?.onTitle
   const onVersionAvailableRef = useRef(options?.onVersionAvailable)
   onVersionAvailableRef.current = options?.onVersionAvailable
+  const onEditingLockRef = useRef(options?.onEditingLock)
+  onEditingLockRef.current = options?.onEditingLock
   const loadedVersionRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -52,17 +58,19 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
       onDeletedRef.current?.()
     }
 
-    const subscription = getConsumer().subscriptions.create(
+    const subscription = getConsumer(options?.connectionIdentity).subscriptions.create(
       { channel: 'DocumentMetaChannel', slug },
       {
         received: ({
           event,
           title,
           version,
+          locked,
         }: {
           event: string
           title?: string
           version?: string
+          locked?: boolean
         }) => {
           if (dead) return
           if (event === 'document_deleted') {
@@ -80,6 +88,10 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
             } else if (loadedVersionRef.current !== version) {
               onVersionAvailableRef.current?.(version)
             }
+            return
+          }
+          if (event === 'editing_lock' && typeof locked === 'boolean') {
+            onEditingLockRef.current?.(locked)
             return
           }
           pending.add(event)
@@ -104,5 +116,5 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
       subscription.unsubscribe()
       if (timer) clearTimeout(timer)
     }
-  }, [slug])
+  }, [slug, options?.connectionIdentity])
 }

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -206,10 +206,11 @@ export default function DocumentShow({
   // the editor keeps it live via onTitleChange once it mounts.
   const [documentTitle, setDocumentTitle] = useState(doc.display_title || doc.title)
   const [newVersionAvailable, setNewVersionAvailable] = useState(false)
-  const [handle, setHandle] = useState<EditorHandle | null>(null)
-  // Drops the static first-paint preview only after the live editor has painted
-  // its synced content — so the preview is replaced, never briefly deleted.
-  const [editorSwapped, setEditorSwapped] = useState(false)
+  const [readyEditor, setReadyEditor] = useState<{
+    key: string
+    handle: EditorHandle
+  } | null>(null)
+  const [swappedEditorKey, setSwappedEditorKey] = useState<string | null>(null)
   const [spans, setSpans] = useState<ProvenanceSpan[]>([])
   const [peers, setPeers] = useState<UserIdentity[]>([])
   const [reviewTarget, setReviewTarget] = useState<ReviewTarget | null>(null)
@@ -218,10 +219,6 @@ export default function DocumentShow({
   const [suggestionNotice, setSuggestionNotice] = useState<string | null>(null)
   const [composerAnchor, setComposerAnchor] = useState<string | null>(null)
   const viewRef = useRef<EditorView | null>(null)
-  // Live handle for code that runs after awaits or inside stable callbacks —
-  // a closure-captured handle goes stale when the editor remounts mid-flight.
-  const handleRef = useRef<EditorHandle | null>(null)
-  handleRef.current = handle
   // Hydration-safe init from server-rendered cookie prefs: SSR and the client's
   // first render derive panel/focus/mode from the same `ui` props, so a user
   // who closed the panel (etc.) sees it closed at first paint — no flip. The
@@ -231,16 +228,28 @@ export default function DocumentShow({
   const [focusMode, setFocusMode] = useState(ui.focus_mode)
   // Demo doc always opens in Edit and stays locked there — a stale mode cookie
   // can't override it (the server also defaults it; this is the client guard).
-  const modeLocked = doc.slug === 'demo'
-  const [mode, setMode] = useState<EditorMode>(modeLocked ? 'edit' : ui.mode)
-  const isReading = mode === 'read'
+  const demoModeLocked = doc.slug === 'demo'
+  const [mode, setMode] = useState<EditorMode>(demoModeLocked ? 'edit' : ui.mode)
+  const effectiveMode: EditorMode = ownership.can_write ? mode : 'read'
+  const modeLocked = demoModeLocked || !ownership.can_write
+  const isReading = effectiveMode === 'read'
+  const connectionIdentity = viewer.account ? `account:${viewer.account.id}` : 'guest'
+  const editorSessionKey = `${doc.slug}:${ownership.can_write ? 'write' : 'read'}`
+  const handle = readyEditor?.key === editorSessionKey ? readyEditor.handle : null
+  // Tie the instant-paint swap to the exact permission-keyed editor. A delayed
+  // callback from the old editor can never hide the preview for a new remount.
+  const editorSwapped = swappedEditorKey === editorSessionKey
+  // Live handle for code that runs after awaits or inside stable callbacks —
+  // a closure-captured handle goes stale when the editor remounts mid-flight.
+  const handleRef = useRef<EditorHandle | null>(null)
+  handleRef.current = handle
   // handleSelection is a stable callback — it reads the live mode via ref.
-  const modeRef = useRef(mode)
-  modeRef.current = mode
+  const modeRef = useRef(effectiveMode)
+  modeRef.current = effectiveMode
   // Leaving Comment mode dismisses any pending click-to-comment affordance.
   useEffect(() => {
-    if (mode !== 'comment') setCommentTarget(null)
-  }, [mode])
+    if (effectiveMode !== 'comment') setCommentTarget(null)
+  }, [effectiveMode])
 
   // ≤64rem: rail and margin cards give way to anchor markers, a bottom dock,
   // and sheets — the full product, rearranged for one hand. Masked by isClient
@@ -289,8 +298,8 @@ export default function DocumentShow({
     setCookieFlag('pruf_focus', focusMode)
   }, [focusMode])
   useEffect(() => {
-    if (!modeLocked) setCookie('pruf_mode', mode)
-  }, [mode, modeLocked])
+    if (!demoModeLocked) setCookie('pruf_mode', mode)
+  }, [mode, demoModeLocked])
 
   // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
   useEffect(() => {
@@ -378,10 +387,21 @@ export default function DocumentShow({
     presencePoll.stop()
     router.visit('/')
   }, [presencePoll])
+  const reloadEditingAccess = useCallback(() => {
+    router.reload({
+      only: ownership.yours ? ['ownership'] : ['document', 'ownership'],
+      async: true,
+    })
+  }, [ownership.yours])
+  const recoverDeniedWrite = useCallback(() => {
+    router.reload({ only: ['document', 'ownership', 'viewer'], async: true })
+  }, [])
   useMetaChannel(doc.slug, {
     onDeleted: onDocumentGone,
     onTitle: setDocumentTitle,
     onVersionAvailable: () => setNewVersionAvailable(true),
+    onEditingLock: reloadEditingAccess,
+    connectionIdentity,
   })
 
   // The sync channel rejects its resubscription when the doc is gone —
@@ -390,8 +410,12 @@ export default function DocumentShow({
     if (!handle) return
     const provider = handle.provider
     provider.on('rejected', onDocumentGone)
-    return () => provider.off('rejected', onDocumentGone)
-  }, [handle, onDocumentGone])
+    provider.on('write-denied', recoverDeniedWrite)
+    return () => {
+      provider.off('rejected', onDocumentGone)
+      provider.off('write-denied', recoverDeniedWrite)
+    }
+  }, [handle, onDocumentGone, recoverDeniedWrite])
 
   const handleSelection = useCallback((view: EditorView) => {
     viewRef.current = view
@@ -941,7 +965,7 @@ export default function DocumentShow({
   // Mode switches close the composer without posting (same as Cancel).
   useEffect(() => {
     setComposerAnchor(null)
-  }, [mode])
+  }, [effectiveMode])
 
   // The anchored text stays visibly marked while the composer is open —
   // the editor selection itself collapses when focus moves to the textarea.
@@ -1036,7 +1060,16 @@ export default function DocumentShow({
                 {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
               </button>
             )}
-            <ModeControl mode={mode} onChange={setMode} locked={modeLocked} />
+            <ModeControl
+              mode={effectiveMode}
+              onChange={setMode}
+              locked={modeLocked}
+              lockedReason={
+                ownership.can_write
+                  ? undefined
+                  : 'Read only — the document owner locked editing'
+              }
+            />
             <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
             <HeaderMenu
               panelOpen={panelOpen}
@@ -1095,23 +1128,28 @@ export default function DocumentShow({
                 <div className="doc-live-editor">
                   {isClient && (
                     <DocumentEditor
+                      key={editorSessionKey}
                       slug={doc.slug}
                       identity={identity}
+                      canWrite={ownership.can_write}
+                      connectionIdentity={connectionIdentity}
                       contentFormat={doc.content_format}
                       initialStateB64={doc.yjs_state_b64}
                       seedContent={doc.seed_content}
                       seedGranted={doc.seed_granted}
                       seedAuthorKind={doc.seed_author_kind}
                       seedAuthorName={doc.seed_author_name}
-                      editable={mode === 'edit' || mode === 'suggest'}
-                      suggesting={mode === 'suggest'}
-                      taskInteractive={mode !== 'comment'}
+                      editable={ownership.can_write && (effectiveMode === 'edit' || effectiveMode === 'suggest')}
+                      suggesting={ownership.can_write && effectiveMode === 'suggest'}
+                      taskInteractive={ownership.can_write && effectiveMode !== 'comment'}
                       onReady={(h) => {
-                        setHandle(h)
+                        setReadyEditor({ key: editorSessionKey, handle: h })
                         // Wait two frames so ProseMirror has painted the synced
                         // content before the preview is removed.
                         requestAnimationFrame(() =>
-                          requestAnimationFrame(() => setEditorSwapped(true)),
+                          requestAnimationFrame(() =>
+                            setSwappedEditorKey(editorSessionKey),
+                          ),
                         )
                       }}
                       onStatus={setStatus}

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,7 +9,7 @@ class Activity < ApplicationRecord
   # Log and announce in one step — every activity is broadcast live.
   def self.log!(document:, actor_name:, actor_kind:, action:, detail: nil)
     activity = create!(document:, actor_name:, actor_kind:, action:, detail:)
-    DocumentMetaChannel.broadcast_event(document, :activities)
+    DocumentMetaChannel.broadcast_event_after_commit(document, :activities)
     activity
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,7 +21,7 @@ class Comment < ApplicationRecord
       action: "commented",
       detail: body.to_s.truncate(80)
     )
-    DocumentMetaChannel.broadcast_event(document, :comments)
+    DocumentMetaChannel.broadcast_event_after_commit(document, :comments)
     comment
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,6 @@
 class Document < ApplicationRecord
+  class EditingLockedError < StandardError; end
+  class NotOwnerError < StandardError; end
   DEFAULT_SEED = "# Untitled\n\nStart writing — everything you type is attributed to you.\n"
   DEFAULT_HTML_SEED = "<h1>Untitled</h1><p>Start writing — everything you type is attributed to you.</p>"
   CONTENT_FORMATS = %w[markdown html].freeze
@@ -113,6 +115,51 @@ class Document < ApplicationRecord
     token.present? && owner_token == token
   end
 
+  def writable_by?(token, user: nil)
+    !editing_locked? || owned_by?(token, user:)
+  end
+
+  def assert_write_access!(token: nil, user: nil)
+    raise EditingLockedError, "This document is read-only." unless writable_by?(token, user:)
+
+    self
+  end
+
+  def with_write_access(token: nil, user: nil)
+    with_lock do
+      reload
+      assert_write_access!(token:, user:)
+
+      yield
+    end
+  end
+
+  def set_editing_locked!(locked:, token:, user: nil)
+    changed = false
+    actor_name = user&.name || owner_name || "Anonymous"
+
+    with_lock do
+      reload
+      raise NotOwnerError, "Only the owner can change editing access." unless owned_by?(token, user:)
+      next if editing_locked? == locked
+
+      update!(editing_locked: locked)
+      activities.create!(
+        actor_name:,
+        actor_kind: "human",
+        action: locked ? "locked_editing" : "unlocked_editing",
+        detail: locked ? "made the document read-only for others" : "reopened the document for editing"
+      )
+      changed = true
+    end
+
+    if changed
+      DocumentMetaChannel.broadcast_event(self, :activities)
+      DocumentMetaChannel.broadcast_event(self, :editing_lock, locked:)
+    end
+    self
+  end
+
   # One normalization rule for display names: strip, cap, nil for blank.
   # nil matters — the identity endpoint clears the session on blank rather
   # than storing a fallback.
@@ -202,7 +249,9 @@ class Document < ApplicationRecord
       claimed: claimed?,
       claimable: claimable?,
       owner_name: owner_name,
-      yours: owned_by?(viewer_token, user: viewer_user)
+      yours: owned_by?(viewer_token, user: viewer_user),
+      editing_locked: editing_locked?,
+      can_write: writable_by?(viewer_token, user: viewer_user)
     }
   end
 

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -49,7 +49,7 @@ class Suggestion < ApplicationRecord
       action: "suggested",
       detail: intent.presence || body.truncate(80)
     )
-    DocumentMetaChannel.broadcast_event(document, :suggestions)
+    DocumentMetaChannel.broadcast_event_after_commit(document, :suggestions)
     suggestion
   end
 

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -267,6 +267,7 @@ class AgentGuide
         "Tracked changes use <ins data-suggestion-id> / <del data-suggestion-id> in the source snapshot. They are human-typed suggestions pending review, not your proposals, and are not resolvable through this API.",
         "Review is human-gated by design: accepting/rejecting suggestions and advancing review states happen in the editor, by humans. Your job is to propose well.",
         "Ownership: a human can claim a document in the browser; claimed docs show an owner in this payload (claimable: false means nobody can ever claim it, e.g. the demo). Claiming is browser-only (cookie-based) — agents cannot claim, so don't POST to any claim path. When a human claims, a claimed_document activity appears in the event feed with their name.",
+        "Editing access: editing_locked=true means the owner made this document read-only for everyone else. You can keep reading state, presence, and events, but suggestions and comments return 423 until the browser owner unlocks it. Agents cannot change this setting.",
         "A claimed document can be deleted by its owner, after which every endpoint here returns 404. Treat a 404 on a previously-working slug as deletion, not an outage to retry.",
         "Document creation, suggestion, and comment writes are rate-limited per source IP. A 429 response means retry later; inspect each endpoint's rate_limits field for the current windows."
       ]
@@ -420,9 +421,12 @@ class AgentGuide
         ## Ownership
         A human can claim a document in their browser; the claimed owner shows
         in the state payload. Claiming is browser-only (cookie-based) — agents
-        cannot claim. An owner can delete their document, after which every
-        endpoint returns 404: treat a 404 on a previously-working slug as
-        deletion, not an outage to retry.
+        cannot claim. When editing_locked is true, everyone except the owner is
+        read-only: keep reading state and events, but wait for the browser owner
+        to unlock before proposing suggestions or comments. Agents cannot change
+        this setting. An owner can delete their document, after which every
+        endpoint returns 404: treat a 404 on a previously-working slug as deletion,
+        not an outage to retry.
 
         Machine-readable version of this guide: GET #{api_base} (JSON).
       GUIDE

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -13,11 +13,14 @@ class YjsPersistence
 
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
-    def merge(document, base64_update)
+    def merge(document, base64_update, token: nil, user: nil)
       update = decode(base64_update)
       lock_for(document.id).synchronize do
         document.with_lock do
-          ydoc = load_ydoc(document.reload)
+          document.reload
+          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+
+          ydoc = load_ydoc(document)
           before = ydoc.state
           ydoc.sync(update)
           # A no-op update (e.g. the empty sync-reply a client joining an
@@ -47,12 +50,15 @@ class YjsPersistence
     # client has observed every Yjs update currently stored by the server.
     # A client may be ahead (its own cable frame is still in flight), but it
     # may not overwrite the API read model from behind.
-    def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title)
+    def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
+                         token: nil, user: nil)
       client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
       lock_for(document.id).synchronize do
         document.with_lock do
           document.reload
+          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+
           if client_state && document.yjs_state.present?
             server_state = decode_state_vector(load_ydoc(document).state)
             current = server_state.all? do |client_id, clock|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
+  patch "d/:slug/editing_lock", to: "documents#update_editing_lock", as: :document_editing_lock
   delete "d/:slug", to: "documents#destroy", as: :destroy_document
   post "d/:slug/snapshot", to: "documents#snapshot", as: :document_snapshot
   post "d/:slug/sync_update", to: "documents#sync_update", as: :document_sync_update

--- a/db/migrate/20260626100000_add_editing_locked_to_documents.rb
+++ b/db/migrate/20260626100000_add_editing_locked_to_documents.rb
@@ -1,0 +1,5 @@
+class AddEditingLockedToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :editing_locked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_100000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -92,6 +92,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_210000) do
     t.string "content_format", default: "markdown", null: false
     t.text "content_markdown"
     t.datetime "created_at", null: false
+    t.boolean "editing_locked", default: false, null: false
     t.string "owner_name", limit: 255
     t.string "owner_token"
     t.json "provenance_spans", default: []

--- a/docs/plans/2026-06-26-001-feat-owner-editing-lock-plan.md
+++ b/docs/plans/2026-06-26-001-feat-owner-editing-lock-plan.md
@@ -1,0 +1,322 @@
+---
+title: "feat: Add owner-controlled document editing lock"
+type: feat
+date: 2026-06-26
+deepened: 2026-06-26
+---
+
+# feat: Add owner-controlled document editing lock
+
+## Summary
+
+Add a claimed-document setting in the header overflow menu that lets the owner make the document read-only for everyone else. Enforce the lock across the browser editor, collaborative transports, and agent write APIs while keeping the document readable and the owner fully editable.
+
+---
+
+## Problem Frame
+
+Claiming establishes who owns a document, but it currently grants only deletion authority. Anyone with the share link can still edit the Yjs document or contribute through suggestions and comments. Owners need a deliberate way to preserve a document's current state without removing shared read access.
+
+---
+
+## Requirements
+
+**Owner control**
+
+- R1. Only the current document owner can enable or disable the editing lock, and the control appears in the header overflow menu only after the document is claimed by that owner.
+- R2. Lock state persists on the document and remains unchanged across reloads, guest-to-account ownership promotion, and other browser sessions for the same signed-in owner.
+- R3. The owner retains all existing edit, suggest, comment, review, and task-toggle capabilities while the lock is enabled.
+
+**Read-only enforcement**
+
+- R4. A locked document remains readable to non-owners, but non-owners cannot mutate its content, suggestions, comments, or review state through browser HTTP routes, Action Cable, fallback sync requests, or agent APIs.
+- R5. Non-owner clients render in a locked Read mode, cannot select another editor mode, and do not emit document updates or durable snapshots.
+- R6. Enabling the lock while non-owners are connected discards any rejected local divergence by reloading authoritative document state; unlocking restores their normal mode choices.
+- R7. Presence, document reads, event polling, and other non-content participation remain available because they do not modify the shared document.
+
+**Discovery and compatibility**
+
+- R8. Browser props and agent state expose the lock without revealing owner credentials, and agent guidance explains that writes are unavailable until the owner unlocks the document.
+- R9. Unclaimed and unlocked documents preserve the existing share-link collaboration behavior.
+- R10. Lock changes notify connected clients promptly and record an attributable activity entry.
+
+---
+
+## Assumptions
+
+- “Nobody else edit, only read” means the owner remains writable while all other humans and agents are read-only.
+- Read-only blocks suggestions, comments, comment resolution, and suggestion review in addition to direct text editing; allowing those actions would contradict the requested read-only state.
+- The setting is available only to an owner. Unclaimed documents must be claimed before they can be locked.
+- Unlocking restores a visitor's previously selected editor mode rather than forcing Edit mode.
+
+---
+
+## Key Technical Decisions
+
+- **Persist a document-level boolean:** Add a non-null `editing_locked` column defaulting to false. This preserves today's open collaboration behavior and makes the policy visible to every transport.
+- **Centralize the authorization predicate and locked write boundary on `Document`:** A single policy answers whether a browser identity may write, using the existing account-or-owner-token rules. A row-locked guard rechecks that policy inside the same transaction as each mutation so a frame authorized before the lock commits cannot persist afterward.
+- **Treat the owner identity as a server-side capability:** Action Cable resolves the signed owner cookie and the configured encrypted session cookie in `ApplicationCable::Connection`, following Rails' cookie-authentication pattern. The guest token is a private connection attribute rather than an `identified_by` value so connection identifiers, statistics, props, JavaScript, logs, and agent payloads never expose it.
+- **Enforce at every persistence boundary:** UI read-only state is guidance. `SyncChannel`, Yjs merge and snapshot persistence, fallback-sync endpoints, browser contribution/review endpoints, and agent contribution endpoints all enter the same row-locked authorization boundary.
+- **Keep awareness separate from document writes:** Locked visitors may remain present and receive live updates. Awareness frames and read-side presence/event bookkeeping remain allowed.
+- **Resync on access changes:** A lock-change meta event reloads both access props and authoritative document state. The editor remounts only when the viewer's effective write permission changes, eliminating rejected local divergence without disrupting the owner.
+- **Make the menu control optimistic but server-authoritative:** The owner sees a checked “Read only for others” menu item. A failed toggle rolls back through the Inertia error path, while the model transition owns activity logging and broadcasts.
+- **Keep lock management human-only:** Agents receive context parity and deterministic locked errors but cannot toggle the lock because ownership itself is intentionally browser-only.
+
+---
+
+## High-Level Technical Design
+
+The same document policy gates every mutation surface:
+
+```mermaid
+flowchart TB
+  A[Mutation attempt] --> B{Document locked?}
+  B -->|No| C[Existing collaboration behavior]
+  B -->|Yes| D{Viewer is owner?}
+  D -->|Yes| E[Allow and persist]
+  D -->|No| F[Reject without persistence]
+  F --> G[Keep document readable]
+```
+
+Lock changes move connected non-owners between normal collaboration and authoritative read-only state:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unlocked
+  Unlocked --> LockedOwner: owner enables lock
+  Unlocked --> LockedReader: owner enables lock
+  LockedOwner --> Unlocked: owner disables lock
+  LockedReader --> Unlocked: owner disables lock
+  LockedReader: Read mode and no writes
+  LockedOwner: Existing owner modes and writes
+```
+
+---
+
+## Implementation Units
+
+### U1. Persist lock state and define the write policy
+
+**Goal:** Give documents a durable owner-controlled lock and one reusable authorization predicate.
+
+**Requirements:** R1, R2, R3, R9, R10
+
+**Dependencies:** none
+
+**Files:**
+
+- `db/migrate/20260626100000_add_editing_locked_to_documents.rb`
+- `db/schema.rb`
+- `app/models/document.rb`
+- `app/controllers/documents_controller.rb`
+- `config/routes.rb`
+- `test/models/document_test.rb`
+- `test/integration/ownership_flow_test.rb`
+
+**Approach:**
+
+- Add `editing_locked` with a database default and null constraint so existing documents remain unlocked.
+- Add a document policy that permits writes when unlocked or when the supplied browser identity owns the document.
+- Add an owner-only PATCH action for changing the lock. Parse the requested boolean strictly, reject non-owners without changing state, and keep repeated requests idempotent.
+- Perform the transition in the model transaction, add one human-attributed activity for a real state change, and broadcast `activities` plus a dedicated editing-lock event after commit.
+
+**Patterns to follow:** `Document#owned_by?` and `Document#claim!` for guest/account identity, transactional activity creation, and post-commit `DocumentMetaChannel` broadcasts; `DocumentsController#destroy` for owner-only redirects and Inertia errors.
+
+**Test scenarios:**
+
+1. A new and pre-migration document is unlocked and writable under the existing share-link policy.
+2. A guest owner and an account owner can each enable and disable the lock from their valid session.
+3. A non-owner, stale pre-promotion guest token, unclaimed visitor, and anonymous request cannot change lock state.
+4. A forged lock request without a valid CSRF token is rejected even when it carries the owner's cookies.
+5. Missing, blank, or non-boolean lock input is rejected without changing state.
+6. Repeating the current state succeeds without duplicate activities or broadcasts.
+7. A real state transition persists, records the owner's display name, and broadcasts activities plus the editing-lock event.
+8. The write-policy predicate allows everyone when unlocked, allows only the owner when locked, and never treats a blank token as ownership.
+
+**Verification:** Model and ownership integration tests prove durable state, owner authorization, idempotency, and broadcasts for both guest and account ownership.
+
+### U2. Enforce the lock at collaborative and HTTP write boundaries
+
+**Goal:** Make the server reject every non-owner document mutation even when the client UI is bypassed or stale.
+
+**Requirements:** R3, R4, R6, R7, R9
+
+**Dependencies:** U1
+
+**Files:**
+
+- `app/channels/application_cable/connection.rb`
+- `app/channels/sync_channel.rb`
+- `app/controllers/documents_controller.rb`
+- `app/controllers/suggestions_controller.rb`
+- `app/controllers/comments_controller.rb`
+- `app/controllers/concerns/document_write_authorization.rb`
+- `app/models/suggestion.rb`
+- `app/models/comment.rb`
+- `app/services/yjs_persistence.rb`
+- `test/channels/application_cable/connection_test.rb`
+- `test/channels/sync_channel_test.rb`
+- `test/integration/ownership_flow_test.rb`
+- `test/integration/suggestion_flow_test.rb`
+- `test/integration/comment_flow_test.rb`
+
+**Approach:**
+
+- Identify each Action Cable connection from the existing signed owner cookie and the encrypted Rails session cookie named by `Rails.application.config.session_options[:key]`. Register only the account user as a connection identifier; retain the guest token as a private channel authorization attribute. Keep unauthenticated connections valid for reading, and consult the document policy on every update or sync-reply frame.
+- Transmit a write-denied signal to stale non-owner clients instead of persisting or broadcasting their frame.
+- Extend Yjs persistence entry points to recheck authorization while holding the document row lock. Gate `snapshot` and `sync_update` before expensive parsing, then recheck inside persistence so a forged or racing request cannot change Yjs state, snapshots, provenance, assets, or titles.
+- Apply one browser-controller concern to suggestion creation and review plus comment creation and resolution. The concern enters the same document-row transaction used by lock transitions, preventing a contribution from committing after a concurrent lock wins.
+- Defer contribution activity and meta-channel broadcasts with Rails' after-all-transactions-commit hook so the new outer authorization transaction never announces a suggestion, comment, or review state that later rolls back.
+- Keep the lock order consistent: acquire the existing per-document Yjs mutex before the database row lock for CRDT operations, and use only the row lock for metadata mutations.
+
+**Patterns to follow:** existing `SyncChannel` validation-before-persistence ordering, JSON error handling in `sync_update`, `DocumentsController#destroy` authorization, and the redirect conventions documented in `SuggestionsController` and `CommentsController`.
+
+**Test scenarios:**
+
+1. A locked non-owner channel update and sync-reply produce no persistence and no peer broadcast, while awareness still relays.
+2. Connection setup recognizes guest and signed-in ownership, while connection identifiers and statistics never contain the guest owner token.
+3. The locked owner can send the same channel update and it persists normally for guest-token and account ownership.
+4. A visitor connected before the owner locks is denied on its next frame because authorization reads current database state.
+5. A lock transition racing a non-owner Yjs merge, snapshot, suggestion, or comment has one serial outcome: the mutation commits before the lock, or the lock commits and the mutation is denied; no mutation crosses the committed boundary.
+6. Locked non-owner snapshot and fallback-sync requests return a permission error without changing Yjs state, source snapshot, provenance, title, or assets.
+7. Locked non-owners cannot create, accept, reject, reopen, or bulk-accept suggestions and cannot create or resolve comments.
+8. A failed authorized contribution transaction emits no activity or meta-channel event; a committed transaction broadcasts only after commit.
+9. The owner can perform every gated browser action while locked, and all actors retain existing behavior after unlock.
+
+**Verification:** Channel and integration tests demonstrate that bypassing the UI cannot mutate a locked document and that non-write collaboration remains live.
+
+### U3. Add the overflow-menu setting and authoritative read-only client state
+
+**Goal:** Let owners manage the setting in the three-dot menu and make non-owner read-only behavior immediate and legible.
+
+**Requirements:** R1, R3, R5, R6, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- `app/controllers/documents_controller.rb`
+- `app/frontend/components/header_menu.tsx`
+- `app/frontend/components/mode_control.tsx`
+- `app/frontend/pages/documents/show.tsx`
+- `app/frontend/editor/milkdown_editor.tsx`
+- `app/frontend/editor/cable_provider.ts`
+- `app/frontend/lib/cable.ts`
+- `app/frontend/lib/use_meta_channel.ts`
+- `app/frontend/entrypoints/application.css`
+- `test/integration/ownership_flow_test.rb`
+
+**Approach:**
+
+- Extend the ownership/access prop with lock state and viewer write permission without exposing credentials.
+- Add an owner-only checked menu item labeled “Read only for others,” with pending and error states that work in desktop popover and mobile sheet layouts. Locked non-owners see a non-interactive “Read only — locked by owner” status in the same overflow menu.
+- Derive an effective mode: locked non-owners render as Read, see the desktop mode control disabled with an accessible lock explanation, lose content/comment/review/task-toggle affordances, and keep their stored mode untouched for later restoration. Do not rely on a disabled button's tooltip as the only explanation.
+- Give `DocumentEditor` and `CableProvider` a separate write-permission input. Suppress local CRDT frames, durable snapshot/fallback writes, and interactive task toggles for locked readers while continuing to apply remote updates and awareness.
+- Handle the editing-lock meta event by reloading access and full document props. Key the editor by effective permission so a newly locked reader remounts from authoritative state; handle a channel write-denied signal with the same recovery path.
+- Key the shared Action Cable consumer by coarse server-known identity (`guest` or account ID). Recreate the connection when authentication changes so guest-to-account promotion and logout cannot leave channels authorizing against stale handshake cookies.
+
+**Patterns to follow:** `HeaderMenu` checkbox items, `OwnershipChip` Inertia mutation behavior, `ModeControl` locked state, `DocumentEditor`'s existing user-input-only editable gate, and `useMetaChannel` special handling for document deletion.
+
+**Test scenarios:**
+
+1. The show response marks an owner writable and a different visitor read-only when locked, with no owner token in the payload.
+2. The setting is visible and interactive only for the owner of a claimed document; it is absent for non-owners and unclaimed documents.
+3. A locked non-owner lands in Read regardless of their mode cookie, cannot change mode or toggle tasks, and does not emit snapshots or Yjs updates.
+4. The owner retains their selected mode and all actions while the lock is enabled.
+5. A connected non-owner receives a lock event, reloads authoritative state, and loses write affordances; an unlock event restores their stored mode.
+6. Guest-to-account promotion, account switching, and logout recreate the cable connection before the next document subscription, preserving the owner's write permission without losing a first edit.
+7. Desktop and mobile overflow menus expose the same owner toggle states, while locked non-owners get a visible and screen-reader-readable status.
+
+**Verification:** TypeScript checks pass and a two-browser test shows the owner toggling read-only while the second browser transitions without preserving rejected local edits.
+
+### U4. Expose lock policy to agents and gate agent contributions
+
+**Goal:** Give agents context parity while preserving the human-only ownership control.
+
+**Requirements:** R4, R7, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- `app/controllers/api/base_controller.rb`
+- `app/controllers/api/suggestions_controller.rb`
+- `app/controllers/api/comments_controller.rb`
+- `app/services/agent_guide.rb`
+- `test/integration/agent_api_test.rb`
+- `test/integration/agent_discovery_test.rb`
+
+**Approach:**
+
+- Include lock state in agent document state and plain-text guidance while keeping the owner token and viewer-specific capability absent.
+- Add a shared API guard that rejects suggestion and comment mutations on locked documents with a deterministic locked response and a next action to wait for the owner to unlock.
+- Preserve GET state, presence, and event polling/acknowledgement because they support reading and coordination without modifying document content.
+- Keep lock toggling browser-owner-only and document that boundary in the agent guide.
+
+**Patterns to follow:** `AgentGuide.state`, endpoint metadata, and notes for machine-readable context; `Api::BaseController#require_agent!` for teaching errors; claimed-document PATCH conflict guidance for owner-controlled workflow boundaries.
+
+**Test scenarios:**
+
+1. JSON and text state identify a locked document as read-only without leaking owner credentials.
+2. Locked suggestion creation, comment creation, and comment resolution return the same deterministic locked contract and create no records, activities, assets, or broadcasts.
+3. State reads, presence, pending-event reads, and acknowledgement remain available on a locked document.
+4. Unlocking restores the existing agent suggestion and comment flows without changing their request or response shapes.
+5. Agent guidance says only the browser owner can change the setting and does not advertise a lock-management endpoint.
+
+**Verification:** Agent API and discovery integration tests prove context parity, mutation denial, credential privacy, and unlocked compatibility.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given Alice owns a claimed document and Bob has it open in Edit mode, when Alice enables “Read only for others,” then Alice keeps editing while Bob reloads authoritative content into locked Read mode and Bob's later updates are rejected.
+- AE2. Given a locked document, when a non-owner forges a Yjs frame, snapshot request, suggestion request, or comment request, then the server persists nothing and the document remains readable.
+- AE3. Given a locked account-owned document, when the same owner signs in from another browser, then the menu shows the setting checked and that browser remains writable.
+- AE4. Given a locked document and an identified agent, when the agent reads state then it sees the lock; when it proposes a change then it receives the locked response and no contribution is created.
+- AE5. Given the owner disables the lock, when a non-owner receives the change then their previously selected mode becomes available and existing open-collaboration behavior resumes.
+
+---
+
+## Scope Boundaries
+
+**In scope:** one document-level owner setting; enforcement for direct edits, task toggles, snapshots, suggestions, comments, and review mutations; browser and agent discovery; live-client transitions.
+
+**Out of scope:** ownership transfer, per-user allowlists, editor/viewer roles beyond owner versus everyone else, password-protected links, expiring locks, and audit-history UI beyond the existing activity feed.
+
+### Deferred to Follow-Up Work
+
+- Rich role-based sharing can build on the centralized write policy if Thinkroom later needs named collaborators who can edit a locked document.
+- A dedicated lock badge outside the overflow menu can be considered if user testing shows the disabled Read mode is not discoverable enough.
+
+---
+
+## System-Wide Impact
+
+- **Authorization:** Ownership becomes an active write boundary rather than deletion-only metadata. All future document mutation paths must consult the centralized policy.
+- **Realtime collaboration:** Action Cable remains open for reads and awareness, but update persistence becomes identity-aware and state-dependent.
+- **Agent parity:** Agents gain access-state visibility but intentionally do not gain the human owner's lock-management action.
+- **Data lifecycle:** The migration is additive and defaults existing records to current behavior; no backfill or rollout flag is required.
+
+---
+
+## Risks & Dependencies
+
+- **Missed mutation surface:** A route omitted from the policy would bypass read-only. The controller concern, explicit route inventory, and integration matrix mitigate this.
+- **Stale collaborative state:** Rejecting a frame without client recovery leaves local content that will disappear later. Lock events and write-denied responses must trigger authoritative remounts.
+- **Authorization time-of-check/time-of-use:** A policy check before a row lock can approve a mutation that persists after the lock commits. Every mutation must recheck under the same document lock as its write, with concurrency coverage for both serialization outcomes.
+- **Action Cable identity drift:** Guest-to-account promotion changes the valid owner identity. Connection setup reads both signed cookies, but long-lived connections can still hold stale identifiers; channel authorization must compare them to freshly reloaded document ownership and promotion must cause existing cable consumers to reconnect or refresh their connection identity.
+- **Premature realtime broadcasts:** Existing suggestion and comment model entry points broadcast immediately. Wrapping them in a new outer authorization transaction would expose uncommitted state unless those broadcasts are deferred until all transactions commit.
+- **Programmatic editor writes:** ProseMirror `editable: false` gates user input but still accepts remote transactions. A separate permission flag is required to suppress outgoing persistence without blocking inbound collaboration.
+- **Partial reload payload size:** Lock changes need the full document prop only when effective write permission changes; owner toggles should avoid remounting despite receiving refreshed props.
+
+---
+
+## Sources & Research
+
+- `docs/plans/2026-06-05-003-feat-claim-doc-ownership-plan.md` — ownership boundaries, browser-only claiming, and live ownership events.
+- `docs/plans/2026-06-25-004-fix-claimed-document-revision-workflow-plan.md` — current claimed-document agent workflow and discovery contract.
+- `app/models/document.rb` and `app/controllers/documents_controller.rb` — account/guest ownership predicate and owner-only deletion pattern.
+- `app/channels/sync_channel.rb` and `app/frontend/editor/cable_provider.ts` — authoritative Yjs persistence and live update protocol.
+- `app/frontend/pages/documents/show.tsx`, `app/frontend/components/header_menu.tsx`, and `app/frontend/components/mode_control.tsx` — current overflow menu and per-visitor Read mode.
+- `docs/solutions/architecture-patterns/server-first-instant-paint.md` — preserve server-authoritative first paint and remount from the current document projection.
+- Rails Action Cable documentation — connections expose the initiating request's signed/encrypted cookies, identifiers delegate to channels, and long-lived channels must refresh database state before authorization: `https://guides.rubyonrails.org/v8.0.0/action_cable_overview.html` and `https://api.rubyonrails.org/v8.1/classes/ActionCable/Connection/Base.html`.

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
+  tests ApplicationCable::Connection
+
+  test "connects readers without an ownership identity" do
+    connect
+
+    assert_nil connection.current_user
+    assert_nil connection.owner_token
+  end
+
+  test "reads the signed guest owner token without identifying the connection by it" do
+    cookies.signed[:owner_token] = "guest-secret"
+
+    connect
+
+    assert_equal "guest-secret", connection.owner_token
+    refute_includes connection.connection_identifier.to_s, "guest-secret"
+  end
+
+  test "reads the signed-in user from the encrypted session cookie" do
+    user = User.create!(
+      name: "Owner",
+      email: "cable-owner@example.com",
+      password: "thoughtful-passphrase"
+    )
+    connect session: { user_id: user.id }
+
+    assert_equal user, connection.current_user
+  end
+end

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -141,6 +141,61 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert doc.reload.yjs_state.present?
   end
 
+  test "locked non-owner updates are rejected without persistence or relay" do
+    doc = Document.create!(
+      title: "Locked",
+      owner_token: "owner-token",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+    subscribe slug: doc.slug
+    update = build_update_b64("forbidden")
+
+    assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
+      perform :receive, { "type" => "update", "update" => update, "cid" => "reader" }
+    end
+
+    assert_nil doc.reload.yjs_state
+    assert_equal "write-denied", transmissions.last["type"]
+  end
+
+  test "locked guest owner updates still persist and relay" do
+    doc = Document.create!(
+      title: "Locked",
+      owner_token: "owner-token",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+    stub_connection(owner_token: "owner-token", current_user: nil)
+    subscribe slug: doc.slug
+    update = build_update_b64("owner edit")
+
+    assert_broadcast_on(
+      SyncChannel.broadcasting_for(doc),
+      type: "update", update:, cid: "owner"
+    ) do
+      perform :receive, { "type" => "update", "update" => update, "cid" => "owner" }
+    end
+    assert doc.reload.yjs_state.present?
+  end
+
+  test "locked readers still relay awareness" do
+    doc = Document.create!(
+      title: "Locked",
+      owner_token: "owner-token",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+    subscribe slug: doc.slug
+
+    assert_broadcast_on(
+      SyncChannel.broadcasting_for(doc),
+      type: "awareness", update: "AAAA", cid: "reader"
+    ) do
+      perform :receive, { "type" => "awareness", "update" => "AAAA", "cid" => "reader" }
+    end
+  end
+
   test "malformed update frames are dropped without raising or relaying" do
     doc = Document.create!(title: "Poison")
     subscribe slug: doc.slug

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -223,13 +223,21 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   test "state read exposes ownership without leaking the token" do
     get "/api/docs/#{@document.slug}", headers: AGENT
     body = response.parsed_body
-    assert_equal({ "claimed" => false, "claimable" => true, "owner_name" => nil }, body["ownership"])
+    assert_equal(
+      { "claimed" => false, "claimable" => true, "owner_name" => nil,
+        "editing_locked" => false, "can_write" => true },
+      body["ownership"]
+    )
 
     @document.claim!(token: "tok-owner", name: "Quiet Falcon")
 
     get "/api/docs/#{@document.slug}", headers: AGENT
     body = response.parsed_body
-    assert_equal({ "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon" }, body["ownership"])
+    assert_equal(
+      { "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon",
+        "editing_locked" => false, "can_write" => true },
+      body["ownership"]
+    )
     refute_includes response.body, "tok-owner"
     refute_includes response.body, "owner_token"
   end
@@ -340,6 +348,41 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "agent", suggestion.author_kind
     assert_equal "pending_human_review", response.parsed_body["status"]
     assert_equal %w[joined suggested], @document.activities.order(:id).pluck(:action).last(2)
+  end
+
+  test "locked document stays readable but rejects agent contributions" do
+    @document.update!(
+      owner_token: "owner-token",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+    comment = @document.comments.create!(
+      author_name: "A", author_kind: "human", body: "Existing"
+    )
+
+    get "/api/docs/#{@document.slug}", headers: AGENT
+    assert_response :success
+    assert_equal true, response.parsed_body.dig("ownership", "editing_locked")
+    assert_equal false, response.parsed_body.dig("ownership", "can_write")
+    assert response.parsed_body["notes"].any? { |note| note.include?("423") }
+
+    assert_no_difference -> { @document.suggestions.count } do
+      post "/api/docs/#{@document.slug}/suggestions",
+           params: { body: "Forbidden" }, headers: AGENT, as: :json
+    end
+    assert_response :locked
+    assert_equal true, response.parsed_body["editing_locked"]
+
+    assert_no_difference -> { @document.comments.count } do
+      post "/api/docs/#{@document.slug}/comments",
+           params: { body: "Forbidden" }, headers: AGENT, as: :json
+    end
+    assert_response :locked
+
+    post api_doc_resolve_comment_path(slug: @document.slug, id: comment.id),
+         headers: AGENT, as: :json
+    assert_response :locked
+    assert_not comment.reload.resolved_at
   end
 
   test "agent comment is agent-attributed and logged" do

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -121,9 +121,28 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     }
 
     body = response.parsed_body
-    assert_equal({ "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon" }, body["ownership"])
+    assert_equal(
+      { "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon",
+        "editing_locked" => false, "can_write" => true },
+      body["ownership"]
+    )
     assert body["notes"].any? { |n| n.include?("cannot claim") }
     refute_includes response.body, "tok-owner"
+  end
+
+  test "text guide explains owner-controlled read-only mode" do
+    @document.update!(
+      owner_token: "tok-owner",
+      owner_name: "Quiet Falcon",
+      editing_locked: true
+    )
+
+    get "/d/#{@document.slug}", headers: { "User-Agent" => "curl/8.6.0" }
+
+    assert_response :success
+    assert_includes response.body, "editing_locked"
+    assert_includes response.body, "read-only"
+    assert_match(/Agents cannot change\s+this setting/, response.body)
   end
 
   test "HTML text guide uses readable native HTML in its suggestion example" do

--- a/test/integration/comment_flow_test.rb
+++ b/test/integration/comment_flow_test.rb
@@ -37,6 +37,28 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test "locked non-owner cannot create or resolve comments" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+    comment = @document.comments.create!(
+      author_name: "A", author_kind: "human", body: "Existing"
+    )
+
+    assert_no_difference -> { @document.comments.count } do
+      post document_comments_path(@document.slug), params: {
+        body: "Forbidden", author_name: "Reader"
+      }
+    end
+    assert_response :redirect
+
+    patch resolve_comment_path(comment), params: { by: "Reader" }, as: :json
+    assert_response :locked
+    assert_not comment.reload.resolved_at
+  end
+
   test "resolving a comment timestamps it and keeps it out of open scope" do
     comment = @document.comments.create!(author_name: "A", author_kind: "human", body: "Fix this")
 

--- a/test/integration/ownership_flow_test.rb
+++ b/test/integration/ownership_flow_test.rb
@@ -256,6 +256,67 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
     refute_match(/owner_token/, response.body)
   end
 
+  test "owner can lock and unlock editing" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+
+    assert_difference -> { @document.activities.count }, 1 do
+      patch document_editing_lock_path(@document.slug), params: { locked: true }
+    end
+    assert_response :see_other
+    assert @document.reload.editing_locked?
+
+    patch document_editing_lock_path(@document.slug), params: { locked: false }
+    assert_response :see_other
+    assert_not @document.reload.editing_locked?
+  end
+
+  test "show exposes viewer-specific write access for a locked document" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+    patch document_editing_lock_path(@document.slug), params: { locked: true }
+
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props.dig(:ownership, :editing_locked) == true &&
+        props.dig(:ownership, :can_write) == true &&
+        props.dig(:ownership, :yours) == true
+    end
+
+    reset!
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props.dig(:ownership, :editing_locked) == true &&
+        props.dig(:ownership, :can_write) == false &&
+        props.dig(:ownership, :yours) == false
+    end
+  end
+
+  test "non-owner cannot change editing lock" do
+    Document.where(id: @document.id).update_all(
+      owner_token: "someone-else", owner_name: "Owner", claimed_at: Time.current
+    )
+    establish_identity
+
+    patch document_editing_lock_path(@document.slug), params: { locked: true }
+
+    assert_response :see_other
+    assert_not @document.reload.editing_locked?
+  end
+
+  test "editing lock rejects missing and invalid values" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+
+    patch document_editing_lock_path(@document.slug), params: {}
+    assert_response :see_other
+    assert_not @document.reload.editing_locked?
+
+    patch document_editing_lock_path(@document.slug), params: { locked: "sometimes" }
+    assert_response :see_other
+    assert_not @document.reload.editing_locked?
+  end
+
   # --- home page: Your docs + deduped recents ---
 
   test "index lists docs claimed by this session under yours, newest first" do
@@ -346,6 +407,18 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
 
       assert_response :unprocessable_entity
       assert_not @document.reload.claimed?
+    end
+  end
+
+  test "forged editing lock PATCH without CSRF token is rejected" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+
+    with_forgery_protection do
+      patch document_editing_lock_path(@document.slug), params: { locked: true }
+
+      assert_response :unprocessable_entity
+      assert_not @document.reload.editing_locked?
     end
   end
 

--- a/test/integration/snapshot_test.rb
+++ b/test/integration/snapshot_test.rb
@@ -11,6 +11,45 @@ class SnapshotTest < ActionDispatch::IntegrationTest
     @document = Document.create!(title: "Snap", content_markdown: "original")
   end
 
+  test "locked non-owner cannot persist a snapshot or sync update" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      editing_locked: true,
+      content_snapshot: "original"
+    )
+    ydoc = Y::Doc.new
+    ydoc.get_text("t") << "forbidden"
+    update = Base64.strict_encode64(ydoc.diff.pack("C*"))
+    state_vector = Base64.strict_encode64(ydoc.state.pack("C*"))
+
+    post document_snapshot_path(@document.slug), params: {
+      content: "changed", spans: [], state_vector:
+    }, as: :json
+    assert_response :locked
+    assert_equal "original", @document.reload.content_snapshot
+
+    post document_sync_update_path(@document.slug), params: { update: }, as: :json
+    assert_response :locked
+    assert_nil @document.reload.yjs_state
+  end
+
+  test "locked requests are denied before snapshot and sync payload validation" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+
+    post document_snapshot_path(@document.slug), params: {
+      content: "changed", markdown: "conflict", spans: []
+    }, as: :json
+    assert_response :locked
+
+    post document_sync_update_path(@document.slug), params: { update: "not-base64" }, as: :json
+    assert_response :locked
+  end
+
   test "persists markdown and sanitized spans" do
     assert_broadcast_on(
       DocumentMetaChannel.broadcasting_for(@document),

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -61,6 +61,46 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     assert_empty @document.suggestions.pending
   end
 
+  test "locked non-owner cannot create or review suggestions" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      editing_locked: true
+    )
+
+    assert_no_difference -> { @document.suggestions.count } do
+      post document_suggestions_path(@document.slug), params: {
+        author_name: "Reader", body: "Forbidden"
+      }
+    end
+    assert_response :redirect
+
+    patch accept_suggestion_path(@suggestion), params: { by: "Reader" }, as: :json
+    assert_response :locked
+    assert_equal "pending", @suggestion.reload.status
+
+    patch reject_suggestion_path(@suggestion), params: { by: "Reader" }, as: :json
+    assert_response :locked
+    assert_equal "pending", @suggestion.reload.status
+
+    patch accept_all_document_suggestions_path(@document.slug),
+          params: { by: "Reader" }, as: :json
+    assert_response :locked
+    assert_equal "pending", @suggestion.reload.status
+  end
+
+  test "locked owner keeps browser contribution access" do
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+    patch document_editing_lock_path(@document.slug), params: { locked: true }
+
+    assert_difference -> { @document.suggestions.count }, 1 do
+      post document_suggestions_path(@document.slug), params: {
+        author_name: "Owner", body: "Allowed"
+      }
+    end
+    assert_response :see_other
+  end
+
   test "resolving an already-resolved suggestion reports an error" do
     @suggestion.reject!
     patch accept_suggestion_path(@suggestion)

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -13,7 +13,8 @@ class DocumentTest < ActiveSupport::TestCase
     assert document.owned_by?("stale-token", user:)
     assert_not document.owned_by?("stale-token")
     assert_equal(
-      { claimed: true, claimable: false, owner_name: "Kieran", yours: true },
+      { claimed: true, claimable: false, owner_name: "Kieran", yours: true,
+        editing_locked: false, can_write: true },
       document.ownership_props("stale-token", viewer_user: user)
     )
   end
@@ -279,6 +280,46 @@ class DocumentTest < ActiveSupport::TestCase
     assert_not doc.owned_by?("tok-b")
   end
 
+  test "editing lock allows only the owner to write" do
+    doc = Document.create!(title: "Mine", owner_token: "tok-a", owner_name: "Owner")
+    assert doc.writable_by?(nil)
+
+    doc.set_editing_locked!(locked: true, token: "tok-a")
+
+    assert doc.writable_by?("tok-a")
+    assert_not doc.writable_by?("tok-b")
+    assert_not doc.writable_by?(nil)
+    assert_raises(Document::EditingLockedError) do
+      doc.with_write_access(token: "tok-b") { flunk "write block must not run" }
+    end
+  end
+
+  test "only the owner can change the editing lock" do
+    doc = Document.create!(title: "Mine", owner_token: "tok-a", owner_name: "Owner")
+
+    assert_raises(Document::NotOwnerError) do
+      doc.set_editing_locked!(locked: true, token: "tok-b")
+    end
+    assert_not doc.reload.editing_locked?
+  end
+
+  test "editing lock changes log and broadcast once" do
+    doc = Document.create!(title: "Mine", owner_token: "tok-a", owner_name: "Owner")
+
+    assert_difference -> { doc.activities.count }, 1 do
+      assert_broadcasts(DocumentMetaChannel.broadcasting_for(doc), 2) do
+        doc.set_editing_locked!(locked: true, token: "tok-a")
+      end
+    end
+    assert_equal "locked_editing", doc.activities.last.action
+
+    assert_no_difference -> { doc.activities.count } do
+      assert_no_broadcasts(DocumentMetaChannel.broadcasting_for(doc)) do
+        doc.set_editing_locked!(locked: true, token: "tok-a")
+      end
+    end
+  end
+
   test "owner_name longer than 255 chars is rejected by validation" do
     doc = Document.new(title: "Long", owner_name: "x" * 256)
     assert_not doc.valid?
@@ -330,11 +371,26 @@ class DocumentTest < ActiveSupport::TestCase
   test "ownership_props shapes the client payload without leaking the token" do
     doc = Document.create!(title: "Free")
     props = doc.ownership_props(nil)
-    assert_equal({ claimed: false, claimable: true, owner_name: nil, yours: false }, props)
+    assert_equal(
+      { claimed: false, claimable: true, owner_name: nil, yours: false,
+        editing_locked: false, can_write: true },
+      props
+    )
 
     doc.claim!(token: "tok-a", name: "Owner")
-    assert_equal({ claimed: true, claimable: false, owner_name: "Owner", yours: true }, doc.ownership_props("tok-a"))
-    assert_equal({ claimed: true, claimable: false, owner_name: "Owner", yours: false }, doc.ownership_props("tok-b"))
+    assert_equal(
+      { claimed: true, claimable: false, owner_name: "Owner", yours: true,
+        editing_locked: false, can_write: true },
+      doc.ownership_props("tok-a")
+    )
+    assert_equal(
+      { claimed: true, claimable: false, owner_name: "Owner", yours: false,
+        editing_locked: false, can_write: true },
+      doc.ownership_props("tok-b")
+    )
+    doc.set_editing_locked!(locked: true, token: "tok-a")
+    assert doc.ownership_props("tok-a")[:can_write]
+    assert_not doc.ownership_props("tok-b")[:can_write]
     assert_not doc.ownership_props("tok-a").value?("tok-a")
   end
 


### PR DESCRIPTION
## Summary

Document owners can now make a claimed document read-only for everyone else from the three-dot menu. The owner keeps editing normally, while other browsers and agents retain live read access without being able to change text, tasks, suggestions, comments, or review state.

The lock is enforced at the persistence boundary rather than only in the UI:

- Action Cable and fallback Yjs writes recheck owner access under the document row lock.
- Browser and agent contribution routes return a deterministic locked response without committing or broadcasting partial work.
- Connected readers move into disabled Read mode, discard rejected local divergence, and continue receiving owner edits and awareness.
- Agent state and guidance expose the policy without exposing ownership credentials.

Lock transitions are persisted, recorded in the activity feed, and broadcast after commit. Existing unlocked and unclaimed collaboration behavior remains unchanged.

Implementation plan: `docs/plans/2026-06-26-001-feat-owner-editing-lock-plan.md`

## Validation

- `bin/rails test` — 363 tests, 1,724 assertions
- `npm run check`
- `bin/rubocop`
- `bin/brakeman --no-pager` — zero warnings
- Two isolated browser sessions: owner lock/unlock, live reader transition, blocked editing, continued inbound owner updates, and mode restoration

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
