### PR TITLE
feat: export documents and sketches

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -40,6 +40,7 @@
 
 # plan_output: html              # md | html (default: md)
 # brainstorm_output: html        # md | html (default: md)
+# ideate_output: md              # md | html (default: html -- ideation docs are human-facing, so HTML is the default; set md to opt out)
 
 # --- ce-promote ---
 # Written automatically when you decline the Spiral setup offer in /ce-promote.

--- a/app/frontend/components/share_popover.tsx
+++ b/app/frontend/components/share_popover.tsx
@@ -9,14 +9,23 @@ import { ThemePicker } from './theme_picker'
  *  person, or copy an agent invite that tells an agent exactly how to join. */
 export function SharePopover({
   agentsActive,
+  exportReady,
+  onExportMarkdown,
+  onExportHtml,
+  onPrint,
   onOpenChange,
 }: {
   agentsActive: number
+  exportReady: boolean
+  onExportMarkdown: () => void | Promise<void>
+  onExportHtml: () => void | Promise<void>
+  onPrint: () => void
   /** Lets the page suppress selection chrome while the popover is open. */
   onOpenChange?: (open: boolean) => void
 }) {
   const [open, setOpenState] = useState(false)
   const [copied, setCopied] = useState<'link' | 'agent' | null>(null)
+  const [exportState, setExportState] = useState<'markdown' | 'html' | 'print' | 'error' | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   // The sticky header's backdrop-filter makes it the containing block for
@@ -46,6 +55,23 @@ export function SharePopover({
     })
   }, [])
 
+  const runExport = useCallback(
+    async (kind: 'markdown' | 'html' | 'print', action: () => void | Promise<void>) => {
+      if (!exportReady || (exportState !== null && exportState !== 'error')) return
+      setExportState(kind)
+      try {
+        await action()
+        setExportState(null)
+      } catch (error) {
+        console.warn('thinkroom: document export failed', kind, error)
+        setExportState('error')
+      }
+    },
+    [exportReady, exportState],
+  )
+
+  const exportBusy = exportState !== null && exportState !== 'error'
+
   useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
 
   const popover = (
@@ -56,32 +82,67 @@ export function SharePopover({
       aria-label="Share this document"
       onClick={(event) => event.stopPropagation()}
     >
-          <div className="share-section">
-            <div className="share-section-title">People</div>
-            <p className="share-section-hint">Anyone with the link joins this live document.</p>
-            <div className="share-copy-row">
-              <code className="share-url">{url}</code>
-              <button className="share-copy" onClick={() => copy('link', url)}>
-                {copied === 'link' ? 'Copied' : 'Copy link'}
-              </button>
-            </div>
-          </div>
-          <div className="share-section share-section--agent">
-            <div className="share-section-title">
-              Your agent
-              <span className={`share-agent-dot ${agentsActive > 0 ? 'is-on' : ''}`} />
-              <span className="share-agent-state">
-                {agentsActive > 0 ? `${agentsActive} active now` : 'same URL, different audience'}
-              </span>
-            </div>
-            <p className="share-section-hint">
-              Agents fetching this link discover the API: state, suggestions, comments,
-              presence — identified by <code>X-Agent-Name</code>.
-            </p>
-            <button className="share-copy share-copy--wide" onClick={() => copy('agent', agentInvite)}>
-              {copied === 'agent' ? 'Copied — paste it to your agent' : 'Copy agent invite'}
-            </button>
-          </div>
+      <div className="share-section">
+        <div className="share-section-title">People</div>
+        <p className="share-section-hint">Anyone with the link joins this live document.</p>
+        <div className="share-copy-row">
+          <code className="share-url">{url}</code>
+          <button className="share-copy" onClick={() => copy('link', url)}>
+            {copied === 'link' ? 'Copied' : 'Copy link'}
+          </button>
+        </div>
+      </div>
+      <div className="share-section share-section--agent">
+        <div className="share-section-title">
+          Your agent
+          <span className={`share-agent-dot ${agentsActive > 0 ? 'is-on' : ''}`} />
+          <span className="share-agent-state">
+            {agentsActive > 0 ? `${agentsActive} active now` : 'same URL, different audience'}
+          </span>
+        </div>
+        <p className="share-section-hint">
+          Agents fetching this link discover the API: state, suggestions, comments,
+          presence — identified by <code>X-Agent-Name</code>.
+        </p>
+        <button className="share-copy share-copy--wide" onClick={() => copy('agent', agentInvite)}>
+          {copied === 'agent' ? 'Copied — paste it to your agent' : 'Copy agent invite'}
+        </button>
+      </div>
+      <div className="share-section share-section--export">
+        <div className="share-section-title">Export</div>
+        <p className="share-section-hint">
+          Download a clean copy, or print to paper or PDF.
+        </p>
+        <div className="share-export-actions">
+          <button
+            className="share-copy"
+            disabled={!exportReady || exportBusy}
+            onClick={() => void runExport('markdown', onExportMarkdown)}
+          >
+            {exportState === 'markdown' ? 'Preparing…' : 'Markdown'}
+          </button>
+          <button
+            className="share-copy"
+            disabled={!exportReady || exportBusy}
+            onClick={() => void runExport('html', onExportHtml)}
+          >
+            {exportState === 'html' ? 'Preparing…' : 'HTML'}
+          </button>
+          <button
+            className="share-copy"
+            disabled={!exportReady || exportBusy}
+            onClick={() => void runExport('print', onPrint)}
+          >
+            Print / PDF
+          </button>
+        </div>
+        {!exportReady && <p className="share-export-status">Preparing document…</p>}
+        {exportState === 'error' && (
+          <p className="share-export-status is-error" role="status">
+            Export failed. Try again.
+          </p>
+        )}
+      </div>
       {/* The header stays minimal — the reading theme lives here, on every
           surface (desktop popover and mobile sheet alike). */}
       <div className="share-section share-section--theme">

--- a/app/frontend/editor/document_export.ts
+++ b/app/frontend/editor/document_export.ts
@@ -1,0 +1,125 @@
+import { editorViewCtx, schemaCtx, type Editor } from '@milkdown/kit/core'
+import { getMarkdown } from '@milkdown/kit/utils'
+import { downloadBlob } from '../lib/download'
+import { serializeHtml } from './document_format'
+import { sketchToSvg } from './sketch/export'
+import { normalizeSketchData } from './sketch/scene'
+
+const EXPORTED_DOCUMENT_STYLES = `
+  :root { color-scheme: light; font-family: Georgia, 'Times New Roman', serif; }
+  body { max-width: 46rem; margin: 0 auto; padding: 3rem 1.5rem 5rem; color: #28231d; background: #fffef9; font-size: 17px; line-height: 1.7; }
+  h1, h2, h3, h4, h5, h6 { line-height: 1.25; letter-spacing: -0.015em; }
+  h1 { font-size: 2rem; } h2 { margin-top: 1.6em; font-size: 1.45rem; } h3 { margin-top: 1.3em; font-size: 1.15rem; }
+  a { color: #6f4f2d; text-underline-offset: 2px; }
+  blockquote { margin-left: 0; border-left: 3px solid #d4c6b4; padding-left: 1.1em; color: #625b52; }
+  pre { overflow-x: auto; border-radius: 8px; background: #f3eee5; padding: 1rem; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9em; }
+  img, svg { display: block; max-width: 100%; height: auto; }
+  figure { margin: 1.5rem 0; overflow: hidden; border: 1px solid #ded4c6; border-radius: 12px; background: #fffef9; }
+  figure svg { width: 100%; }
+  figcaption { border-top: 1px solid #e7ded2; padding: 0.55rem 0.75rem; color: #71685d; font: 500 12px/1.35 system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; } th, td { border: 1px solid #ded4c6; padding: 0.45rem 0.6rem; text-align: left; }
+  ins { text-decoration: none; background: #e7f2df; } del { background: #f7e3df; }
+  @media print { body { max-width: none; padding: 0; } }
+`
+
+const safeFilename = (title: string, extension: string): string => {
+  const base = title
+    .trim()
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+  return `${base || 'thinkroom-document'}.${extension}`
+}
+
+export function downloadDocumentMarkdown(editor: Editor, title: string): void {
+  const markdown = editor.action((ctx) => getMarkdown()(ctx))
+  downloadBlob(
+    new Blob([markdown], { type: 'text/markdown;charset=utf-8' }),
+    safeFilename(title, 'md'),
+  )
+}
+
+const sketchDataFromFigure = (figure: HTMLElement) => {
+  try {
+    return normalizeSketchData({
+      id: figure.dataset.sketchId,
+      formatVersion: Number(figure.dataset.formatVersion),
+      description: figure.dataset.description ?? '',
+      height: figure.dataset.sketchHeight ? Number(figure.dataset.sketchHeight) : undefined,
+      scene: JSON.parse(figure.dataset.scene ?? ''),
+    })
+  } catch {
+    return null
+  }
+}
+
+const absolutizeDocumentUrls = (root: ParentNode): void => {
+  root.querySelectorAll<HTMLElement>('[href], [src]').forEach((element) => {
+    for (const attribute of ['href', 'src']) {
+      const value = element.getAttribute(attribute)
+      if (!value || value.startsWith('#') || value.startsWith('data:')) continue
+      try {
+        element.setAttribute(attribute, new URL(value, window.location.origin).href)
+      } catch {
+        // The editor sanitizer has already constrained URLs. Leave an unusual
+        // but valid value untouched if the URL constructor cannot normalize it.
+      }
+    }
+  })
+}
+
+export async function exportedDocumentHtml(editor: Editor, title: string): Promise<string> {
+  const source = editor.action((ctx) =>
+    serializeHtml(ctx.get(editorViewCtx).state.doc, ctx.get(schemaCtx)),
+  )
+  const exported = document.implementation.createHTMLDocument(title.trim() || 'Thinkroom document')
+  exported.documentElement.lang = 'en'
+  const charset = exported.createElement('meta')
+  charset.setAttribute('charset', 'utf-8')
+  const viewport = exported.createElement('meta')
+  viewport.name = 'viewport'
+  viewport.content = 'width=device-width, initial-scale=1'
+  const style = exported.createElement('style')
+  style.textContent = EXPORTED_DOCUMENT_STYLES
+  exported.head.prepend(charset, viewport)
+  exported.head.append(style)
+
+  const main = exported.createElement('main')
+  main.innerHTML = source
+  const sketches = Array.from(
+    main.querySelectorAll<HTMLElement>('figure[data-thinkroom-sketch]'),
+  )
+  await Promise.all(
+    sketches.map(async (figure) => {
+      const data = sketchDataFromFigure(figure)
+      if (!data) return
+      const svg = await sketchToSvg(data.scene)
+      svg.setAttribute('role', 'img')
+      svg.setAttribute('aria-label', data.description || 'Sketch')
+      const caption = exported.createElement('figcaption')
+      caption.textContent = data.description || 'Sketch'
+      figure.replaceChildren(exported.importNode(svg, true), caption)
+      for (const attribute of Array.from(figure.attributes)) {
+        if (attribute.name.startsWith('data-') || attribute.name === 'aria-label') {
+          figure.removeAttribute(attribute.name)
+        }
+      }
+    }),
+  )
+  absolutizeDocumentUrls(main)
+  exported.body.replaceChildren(main)
+  return `<!doctype html>\n${exported.documentElement.outerHTML}`
+}
+
+export async function downloadDocumentHtml(editor: Editor, title: string): Promise<void> {
+  const html = await exportedDocumentHtml(editor, title)
+  downloadBlob(
+    new Blob([html], { type: 'text/html;charset=utf-8' }),
+    safeFilename(title, 'html'),
+  )
+}
+
+export function printDocument(): void {
+  window.print()
+}

--- a/app/frontend/editor/sketch/export.ts
+++ b/app/frontend/editor/sketch/export.ts
@@ -1,4 +1,5 @@
 import type { SketchScene } from './scene'
+import { downloadBlob } from '../../lib/download'
 
 export async function sketchToSvg(scene: SketchScene): Promise<SVGSVGElement> {
   const { exportToSvg } = await import('@excalidraw/excalidraw')
@@ -29,10 +30,6 @@ export async function copySketchSvg(scene: SketchScene): Promise<void> {
 
 export async function downloadSketchSvg(scene: SketchScene, name: string): Promise<void> {
   const markup = svgMarkup(await sketchToSvg(scene))
-  const url = URL.createObjectURL(new Blob([markup], { type: 'image/svg+xml' }))
-  const anchor = document.createElement('a')
-  anchor.href = url
-  anchor.download = `${name.trim().replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'sketch'}.svg`
-  anchor.click()
-  URL.revokeObjectURL(url)
+  const filename = `${name.trim().replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'sketch'}.svg`
+  downloadBlob(new Blob([markup], { type: 'image/svg+xml' }), filename)
 }

--- a/app/frontend/editor/sketch/node_view.ts
+++ b/app/frontend/editor/sketch/node_view.ts
@@ -262,11 +262,13 @@ const buildSketchView = (
     downloadButton.textContent = 'Preparing…'
     void downloadSketchSvg(currentData.scene, currentData.description || 'sketch')
       .then(() => {
+        if (destroyed) return
         downloadButton.textContent = 'Downloaded'
         downloadButton.setAttribute('aria-label', 'Sketch downloaded as SVG')
         downloadResetTimer = setTimeout(resetDownloadButton, 1600)
       })
       .catch((error) => {
+        if (destroyed) return
         console.warn('thinkroom: sketch export failed', error)
         downloadButton.disabled = false
         downloadButton.textContent = 'Retry'

--- a/app/frontend/editor/sketch/node_view.ts
+++ b/app/frontend/editor/sketch/node_view.ts
@@ -9,6 +9,7 @@ import {
 import { $ctx, $prose, $view } from '@milkdown/kit/utils'
 import { Plugin, TextSelection } from '@milkdown/kit/prose/state'
 import { attrsFromSketchData, dataFromSketchNode, sketchSchema } from './schema'
+import { downloadSketchSvg } from './export'
 import {
   fitSketchViewport,
   renderExactSketchPreview,
@@ -81,6 +82,7 @@ const buildSketchView = (
   const titleInput = document.createElement('input')
   const editorMount = document.createElement('div')
   const deleteButton = document.createElement('button')
+  const downloadButton = document.createElement('button')
   let currentData = dataFromSketchNode(initialNode)
   let displayData = currentData
   let renderedScene = ''
@@ -90,6 +92,7 @@ const buildSketchView = (
   let destroyed = false
   let lastPreviewWidth = 0
   let renderedTapeId = ''
+  let downloadResetTimer: ReturnType<typeof setTimeout> | null = null
 
   const syncTapeVariation = (id: string) => {
     const hash = Array.from(id).reduce(
@@ -116,7 +119,12 @@ const buildSketchView = (
   deleteButton.textContent = '×'
   deleteButton.contentEditable = 'false'
   deleteButton.setAttribute('aria-label', 'Delete sketch')
-  dom.append(preview, editorMount, caption, deleteButton)
+  downloadButton.className = 'sketch-download-button'
+  downloadButton.type = 'button'
+  downloadButton.textContent = 'Download'
+  downloadButton.contentEditable = 'false'
+  downloadButton.setAttribute('aria-label', 'Download sketch as SVG')
+  dom.append(preview, editorMount, caption, downloadButton, deleteButton)
 
   const renderExactPreview = (data: SketchData, generation: number) => {
     // ProseMirror attaches the node view before the microtask queue drains.
@@ -171,8 +179,10 @@ const buildSketchView = (
       preview.replaceChildren()
       titleInput.value = 'Invalid sketch'
       titleInput.readOnly = true
+      downloadButton.hidden = true
       return
     }
+    downloadButton.hidden = false
     const scene = node.attrs.scene as string
     if (scene !== renderedScene) displayData = currentData
     const description = currentData.description
@@ -237,6 +247,33 @@ const buildSketchView = (
     if (currentData && enabled()) remove(currentData.id)
   }
   deleteButton.addEventListener('click', onDelete)
+  const resetDownloadButton = () => {
+    downloadResetTimer = null
+    downloadButton.disabled = false
+    downloadButton.textContent = 'Download'
+    downloadButton.setAttribute('aria-label', 'Download sketch as SVG')
+  }
+  const onDownload = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!currentData || downloadButton.disabled) return
+    if (downloadResetTimer) clearTimeout(downloadResetTimer)
+    downloadButton.disabled = true
+    downloadButton.textContent = 'Preparing…'
+    void downloadSketchSvg(currentData.scene, currentData.description || 'sketch')
+      .then(() => {
+        downloadButton.textContent = 'Downloaded'
+        downloadButton.setAttribute('aria-label', 'Sketch downloaded as SVG')
+        downloadResetTimer = setTimeout(resetDownloadButton, 1600)
+      })
+      .catch((error) => {
+        console.warn('thinkroom: sketch export failed', error)
+        downloadButton.disabled = false
+        downloadButton.textContent = 'Retry'
+        downloadButton.setAttribute('aria-label', 'Sketch export failed. Retry download')
+      })
+  }
+  downloadButton.addEventListener('click', onDownload)
   const saveTitle = () => {
     if (!displayData || !enabled()) return
     if (titleTimer) clearTimeout(titleTimer)
@@ -279,7 +316,9 @@ const buildSketchView = (
       titleInput.removeEventListener('input', onTitleInput)
       titleInput.removeEventListener('blur', saveTitle)
       deleteButton.removeEventListener('click', onDelete)
+      downloadButton.removeEventListener('click', onDownload)
       if (titleTimer) clearTimeout(titleTimer)
+      if (downloadResetTimer) clearTimeout(downloadResetTimer)
       if (currentData) close(currentData.id)
     },
   }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2308,6 +2308,11 @@ a:focus-visible {
   border-top: 1px solid var(--line);
 }
 
+.share-section--export {
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+}
+
 .share-popover .theme-picker {
   display: flex;
   width: 100%;
@@ -2376,8 +2381,41 @@ a:focus-visible {
   border-color: var(--ink-faint);
 }
 
+.share-copy:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.share-copy:disabled {
+  color: var(--ink-faint);
+  cursor: wait;
+  opacity: 0.62;
+}
+
 .share-copy--wide {
   width: 100%;
+}
+
+.share-export-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.share-export-actions .share-copy {
+  min-width: 0;
+  padding-inline: 0.35rem;
+  white-space: normal;
+}
+
+.share-export-status {
+  margin: 0.45rem 0 0;
+  color: var(--ink-faint);
+  font: 500 0.68rem/1.35 var(--font-ui);
+}
+
+.share-export-status.is-error {
+  color: #a1372c;
 }
 
 .share-agent-dot {
@@ -3093,6 +3131,50 @@ a:focus-visible {
   outline-offset: 2px;
 }
 
+.sketch-download-button {
+  position: absolute;
+  z-index: 5;
+  top: 12px;
+  right: 12px;
+  min-height: 32px;
+  border: 1px solid rgb(65 51 32 / 14%);
+  border-radius: 7px;
+  background: rgb(255 254 249 / 92%);
+  box-shadow: 0 3px 10px rgb(38 28 16 / 9%);
+  color: var(--ink-soft);
+  padding: 6px 10px;
+  font: 600 11px/1 var(--font-ui);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.sketch-download-button[hidden],
+.thinkroom-sketch.is-editing .sketch-download-button {
+  display: none;
+}
+
+.thinkroom-sketch:hover .sketch-download-button,
+.sketch-download-button:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sketch-download-button:hover {
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
+  background: #fffef9;
+}
+
+.sketch-download-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sketch-download-button:disabled {
+  cursor: wait;
+}
+
 .thinkroom-sketch-preview {
   display: grid;
   position: relative;
@@ -3293,4 +3375,85 @@ a:focus-visible {
 @media (max-width: 700px) {
   .thinkroom-sketch { margin: 18px 0; border-radius: 9px; }
   .thinkroom-sketch-preview { min-height: 150px; }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .sketch-download-button {
+    min-width: 44px;
+    min-height: 44px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media print {
+  @page {
+    margin: 0.7in;
+  }
+
+  body,
+  .doc-page {
+    min-height: 0;
+    background: #fff;
+  }
+
+  .doc-header,
+  .claim-banner,
+  .doc-notice,
+  .margin-gutter,
+  .doc-rail,
+  .mobile-dock,
+  .mobile-sheet,
+  .selection-toolbar,
+  .review-popover,
+  .comment-composer--anchored,
+  .thinkroom-slash-menu,
+  .sketch-add-inline,
+  .sketch-delete-tape,
+  .sketch-download-button,
+  .thinkroom-sketch-editor-mount {
+    display: none !important;
+  }
+
+  .doc-body,
+  .doc-canvas,
+  .doc-main,
+  .doc-editor-stack,
+  .doc-live-editor {
+    display: block;
+    position: static !important;
+    width: auto;
+    min-height: 0;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    visibility: visible !important;
+  }
+
+  .doc-static-preview {
+    display: none !important;
+  }
+
+  .milkdown,
+  .milkdown .ProseMirror {
+    min-height: 0;
+  }
+
+  .milkdown .ProseMirror {
+    color: #28231d;
+    font-size: 11.5pt;
+  }
+
+  .thinkroom-sketch,
+  pre,
+  table,
+  blockquote {
+    break-inside: avoid;
+  }
+
+  a {
+    color: inherit;
+    text-decoration-color: currentColor;
+  }
 }

--- a/app/frontend/lib/download.ts
+++ b/app/frontend/lib/download.ts
@@ -1,0 +1,8 @@
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  queueMicrotask(() => URL.revokeObjectURL(url))
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -36,6 +36,11 @@ import {
 import { refreshAgentCursors } from '../../editor/agent_cursors'
 import { editorViewCtx, parserCtx, schemaCtx } from '@milkdown/kit/core'
 import { sourceParser } from '../../editor/document_format'
+import {
+  downloadDocumentHtml,
+  downloadDocumentMarkdown,
+  printDocument,
+} from '../../editor/document_export'
 import { collectInlineSuggestions } from '../../editor/suggest_changes'
 import {
   MarginInlineSuggestions,
@@ -243,6 +248,16 @@ export default function DocumentShow({
   // a closure-captured handle goes stale when the editor remounts mid-flight.
   const handleRef = useRef<EditorHandle | null>(null)
   handleRef.current = handle
+  const exportMarkdown = useCallback(() => {
+    const live = handleRef.current
+    if (!live) throw new Error('Document editor is not ready')
+    downloadDocumentMarkdown(live.editor, documentTitle)
+  }, [documentTitle])
+  const exportHtml = useCallback(async () => {
+    const live = handleRef.current
+    if (!live) throw new Error('Document editor is not ready')
+    await downloadDocumentHtml(live.editor, documentTitle)
+  }, [documentTitle])
   // handleSelection is a stable callback — it reads the live mode via ref.
   const modeRef = useRef(effectiveMode)
   modeRef.current = effectiveMode
@@ -1070,7 +1085,14 @@ export default function DocumentShow({
                   : 'Read only — the document owner locked editing'
               }
             />
-            <SharePopover agentsActive={presences.length} onOpenChange={setShareOpen} />
+            <SharePopover
+              agentsActive={presences.length}
+              exportReady={Boolean(handle)}
+              onExportMarkdown={exportMarkdown}
+              onExportHtml={exportHtml}
+              onPrint={printDocument}
+              onOpenChange={setShareOpen}
+            />
             <HeaderMenu
               panelOpen={panelOpen}
               onTogglePanel={() => setPanelOpen((open) => !open)}

--- a/docs/plans/2026-06-26-002-feat-document-export-controls-plan.md
+++ b/docs/plans/2026-06-26-002-feat-document-export-controls-plan.md
@@ -1,0 +1,148 @@
+---
+title: "feat: Add document and sketch export controls"
+type: feat
+date: 2026-06-26
+---
+
+# feat: Add document and sketch export controls
+
+## Summary
+
+Add export actions to the existing Share surface and an image-download action to every rendered sketch. Exports use the current hydrated document, work for readers as well as editors, and keep Thinkroom's read mode visually clean.
+
+---
+
+## Problem Frame
+
+Thinkroom can display and collaborate on documents and sketches, but readers cannot take a portable copy from the interface. Sketches already have an SVG export primitive that is not exposed, while whole-document export has no user-facing path.
+
+---
+
+## Requirements
+
+### Document export
+
+- R1. The Share popover exposes Markdown, standalone HTML, and Print / PDF actions without adding another permanent header control.
+- R2. Markdown and HTML downloads serialize the latest hydrated editor state and use a safe filename derived from the document title.
+- R3. Standalone HTML renders sketches as inline SVG and rewrites document-local links and images to usable absolute URLs.
+- R4. Print / PDF produces a document-only layout that omits collaboration chrome, editing controls, sidebars, and export controls.
+
+### Sketch export
+
+- R5. Every valid rendered sketch can be downloaded as an SVG in read and write modes.
+- R6. The sketch download action appears on hover or keyboard focus, remains discoverable with a minimum 44-by-44-pixel target on coarse-pointer devices, and does not open the sketch editor.
+
+### Resilience and accessibility
+
+- R7. Document export actions remain disabled until the live editor is ready and expose failures as status text instead of failing silently.
+- R8. Export controls have explicit button labels, visible focus states, and permission-independent behavior.
+
+---
+
+## Assumptions
+
+- "PDF export" uses the browser's Print / Save as PDF dialog rather than adding a PDF-generation dependency.
+- SVG is the only per-sketch download format because it is lossless, already supported by `app/frontend/editor/sketch/export.ts`, and preserves the Excalidraw rendering.
+- Whole-document export belongs in Share in every editor mode; print styling supplies the same clean output that read mode presents without forcing a mode change.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Serialize from the live Milkdown editor: this includes unsaved collaborative changes already present in Yjs and avoids stale controller props.
+- KTD2. Keep export generation client-side: existing editor serializers and Excalidraw SVG generation already contain the required state, so no endpoint or persistence change is needed.
+- KTD3. Generate a self-contained HTML shell: semantic editor HTML is copied into a static document, sketch metadata is replaced by inline SVG, and minimal reading styles travel with the file.
+- KTD4. Reuse browser printing for PDF: print-specific CSS keeps the result clean while preserving native page sizing, destination, and accessibility controls.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Share export action] --> B{Live editor ready?}
+  B -->|No| C[Disabled action]
+  B -->|Yes| D[Read current ProseMirror state]
+  D --> E{Requested output}
+  E -->|Markdown| F[Serialize Markdown and download]
+  E -->|HTML| G[Serialize HTML]
+  G --> H[Replace sketch metadata with inline SVG]
+  H --> I[Wrap standalone document and download]
+  E -->|Print / PDF| J[Open browser print dialog]
+```
+
+---
+
+## Implementation Units
+
+### U1. Live document export helpers
+
+- **Goal:** Produce safe Markdown and standalone HTML downloads from the current editor state.
+- **Requirements:** R2, R3, R7
+- **Dependencies:** None
+- **Files:** `app/frontend/editor/document_export.ts`, `script/export_check.mjs`
+- **Approach:** Share filename normalization and Blob download cleanup; serialize Markdown with Milkdown and HTML with the existing sanitizer-backed serializer; turn sketch figures into inline exported SVG before wrapping the HTML in a static reading document.
+- **Patterns to follow:** `app/frontend/editor/milkdown_editor.tsx` for current-state serialization, `app/frontend/editor/sketch/export.ts` for SVG generation, and `app/frontend/editor/document_format.ts` for sanitized HTML.
+- **Test scenarios:**
+  - A live Markdown document downloaded after an edit contains the edited text and uses a title-derived `.md` filename.
+  - An HTML download contains a complete document shell, the current prose, and an inline SVG instead of raw sketch scene metadata.
+  - Relative document links and image URLs become absolute in the standalone HTML.
+  - A requested export before editor readiness remains unavailable and does not create an empty file.
+- **Verification:** Downloaded Markdown opens as source, downloaded HTML opens independently with prose and sketches visible, and object URLs are revoked after use.
+
+### U2. Share export surface and clean printing
+
+- **Goal:** Place document export in Share and make Print / PDF produce a document-only layout.
+- **Requirements:** R1, R4, R7, R8
+- **Dependencies:** U1
+- **Files:** `app/frontend/components/share_popover.tsx`, `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`, `script/export_check.mjs`
+- **Approach:** Pass export callbacks and readiness from the document page into a new Share section; keep actions available to readers and editors; use transient status copy for success/failure and a print media block for layout cleanup.
+- **Patterns to follow:** Existing Share sections and button states in `app/frontend/components/share_popover.tsx`; existing read-mode layout gates in `app/frontend/pages/documents/show.tsx`.
+- **Test scenarios:**
+  - Opening Share after hydration reveals Markdown, HTML, and Print / PDF actions.
+  - Triggering each download calls the corresponding current-state exporter and closes no unrelated UI.
+  - An exporter rejection produces an accessible failure message and leaves the popover usable for retry.
+  - Print / PDF invokes browser printing and the print stylesheet hides header, rails, gutters, editing mounts, and floating controls while retaining document content and sketch previews.
+- **Verification:** The Share surface remains usable at desktop and mobile breakpoints, downloads complete, and print preview contains only the reading document.
+
+### U3. Per-sketch SVG download action
+
+- **Goal:** Let any reader download a sketch image directly from its rendered section.
+- **Requirements:** R5, R6, R8
+- **Dependencies:** None
+- **Files:** `app/frontend/editor/sketch/node_view.ts`, `app/frontend/editor/sketch/export.ts`, `app/frontend/entrypoints/application.css`, `script/export_check.mjs`
+- **Approach:** Add an always-enabled child button to the sketch node view, stop its event from reaching the edit affordance, and call the existing SVG exporter with the sketch title or fallback name; expose progress/failure state on the button.
+- **Patterns to follow:** The existing hover/focus delete control in `app/frontend/editor/sketch/node_view.ts` and `.sketch-delete-tape` styling in `app/frontend/entrypoints/application.css`.
+- **Test scenarios:**
+  - Hovering or focusing a valid sketch exposes a labeled Download action and downloads a non-empty `.svg` file.
+  - Clicking Download in Edit mode does not open the Excalidraw editor or delete/change the sketch.
+  - A read-only viewer can download the same sketch even though edit and delete affordances are unavailable.
+  - Touch/coarse-pointer styling keeps the action visible without hover and provides at least a 44-by-44-pixel target.
+  - SVG generation failure changes the button to an accessible retryable error state.
+- **Verification:** Downloaded SVG renders the whole sketch, the document remains unchanged, and keyboard and touch users can reach the action.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a hydrated document with a newly received collaborator edit, when a reader chooses Download Markdown, then the file includes that edit.
+- AE2. Given a document containing a sketch, when a reader chooses Download HTML, then the saved file opens with the sketch rendered and contains no raw scene JSON.
+- AE3. Given a document in any mode, when a reader chooses Print / PDF, then the browser print dialog opens on a layout without application chrome.
+- AE4. Given a read-only sketch, when a reader hovers, focuses, or uses a touch device, then Download is reachable and produces an SVG without entering edit mode.
+
+---
+
+## Risks & Dependencies
+
+- Browser download and clipboard policies vary, so export actions must begin from direct user gestures and surface failures.
+- Print rendering is browser-owned; verification should cover the print media DOM/CSS contract rather than pixel-identical PDF output.
+- Excalidraw remains dynamically loaded for SVG generation, so buttons need an in-progress state and must tolerate import/export failure.
+
+---
+
+## Sources & Research
+
+- `app/frontend/editor/sketch/export.ts` already implements SVG generation and download but has no caller.
+- `app/frontend/components/share_popover.tsx` is the established grouped surface for link, agent, and reading-theme actions.
+- `docs/solutions/architecture-patterns/server-first-instant-paint.md` requires preserving the existing static-preview-to-live-editor handoff; exports therefore attach to the live editor without changing first paint.
+- `STRATEGY.md` names deliberate reading modes as an active product track; export is kept subordinate to reading instead of becoming permanent header chrome.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "check": "tsc -p tsconfig.app.json && tsc -p tsconfig.node.json",
+    "check:exports": "node script/export_check.mjs",
     "check:html": "node script/html_document_check.mjs",
     "check:links": "node script/link_check.mjs"
   },

--- a/script/export_check.mjs
+++ b/script/export_check.mjs
@@ -1,0 +1,169 @@
+// Focused document/sketch export regression check using Playwright.
+// Usage: BASE_URL=http://localhost:3000 node script/export_check.mjs
+import { chromium } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
+const AGENT_HEADERS = {
+  'X-Agent-Name': 'Export Check',
+  'Content-Type': 'application/json',
+}
+
+const assert = (condition, message, detail = '') => {
+  if (!condition) throw new Error(`${message}${detail ? `: ${detail}` : ''}`)
+  console.log(`✓ ${message}`)
+}
+
+const downloadText = async (download) => {
+  const stream = await download.createReadStream()
+  const chunks = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const sketchElement = {
+  id: 'export-text',
+  type: 'text',
+  x: 48,
+  y: 42,
+  width: 126,
+  height: 25,
+  angle: 0,
+  strokeColor: '#1e1e1e',
+  backgroundColor: 'transparent',
+  fillStyle: 'solid',
+  strokeWidth: 1,
+  strokeStyle: 'solid',
+  roughness: 1,
+  opacity: 100,
+  groupIds: [],
+  frameId: null,
+  index: 'a0',
+  roundness: null,
+  seed: 1,
+  version: 1,
+  versionNonce: 1,
+  isDeleted: false,
+  boundElements: null,
+  updated: 1,
+  link: null,
+  locked: false,
+  text: 'Export me',
+  fontSize: 20,
+  fontFamily: 1,
+  textAlign: 'left',
+  verticalAlign: 'top',
+  containerId: null,
+  originalText: 'Export me',
+  autoResize: true,
+  lineHeight: 1.25,
+}
+
+const sketch = {
+  id: 'export_flow',
+  formatVersion: 1,
+  description: 'Export flow',
+  height: 260,
+  scene: {
+    type: 'excalidraw',
+    version: 2,
+    elements: [sketchElement],
+    appState: { viewBackgroundColor: '#fffef9' },
+    files: {},
+  },
+}
+
+const browser = await chromium.launch()
+const context = await browser.newContext({ acceptDownloads: true })
+await context.addCookies([
+  {
+    name: 'pruf_guest',
+    value: encodeURIComponent(JSON.stringify({ name: 'Export Reader', color: '#5f7470' })),
+    url: BASE,
+  },
+])
+const page = await context.newPage()
+const errors = []
+page.on('pageerror', (error) => errors.push(error.stack ?? String(error)))
+page.on('console', (message) => {
+  if (message.type() === 'error') errors.push(message.text())
+})
+
+try {
+  const response = await fetch(`${BASE}/api/docs`, {
+    method: 'POST',
+    headers: AGENT_HEADERS,
+    body: JSON.stringify({
+      title: 'Export check',
+      format: 'markdown',
+      content: `# Export check\n\nBefore export.\n\n\`\`\`excalidraw\n${JSON.stringify(sketch)}\n\`\`\`\n`,
+    }),
+  })
+  assert(response.status === 201, 'created a document with a sketch')
+  const created = await response.json()
+
+  await page.goto(`${BASE}/d/${created.slug}`)
+  await page.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await page.waitForSelector('.thinkroom-sketch', { timeout: 15000 })
+  await page.locator('.mode-control-trigger').click()
+  await page.getByRole('option', { name: /^Read / }).click()
+  assert(
+    (await page.locator('.mode-control-trigger').textContent())?.includes('Read'),
+    'export controls are exercised from read mode',
+  )
+
+  await page.locator('.share-button').click()
+  const exportSection = page.locator('.share-section--export')
+  await exportSection.waitFor()
+  assert((await exportSection.getByRole('button').count()) === 3, 'Share exposes three export actions')
+
+  const markdownEvent = page.waitForEvent('download')
+  await exportSection.getByRole('button', { name: 'Markdown' }).click()
+  const markdownDownload = await markdownEvent
+  const markdown = await downloadText(markdownDownload)
+  assert(markdownDownload.suggestedFilename() === 'export-check.md', 'Markdown uses a safe title filename')
+  assert(
+    markdown.includes('Export check') && markdown.includes('```excalidraw'),
+    'Markdown contains current prose and sketch source',
+    markdown.slice(0, 500),
+  )
+
+  const htmlEvent = page.waitForEvent('download')
+  await exportSection.getByRole('button', { name: 'HTML' }).click()
+  const htmlDownload = await htmlEvent
+  const html = await downloadText(htmlDownload)
+  assert(htmlDownload.suggestedFilename() === 'export-check.html', 'HTML uses a safe title filename')
+  assert(/^<!doctype html>/i.test(html) && html.includes('Before export.'), 'HTML is a standalone current document')
+  assert(html.includes('<svg') && !html.includes('data-scene='), 'HTML embeds sketch SVG without raw scene metadata')
+
+  await page.evaluate(() => {
+    window.__exportPrintCalled = false
+    window.print = () => { window.__exportPrintCalled = true }
+  })
+  await exportSection.getByRole('button', { name: 'Print / PDF' }).click()
+  assert(await page.evaluate(() => window.__exportPrintCalled), 'Print / PDF invokes browser printing')
+
+  await page.locator('.share-button').click()
+  const sketchFigure = page.locator('.thinkroom-sketch')
+  await sketchFigure.hover()
+  const sketchButton = sketchFigure.getByRole('button', { name: 'Download sketch as SVG' })
+  await sketchButton.waitFor()
+  const sketchEvent = page.waitForEvent('download')
+  await sketchButton.click()
+  const sketchDownload = await sketchEvent
+  const svg = await downloadText(sketchDownload)
+  assert(sketchDownload.suggestedFilename() === 'Export-flow.svg', 'sketch uses its title as the SVG filename')
+  assert(svg.includes('<svg') && svg.includes('Export me'), 'downloaded SVG contains the rendered sketch')
+  assert((await page.locator('.thinkroom-sketch-editor').count()) === 0, 'sketch download does not enter edit mode')
+
+  await page.emulateMedia({ media: 'print' })
+  assert(await page.locator('.doc-header').evaluate((node) => getComputedStyle(node).display === 'none'), 'print hides application header')
+  assert(await page.locator('.doc-main').evaluate((node) => getComputedStyle(node).display === 'block'), 'print retains document content')
+  assert(
+    await page.locator('.sketch-download-button').evaluate((node) => getComputedStyle(node).display === 'none'),
+    'print hides sketch export controls',
+  )
+
+  assert(errors.length === 0, 'export flow completed without browser errors', errors.join('\n'))
+} finally {
+  await browser.close()
+}

--- a/script/export_check.mjs
+++ b/script/export_check.mjs
@@ -82,10 +82,25 @@ await context.addCookies([
   },
 ])
 const page = await context.newPage()
+const failObjectUrlCreation = () =>
+  page.evaluate(() => {
+    window.__originalCreateObjectURL = URL.createObjectURL
+    URL.createObjectURL = () => { throw new Error('Forced object URL failure') }
+  })
+const restoreObjectUrlCreation = () =>
+  page.evaluate(() => {
+    URL.createObjectURL = window.__originalCreateObjectURL
+    delete window.__originalCreateObjectURL
+  })
 const errors = []
-page.on('pageerror', (error) => errors.push(error.stack ?? String(error)))
+const expectedBrowserNoise = (message) =>
+  message.includes('ResizeObserver loop completed with undelivered notifications')
+page.on('pageerror', (error) => {
+  const message = error.stack ?? String(error)
+  if (!expectedBrowserNoise(message)) errors.push(message)
+})
 page.on('console', (message) => {
-  if (message.type() === 'error') errors.push(message.text())
+  if (message.type() === 'error' && !expectedBrowserNoise(message.text())) errors.push(message.text())
 })
 
 try {
@@ -135,6 +150,19 @@ try {
   assert(/^<!doctype html>/i.test(html) && html.includes('Before export.'), 'HTML is a standalone current document')
   assert(html.includes('<svg') && !html.includes('data-scene='), 'HTML embeds sketch SVG without raw scene metadata')
 
+  await failObjectUrlCreation()
+  await exportSection.getByRole('button', { name: 'Markdown' }).click()
+  await exportSection.locator('.share-export-status.is-error').waitFor()
+  assert(
+    await exportSection.getByRole('button', { name: 'Markdown' }).isEnabled(),
+    'document export failure stays visible and retryable',
+  )
+  await restoreObjectUrlCreation()
+  const retryMarkdownEvent = page.waitForEvent('download')
+  await exportSection.getByRole('button', { name: 'Markdown' }).click()
+  await retryMarkdownEvent
+  assert((await exportSection.locator('.share-export-status.is-error').count()) === 0, 'document export retry clears the error')
+
   await page.evaluate(() => {
     window.__exportPrintCalled = false
     window.print = () => { window.__exportPrintCalled = true }
@@ -147,8 +175,14 @@ try {
   await sketchFigure.hover()
   const sketchButton = sketchFigure.getByRole('button', { name: 'Download sketch as SVG' })
   await sketchButton.waitFor()
-  const sketchEvent = page.waitForEvent('download')
+  await failObjectUrlCreation()
   await sketchButton.click()
+  const retrySketchButton = sketchFigure.getByRole('button', { name: 'Sketch export failed. Retry download' })
+  await retrySketchButton.waitFor()
+  assert(await retrySketchButton.isEnabled(), 'sketch export failure exposes an enabled Retry action')
+  await restoreObjectUrlCreation()
+  const sketchEvent = page.waitForEvent('download')
+  await retrySketchButton.click()
   const sketchDownload = await sketchEvent
   const svg = await downloadText(sketchDownload)
   assert(sketchDownload.suggestedFilename() === 'Export-flow.svg', 'sketch uses its title as the SVG filename')


### PR DESCRIPTION
## Summary

Make read-only documents portable without leaving the reading experience. The Share menu now exports the live document as Markdown or a standalone HTML file and opens a print-friendly view for printing or saving as PDF. Embedded sketches can be downloaded directly as SVG from a hover, focus, or touch-friendly control.

## Design decisions

- Export the latest live editor state so downloads match what the reader is currently seeing.
- Preserve sketches in Markdown metadata while rendering them as inline SVG in standalone HTML.
- Keep export actions in Share and sketch downloads on the sketch itself, so both remain discoverable without adding persistent page chrome.
- Reuse a shared browser download helper and surface preparing, failure, and retry states for both document and sketch exports.
- Keep print output focused on document content with dedicated print styles suitable for browser Save as PDF.

## Tests

- `npm run check`
- `npm run check:exports` — 18 browser assertions covering Markdown, HTML, print, sketch SVG downloads, read-mode behavior, failures, and retries
- `bin/vite build --mode test`
- Manually verified the Share export UI and sketch hover action at desktop and 390×844 mobile viewports

---
[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-3.14.3-6f42c1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
