### PR TITLE
[codex] Organize the document index

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -162,20 +162,20 @@ class DocumentsController < InertiaController
   def update_tags
     document = Document.find_by!(slug: params[:slug])
     unless document.owned_by?(owner_token, user: current_user)
-      return redirect_back fallback_location: root_path, status: :see_other,
+      return redirect_back fallback_location: root_path,
                            inertia: { errors: { tags: "Only the owner can organize this document" } }
     end
 
     tags = params[:tags]
     unless tags.is_a?(Array)
-      return redirect_back fallback_location: root_path, status: :see_other,
+      return redirect_back fallback_location: root_path,
                            inertia: { errors: { tags: "Tags must be a list" } }
     end
 
     if document.update(tags:)
       redirect_back fallback_location: root_path, status: :see_other
     else
-      redirect_back fallback_location: root_path, status: :see_other,
+      redirect_back fallback_location: root_path,
                     inertia: { errors: { tags: document.errors[:tags].to_sentence } }
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,6 +13,8 @@ class DocumentsController < InertiaController
   inertia_config ssr_enabled: -> { %w[show index].include?(action_name) }
 
   def index
+    now = Time.current
+    week_start = now.beginning_of_week
     # Signed-in ownership follows the account across browsers. Guests retain
     # the original permanent-cookie ownership model.
     yours = if current_user
@@ -28,13 +30,15 @@ class DocumentsController < InertiaController
     slugs = Array(session[:recent_slugs])
     docs = Document.where(slug: slugs).index_by(&:slug)
     render inertia: "documents/index", props: {
-      yours: yours.map { |d| d.slice(:title, :slug, :content_format) },
+      yours: yours.map do |document|
+        index_document_props(document, week_start:, current_year: now.year)
+      end,
       # Recent rows carry ownership state so claimable docs can offer an
       # inline claim affordance. Render-time staleness is fine: the claim
       # POST is race-tolerant and the scoped reload reconciles the lists.
       recent: slugs.filter_map { |slug| docs[slug] unless your_slugs.include?(slug) }
                    .map do |d|
-                     d.slice(:title, :slug, :content_format)
+                     index_document_props(d, week_start:, current_year: now.year)
                        .merge(d.ownership_props(owner_token, viewer_user: current_user))
                    end
     }
@@ -152,6 +156,29 @@ class DocumentsController < InertiaController
   rescue ActiveRecord::RecordNotFound
     # The doc was deleted while the claim was in flight — go home cleanly
     # instead of popping a 404 modal over a dead editor.
+    redirect_to root_path, status: :see_other
+  end
+
+  def update_tags
+    document = Document.find_by!(slug: params[:slug])
+    unless document.owned_by?(owner_token, user: current_user)
+      return redirect_back fallback_location: root_path, status: :see_other,
+                           inertia: { errors: { tags: "Only the owner can organize this document" } }
+    end
+
+    tags = params[:tags]
+    unless tags.is_a?(Array)
+      return redirect_back fallback_location: root_path, status: :see_other,
+                           inertia: { errors: { tags: "Tags must be a list" } }
+    end
+
+    if document.update(tags:)
+      redirect_back fallback_location: root_path, status: :see_other
+    else
+      redirect_back fallback_location: root_path, status: :see_other,
+                    inertia: { errors: { tags: document.errors[:tags].to_sentence } }
+    end
+  rescue ActiveRecord::RecordNotFound
     redirect_to root_path, status: :see_other
   end
 
@@ -318,6 +345,23 @@ class DocumentsController < InertiaController
 
   def broadcast_title(document)
     DocumentMetaChannel.broadcast_event(document, :title, title: document.title)
+  end
+
+  def index_document_props(document, week_start:, current_year:)
+    created_at = document.created_at.in_time_zone
+    created_label = if created_at.year == current_year
+      created_at.strftime("%b %-d")
+    else
+      created_at.strftime("%b %-d, %Y")
+    end
+    {
+      title: document.title,
+      slug: document.slug,
+      tags: document.tags,
+      created_at: created_at.iso8601,
+      created_label:,
+      age_group: created_at >= week_start ? "this_week" : "earlier"
+    }
   end
 
   def sanitize_snapshot_spans(raw_spans)

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -272,6 +272,8 @@ a:focus-visible {
 
 /* ---------------------------- Document library -------------------------- */
 .document-library {
+  --document-library-muted: color-mix(in srgb, var(--ink-soft) 88%, var(--ink));
+
   margin-top: 3.5rem;
   text-align: left;
 }
@@ -300,7 +302,7 @@ a:focus-visible {
 
 .document-library-heading p {
   margin: 0.2rem 0 0;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.75rem;
 }
 
@@ -313,10 +315,10 @@ a:focus-visible {
 
 .document-tag-filters button {
   min-height: 1.85rem;
-  border: 1px solid var(--ink-soft);
+  border: 1px solid var(--document-library-muted);
   border-radius: 999px;
   background: transparent;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   padding: 0.28rem 0.65rem;
   font-size: 0.7rem;
   font-weight: 600;
@@ -339,7 +341,7 @@ a:focus-visible {
 .document-library-empty {
   margin: 0;
   padding: 1.2rem 0;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.85rem;
   line-height: 1.5;
 }
@@ -361,7 +363,7 @@ a:focus-visible {
 
 .document-group-heading h3 {
   margin: 0;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -369,7 +371,7 @@ a:focus-visible {
 }
 
 .document-group-heading span {
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.68rem;
   font-variant-numeric: tabular-nums;
 }
@@ -426,7 +428,7 @@ a:focus-visible {
 }
 
 .document-row-date {
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.7rem;
   font-variant-numeric: tabular-nums;
 }
@@ -462,7 +464,7 @@ a:focus-visible {
 .document-tag-cancel {
   border: 0;
   background: transparent;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   font-size: 0.7rem;
   font-weight: 650;
   cursor: pointer;
@@ -503,7 +505,7 @@ a:focus-visible {
   flex: 1;
   min-width: 0;
   height: 2.15rem;
-  border: 1px solid var(--ink-soft);
+  border: 1px solid var(--document-library-muted);
   border-radius: 7px;
   background: var(--surface);
   color: var(--ink);
@@ -537,7 +539,7 @@ a:focus-visible {
 }
 
 .document-tag-help {
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
 }
 
 .document-tag-error {
@@ -550,10 +552,10 @@ a:focus-visible {
   justify-content: center;
   width: 1.9rem;
   height: 1.9rem;
-  border: 1px solid var(--ink-soft);
+  border: 1px solid var(--document-library-muted);
   border-radius: 6px;
   background: transparent;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
@@ -570,7 +572,7 @@ a:focus-visible {
 
 .recent-owner {
   font-size: 0.72rem;
-  color: var(--ink-soft);
+  color: var(--document-library-muted);
   white-space: nowrap;
 }
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -209,9 +209,14 @@ a:focus-visible {
 
 .landing-main {
   width: 100%;
-  max-width: 26rem;
+  max-width: 44rem;
   margin-block: auto;
   text-align: center;
+}
+
+.landing-hero {
+  max-width: 28rem;
+  margin-inline: auto;
 }
 
 .landing-wordmark {
@@ -246,11 +251,6 @@ a:focus-visible {
   justify-content: center;
 }
 
-.landing-recent {
-  margin-top: 3rem;
-  text-align: left;
-}
-
 .landing-recent-heading {
   font-size: 0.7rem;
   text-transform: uppercase;
@@ -259,47 +259,6 @@ a:focus-visible {
   margin-bottom: 0.5rem;
 }
 
-.landing-recent ul {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.landing-recent a {
-  color: var(--ink-soft);
-  font-size: 0.9rem;
-  text-decoration: none;
-  border-radius: 6px;
-  padding: 0.3rem 0.5rem;
-  margin: 0 -0.5rem;
-  display: block;
-  transition: background 120ms ease, color 120ms ease;
-}
-
-.landing-recent a:hover {
-  background: var(--accent-soft);
-  color: var(--ink);
-}
-
-.landing-recent-empty {
-  font-size: 0.8rem;
-  color: var(--ink-faint);
-  line-height: 1.5;
-}
-
-/* Recent rows: title link + optional claim icon / owner label inline. */
-.recent-row {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.recent-row a {
-  flex: 1;
-  min-width: 0;
-}
-
-.format-label,
 .doc-format {
   flex: none;
   color: var(--ink-faint);
@@ -311,16 +270,290 @@ a:focus-visible {
   white-space: nowrap;
 }
 
+/* ---------------------------- Document library -------------------------- */
+.document-library {
+  margin-top: 3.5rem;
+  text-align: left;
+}
+
+.document-library--recent {
+  margin-top: 2.75rem;
+}
+
+.document-library-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.8rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 28%, var(--line));
+}
+
+.document-library-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-doc);
+  font-size: 1.22rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.document-library-heading p {
+  margin: 0.2rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+}
+
+.document-tag-filters {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.document-tag-filters button {
+  min-height: 1.85rem;
+  border: 1px solid var(--ink-soft);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink-soft);
+  padding: 0.28rem 0.65rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.document-tag-filters button:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.document-tag-filters button.is-active {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.document-library-empty {
+  margin: 0;
+  padding: 1.2rem 0;
+  color: var(--ink-soft);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.document-groups {
+  display: grid;
+  gap: 1.5rem;
+  padding-top: 1.25rem;
+}
+
+.document-group-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.45rem;
+  padding-inline: 0.15rem;
+}
+
+.document-group-heading h3 {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.document-group-heading span {
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.document-list {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--ink) 24%, var(--line));
+  border-radius: 10px;
+  background: var(--surface-raised);
+  box-shadow: 0 1px 2px rgb(38 28 16 / 4%);
+}
+
+.document-row {
+  padding: 0.78rem 0.9rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 16%, var(--line));
+  transition: background 120ms ease;
+}
+
+.document-row:last-child {
+  border-bottom: 0;
+}
+
+.document-row:has(.document-row-title:hover),
+.document-row:has(.document-row-title:focus-visible) {
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface-raised));
+}
+
+.document-row-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.document-row-copy {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.document-row-title {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 0.93rem;
+  font-weight: 620;
+  line-height: 1.35;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.document-row-title:hover {
+  color: color-mix(in srgb, var(--accent) 68%, var(--ink));
+}
+
+.document-row-date {
+  color: var(--ink-soft);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.document-row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  flex: none;
+}
+
+.document-tags {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  margin-top: 0.55rem;
+}
+
+.document-tag {
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 58%, var(--ink));
+  padding: 0.2rem 0.48rem;
+  font-size: 0.65rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.document-tag-edit,
+.document-reveal,
+.document-tag-save,
+.document-tag-cancel {
+  border: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 0.7rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.document-tag-edit:hover,
+.document-reveal:hover,
+.document-tag-cancel:hover {
+  color: var(--ink);
+}
+
+.document-reveal {
+  justify-self: start;
+  padding: 0.2rem 0.15rem;
+}
+
+.document-tag-editor {
+  margin-top: 0.75rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid color-mix(in srgb, var(--ink) 16%, var(--line));
+}
+
+.document-tag-editor > label {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--ink);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.document-tag-editor-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.document-tag-editor input {
+  flex: 1;
+  min-width: 0;
+  height: 2.15rem;
+  border: 1px solid var(--ink-soft);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0.4rem 0.55rem;
+  font-size: 0.78rem;
+}
+
+.document-tag-save {
+  height: 2.15rem;
+  border-radius: 7px;
+  background: var(--ink);
+  color: var(--surface);
+  padding: 0.4rem 0.72rem;
+}
+
+.document-tag-save:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.document-tag-cancel {
+  height: 2.15rem;
+  padding: 0.4rem 0.3rem;
+}
+
+.document-tag-help,
+.document-tag-error {
+  margin: 0.32rem 0 0;
+  font-size: 0.67rem;
+  line-height: 1.4;
+}
+
+.document-tag-help {
+  color: var(--ink-soft);
+}
+
+.document-tag-error {
+  color: #9b2f27;
+}
+
 .recent-claim {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.6rem;
-  height: 1.6rem;
-  border: none;
+  width: 1.9rem;
+  height: 1.9rem;
+  border: 1px solid var(--ink-soft);
   border-radius: 6px;
   background: transparent;
-  color: var(--ink-faint);
+  color: var(--ink-soft);
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
@@ -337,8 +570,40 @@ a:focus-visible {
 
 .recent-owner {
   font-size: 0.72rem;
-  color: var(--ink-faint);
+  color: var(--ink-soft);
   white-space: nowrap;
+}
+
+@media (max-width: 40rem) {
+  .landing {
+    padding-inline: 1rem;
+  }
+
+  .document-library-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .document-tag-filters {
+    justify-content: flex-start;
+  }
+
+  .document-row-summary {
+    align-items: flex-start;
+  }
+
+  .document-row-actions {
+    flex-wrap: wrap;
+  }
+
+  .document-tag-editor-controls {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .document-tag-editor input {
+    flex-basis: 100%;
+  }
 }
 
 /* --------------------------- Agent create card ---------------------------- */

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -75,7 +75,7 @@ function TagEditor({ document, onClose }: { document: DocLink; onClose: () => vo
     }))
     form.patch(`/d/${document.slug}/tags`, {
       preserveScroll: true,
-      only: ['yours', 'recent'],
+      only: ['yours', 'recent', 'errors'],
       onSuccess: onClose,
     })
   }

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
@@ -8,32 +8,39 @@ import { useIsClient } from '../../lib/use_is_client'
 import type { OwnershipPayload } from '../../components/ownership_chip'
 import type { ViewerPayload } from '../../types/viewer'
 
-interface DocLink {
+type AgeGroup = 'this_week' | 'earlier'
+
+type DocLink = {
   title: string
   slug: string
-  content_format: 'markdown' | 'html'
+  tags: string[]
+  created_at: string
+  created_label: string
+  age_group: AgeGroup
 }
 
-interface RecentDoc extends DocLink, OwnershipPayload {}
+type RecentDoc = DocLink & OwnershipPayload
 
-interface Props {
+type Props = {
   yours: DocLink[]
   recent: RecentDoc[]
   viewer: ViewerPayload
 }
 
+const EARLIER_PREVIEW_LIMIT = 8
 const GITHUB_REPOSITORY_URL = 'https://github.com/kieranklaassen/thinkroom'
 const GITHUB_PROFILE_URL = 'https://github.com/kieranklaassen'
 
-/**
- * Inline claim icon for a claimable Recent row. On win the scoped reload
- * moves the row to "Your docs"; on a lost race the row re-renders with the
- * winner's name — no error modal (the hook swallows the Inertia error).
- */
+const errorText = (error: unknown): string | null => {
+  if (Array.isArray(error)) return error.find((value) => typeof value === 'string') ?? null
+  return typeof error === 'string' ? error : null
+}
+
 function RecentClaimButton({ slug, claimerName }: { slug: string; claimerName: string }) {
   const { claim, claiming, claimFailed } = useClaim(slug, claimerName, {
     only: ['yours', 'recent'],
   })
+
   return (
     <button
       className="recent-claim"
@@ -55,27 +62,169 @@ function RecentClaimButton({ slug, claimerName }: { slug: string; claimerName: s
   )
 }
 
+function TagEditor({ document, onClose }: { document: DocLink; onClose: () => void }) {
+  const form = useForm(`DocumentTags:${document.slug}`, {
+    tags: document.tags.join(', '),
+  })
+  const tagError = errorText(form.errors.tags)
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    form.transform((data) => ({
+      tags: data.tags.split(',').map((tag) => tag.trim()),
+    }))
+    form.patch(`/d/${document.slug}/tags`, {
+      preserveScroll: true,
+      only: ['yours', 'recent'],
+      onSuccess: onClose,
+    })
+  }
+
+  return (
+    <form className="document-tag-editor" onSubmit={submit}>
+      <label htmlFor={`tags-${document.slug}`}>Tags</label>
+      <div className="document-tag-editor-controls">
+        <input
+          id={`tags-${document.slug}`}
+          value={form.data.tags}
+          onChange={(event) => form.setData('tags', event.target.value)}
+          placeholder="Research, planning"
+          autoFocus
+          aria-describedby={`tags-help-${document.slug}`}
+          aria-invalid={Boolean(tagError)}
+        />
+        <button className="document-tag-save" type="submit" disabled={form.processing}>
+          {form.processing ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          className="document-tag-cancel"
+          type="button"
+          onClick={() => {
+            form.clearErrors()
+            onClose()
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+      <p id={`tags-help-${document.slug}`} className="document-tag-help">
+        Up to 8 tags, 32 characters each. Separate with commas.
+      </p>
+      {tagError && (
+        <p className="document-tag-error" role="alert">
+          {tagError}
+        </p>
+      )}
+    </form>
+  )
+}
+
+function DocumentTags({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null
+
+  return (
+    <div className="document-tags" aria-label="Tags">
+      {tags.map((tag) => (
+        <span className="document-tag" key={tag.toLowerCase()}>
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function DocumentRow({
+  document,
+  editable = false,
+  claimerName,
+}: {
+  document: DocLink | RecentDoc
+  editable?: boolean
+  claimerName?: string
+}) {
+  const [editingTags, setEditingTags] = useState(false)
+  const recentDocument = 'claimable' in document ? document : null
+
+  return (
+    <li className="document-row">
+      <div className="document-row-summary">
+        <div className="document-row-copy">
+          <Link className="document-row-title" href={`/d/${document.slug}`} prefetch>
+            {document.title}
+          </Link>
+          <time className="document-row-date" dateTime={document.created_at}>
+            Created {document.created_label}
+          </time>
+        </div>
+        <div className="document-row-actions">
+          {editable && (
+            <button
+              className="document-tag-edit"
+              type="button"
+              aria-expanded={editingTags}
+              onClick={() => setEditingTags((open) => !open)}
+            >
+              {document.tags.length > 0 ? 'Edit tags' : '+ Add tag'}
+            </button>
+          )}
+          {recentDocument?.claimable && claimerName && (
+            <RecentClaimButton slug={document.slug} claimerName={claimerName} />
+          )}
+          {recentDocument?.claimed && !recentDocument.yours && recentDocument.owner_name && (
+            <span className="recent-owner">Owned by {recentDocument.owner_name}</span>
+          )}
+        </div>
+      </div>
+      <DocumentTags tags={document.tags} />
+      {editingTags && <TagEditor document={document} onClose={() => setEditingTags(false)} />}
+    </li>
+  )
+}
+
+function DocumentGroup({
+  title,
+  documents,
+  editable,
+  claimerName,
+}: {
+  title: string
+  documents: Array<DocLink | RecentDoc>
+  editable?: boolean
+  claimerName?: string
+}) {
+  if (documents.length === 0) return null
+  const headingId = `document-group-${title.toLowerCase().replace(/\s+/g, '-')}`
+
+  return (
+    <section className="document-group" aria-labelledby={headingId}>
+      <div className="document-group-heading">
+        <h3 id={headingId}>{title}</h3>
+        <span>{documents.length}</span>
+      </div>
+      <ul className="document-list">
+        {documents.map((document) => (
+          <DocumentRow
+            key={document.slug}
+            document={document}
+            editable={editable}
+            claimerName={claimerName}
+          />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
 export default function DocumentsIndex({ yours, recent, viewer }: Props) {
-  // Lazy initializer: the chosen session name wins; guests post their
-  // random localStorage name as the fallback (the server prefers the
-  // session name on create anyway). Staying on useForm keeps the
-  // `processing` double-submit guard.
+  const [identityName] = useState(() => userIdentity(viewer.name).name)
   const { post, processing } = useForm(() => ({
-    name: userIdentity(viewer.name).name,
+    name: identityName,
   }))
   const [copied, setCopied] = useState(false)
-  // RiffrecRecorder (the Feedback button) is not SSR-isomorphic — its Node
-  // passthrough renders different markup than the browser build, so rendering
-  // it on the server would mismatch on hydration. Gate it as a client-only
-  // island: the corner shows AccountControl (SSR-safe) on first paint and the
-  // Feedback button mounts one frame later, after hydration. On the doc page
-  // FeedbackButton lives inside a closed HeaderMenu, so it never renders on
-  // first paint there — this gate is only needed where it renders eagerly.
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [showAllEarlier, setShowAllEarlier] = useState(false)
   const isClient = useIsClient()
 
-  // SSR-safe: the server and the client's first render both use an empty
-  // origin so the rendered agent instruction matches (no hydration mismatch);
-  // the real origin is filled in a post-hydration effect, one frame later.
   const [origin, setOrigin] = useState('')
   useEffect(() => {
     setOrigin(window.location.origin)
@@ -94,8 +243,26 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     })
   }, [agentInstruction])
 
-  const formatLabel = (format: DocLink['content_format']) =>
-    format === 'html' ? 'HTML' : 'Markdown'
+  const availableTags = yours.reduce<string[]>((tags, document) => {
+    document.tags.forEach((tag) => {
+      if (!tags.some((existingTag) => existingTag.toLowerCase() === tag.toLowerCase())) {
+        tags.push(tag)
+      }
+    })
+    return tags
+  }, [])
+  const activeTag = availableTags.includes(selectedTag ?? '') ? selectedTag : null
+  const visibleDocuments = activeTag
+    ? yours.filter((document) =>
+        document.tags.some((tag) => tag.toLowerCase() === activeTag.toLowerCase()),
+      )
+    : yours
+  const thisWeek = visibleDocuments.filter((document) => document.age_group === 'this_week')
+  const earlier = visibleDocuments.filter((document) => document.age_group === 'earlier')
+  const visibleEarlier =
+    showAllEarlier || activeTag ? earlier : earlier.slice(0, EARLIER_PREVIEW_LIMIT)
+  const hiddenEarlierCount = earlier.length - visibleEarlier.length
+  const claimerName = identityName
 
   return (
     <>
@@ -106,71 +273,101 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
           {isClient && <FeedbackButton />}
         </div>
         <main className="landing-main">
-          <h1 className="landing-wordmark">
-            <Link href="/" className="landing-wordmark-link">
-              Thinkroom
-            </Link>
-          </h1>
-          <p className="landing-tagline">Where deeper thinking compounds.</p>
-          <p className="landing-byline">From the creator of Compound Engineering.</p>
-          <div className="landing-actions">
-            <button
-              className="btn btn-primary"
-              type="button"
-              disabled={processing}
-              onClick={() => post('/documents')}
-            >
-              {processing ? 'Creating…' : 'New document'}
-            </button>
-            {recent.some((d) => d.slug === 'demo') && (
-              <Link href="/d/demo" className="btn btn-ghost" prefetch>
-                Open the demo
+          <header className="landing-hero">
+            <h1 className="landing-wordmark">
+              <Link href="/" className="landing-wordmark-link">
+                Thinkroom
               </Link>
-            )}
-          </div>
-          {yours.length > 0 && (
-            <section className="landing-recent">
-              <h2 className="landing-recent-heading">Your docs</h2>
-              <ul>
-                {yours.map((doc) => (
-                  <li key={doc.slug} className="recent-row">
-                    <Link href={`/d/${doc.slug}`} prefetch>
-                      {doc.title}
-                    </Link>
-                    <span className="format-label">{formatLabel(doc.content_format)}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-          <section className="landing-recent">
-            <h2 className="landing-recent-heading">Recent</h2>
-            {recent.length > 0 ? (
-              <ul>
-                {recent.map((doc) => (
-                  <li key={doc.slug} className="recent-row">
-                    <Link href={`/d/${doc.slug}`} prefetch>
-                      {doc.title}
-                    </Link>
-                    <span className="format-label">{formatLabel(doc.content_format)}</span>
-                    {doc.claimable && (
-                      <RecentClaimButton
-                        slug={doc.slug}
-                        claimerName={userIdentity(viewer.name).name}
-                      />
-                    )}
-                    {doc.claimed && !doc.yours && doc.owner_name && (
-                      <span className="recent-owner">Owned by {doc.owner_name}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
+            </h1>
+            <p className="landing-tagline">Where deeper thinking compounds.</p>
+            <p className="landing-byline">From the creator of Compound Engineering.</p>
+            <div className="landing-actions">
+              <button
+                className="btn btn-primary"
+                type="button"
+                disabled={processing}
+                onClick={() => post('/documents')}
+              >
+                {processing ? 'Creating…' : 'New document'}
+              </button>
+              {recent.some((document) => document.slug === 'demo') && (
+                <Link href="/d/demo" className="btn btn-ghost" prefetch>
+                  Open the demo
+                </Link>
+              )}
+            </div>
+          </header>
+
+          <section className="document-library" aria-labelledby="your-documents-heading">
+            <div className="document-library-heading">
+              <div>
+                <h2 id="your-documents-heading">Your documents</h2>
+                <p>{yours.length === 1 ? '1 document' : `${yours.length} documents`}</p>
+              </div>
+              {availableTags.length > 0 && (
+                <div className="document-tag-filters" aria-label="Filter documents by tag">
+                  <button
+                    className={activeTag === null ? 'is-active' : undefined}
+                    type="button"
+                    aria-pressed={activeTag === null}
+                    onClick={() => setSelectedTag(null)}
+                  >
+                    All
+                  </button>
+                  {availableTags.map((tag) => (
+                    <button
+                      className={activeTag === tag ? 'is-active' : undefined}
+                      type="button"
+                      key={tag.toLowerCase()}
+                      aria-pressed={activeTag === tag}
+                      onClick={() => setSelectedTag(tag)}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {yours.length === 0 ? (
+              <p className="document-library-empty">
+                Create a document and it will stay close at hand here.
+              </p>
+            ) : visibleDocuments.length === 0 ? (
+              <p className="document-library-empty">No documents use this tag yet.</p>
             ) : (
-              <p className="landing-recent-empty">
+              <div className="document-groups">
+                <DocumentGroup title="This week" documents={thisWeek} editable />
+                <DocumentGroup title="Earlier" documents={visibleEarlier} editable />
+                {hiddenEarlierCount > 0 && (
+                  <button
+                    className="document-reveal"
+                    type="button"
+                    onClick={() => setShowAllEarlier(true)}
+                  >
+                    Show {hiddenEarlierCount} more
+                  </button>
+                )}
+              </div>
+            )}
+          </section>
+
+          <section className="document-library document-library--recent" aria-labelledby="recent-documents-heading">
+            <div className="document-library-heading">
+              <div>
+                <h2 id="recent-documents-heading">Recently opened</h2>
+                <p>Documents from this browser</p>
+              </div>
+            </div>
+            {recent.length > 0 ? (
+              <DocumentGroup title="Recent" documents={recent} claimerName={claimerName} />
+            ) : (
+              <p className="document-library-empty">
                 Documents you open in this browser show up here.
               </p>
             )}
           </section>
+
           <section className="landing-agent">
             <h2 className="landing-recent-heading">Have an agent start a doc</h2>
             <p className="landing-agent-hint">

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,6 +5,8 @@ class Document < ApplicationRecord
   DEFAULT_HTML_SEED = "<h1>Untitled</h1><p>Start writing — everything you type is attributed to you.</p>"
   CONTENT_FORMATS = %w[markdown html].freeze
   MAX_CONTENT_BYTES = 2.megabytes
+  MAX_TAGS = 8
+  MAX_TAG_LENGTH = 32
 
   # A stale seed claim (seeder crashed or never connected before its first
   # update persisted) is reclaimable after this window.
@@ -33,6 +35,7 @@ class Document < ApplicationRecord
   belongs_to :user, optional: true
 
   before_validation :ensure_slug, on: :create
+  before_validation :normalize_tags
 
   validates :title, presence: true
   validates :slug, presence: true, uniqueness: true
@@ -49,6 +52,7 @@ class Document < ApplicationRecord
   # value written by a future code path would silently claim text as AI —
   # constrain the vocabulary at the model.
   validates :seed_author_kind, inclusion: { in: %w[human agent] }, allow_nil: true
+  validate :tags_are_bounded
 
   def to_param = slug
 
@@ -290,6 +294,27 @@ class Document < ApplicationRecord
   end
 
   private
+
+  def normalize_tags
+    seen = Set.new
+    self.tags = Array(tags).filter_map do |tag|
+      normalized = tag.to_s.squish
+      next if normalized.blank?
+
+      key = normalized.downcase
+      next if seen.include?(key)
+
+      seen << key
+      normalized
+    end
+  end
+
+  def tags_are_bounded
+    errors.add(:tags, "can include at most #{MAX_TAGS} tags") if tags.length > MAX_TAGS
+    return unless tags.any? { |tag| tag.length > MAX_TAG_LENGTH }
+
+    errors.add(:tags, "must be #{MAX_TAG_LENGTH} characters or fewer")
+  end
 
   def content_format_is_immutable
     errors.add(:content_format, "cannot be changed") if will_save_change_to_content_format?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
+  patch "d/:slug/tags", to: "documents#update_tags", as: :document_tags
   patch "d/:slug/editing_lock", to: "documents#update_editing_lock", as: :document_editing_lock
   delete "d/:slug", to: "documents#destroy", as: :destroy_document
   post "d/:slug/snapshot", to: "documents#snapshot", as: :document_snapshot

--- a/db/migrate/20260626110000_add_tags_to_documents.rb
+++ b/db/migrate/20260626110000_add_tags_to_documents.rb
@@ -1,0 +1,5 @@
+class AddTagsToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :tags, :json, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_110000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -102,6 +102,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_100000) do
     t.text "seed_markdown"
     t.string "seed_state", default: "pending", null: false
     t.string "slug", null: false
+    t.json "tags", default: [], null: false
     t.string "title", default: "Untitled", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"

--- a/docs/plans/2026-06-26-003-feat-organized-document-index-plan.md
+++ b/docs/plans/2026-06-26-003-feat-organized-document-index-plan.md
@@ -1,0 +1,156 @@
+---
+title: "feat: Organize the document index"
+type: feat
+date: 2026-06-26
+---
+
+# feat: Organize the document index
+
+## Summary
+
+Redesign the home-page document lists into a higher-contrast library with creation dates, stable “This week” and “Earlier” groups, tag filtering, and owner-controlled inline tag editing. Remove format badges from the index and keep recent-document claiming intact.
+
+---
+
+## Problem Frame
+
+The index treats documents as a low-contrast stream of title links with implementation-format labels that do not help someone find or organize their work. As ownership accumulates up to 50 documents, the list becomes difficult to scan because it has no time hierarchy, visible creation context, or user-defined grouping.
+
+The index is also server-rendered. Any time grouping or date label rendered from the browser clock could differ from the server render and create hydration drift, so the presentation contract must arrive in the Inertia props.
+
+---
+
+## Requirements
+
+### Document hierarchy and metadata
+
+- R1. Index rows omit Markdown and HTML format labels while preserving document-format behavior everywhere else.
+- R2. Every owned and recently opened document row shows a concise creation date backed by a machine-readable date value.
+- R3. Owned documents are grouped into “This week” and “Earlier” using a server-derived boundary that renders identically during SSR and hydration.
+- R4. The earlier group initially shows eight rows and offers an in-place reveal control for the remainder so a large library stays compact without dropping records.
+
+### Tags and organization
+
+- R5. Document owners can add, rename, and remove up to eight normalized tags of 32 characters each from the index without leaving the page.
+- R6. Owned-document tags appear as compact chips and provide an “All” plus per-tag filter that preserves the time groups within the filtered result.
+- R7. Tag mutation is enforced as owner-only on the server for both signed-in and guest-token ownership, and validation failures remain visible in the edited row.
+
+### Visual and behavioral continuity
+
+- R8. The document library uses stronger title, metadata, divider, hover, and focus contrast while remaining consistent with the existing warm-paper design tokens; text and interactive states meet WCAG AA contrast.
+- R9. Recent-document empty states, claim actions, ownership labels, new-document creation, agent instructions, account controls, and footer behavior continue to work.
+- R10. The revised library remains usable on narrow screens, including wrapped tag chips, non-overlapping metadata, and reachable edit/reveal controls.
+
+---
+
+## Assumptions
+
+- Tags are shared document metadata: anyone who encounters the document in their recent list can see them, but only the owner can change them.
+- This iteration keeps tagging focused on the human index. Agent API creation, API tag mutation, dedicated tag-management pages, and tag display inside the editor are outside scope.
+- “This week” follows the Rails application time zone and its configured beginning of week, which keeps SSR deterministic. The date label is intentionally day-level rather than relative-time copy that can become stale.
+- The “Earlier” reveal is ephemeral UI state. It does not paginate, change the existing 50-document ownership cap, or add URL state.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Store tags as a constrained JSON array on each document:** A join model would add identity, lifecycle, and query complexity that this single-owner organization surface does not need. Model normalization and validation will keep the array bounded and predictable.
+- KTD2. **Keep server props as the index source of truth:** `DocumentsController#index` will serialize tags, an ISO creation date, a display label, and a stable age group. React will filter and render those props without a second fetch lifecycle.
+- KTD3. **Use an owner-only PRG mutation endpoint:** Inline editors submit through Inertia to a dedicated document-tags route, then redirect back and partially reload the document lists. The controller repeats ownership enforcement even though the edit affordance is hidden for non-owners.
+- KTD4. **Filter locally, mutate on the server:** The owned library is already capped at 50 records, so tag filtering and earlier-list expansion are cheap ephemeral state. Persisted tags and authorization remain server-owned.
+- KTD5. **Preserve the existing index SSR contract:** Grouping, labels, default expansion, and initial markup must not depend on `window`, locale-specific browser formatting, or a post-mount regrouping pass. This follows the server-first pattern documented in `docs/solutions/architecture-patterns/server-first-instant-paint.md`.
+
+---
+
+## Scope Boundaries
+
+### Included
+
+- Home-page owned and recent document lists, their responsive styling, creation metadata, and existing claim/owner affordances.
+- Persistent document tags, owner-only tag mutation, tag chips, and owned-library tag filtering.
+- Regression coverage for the model contract, Inertia props, authorization, grouping metadata, and browser-visible interactions.
+
+### Outside this change
+
+- Changing Markdown or HTML editing, creation, export, or API contracts.
+- Searching document contents, sorting controls, pagination, folders, nested tags, tag colors, or a standalone taxonomy manager.
+- Raising or removing the existing 50-owned-document and 12-recent-document caps.
+- Reworking the hero, agent instruction card, account controls, footer, or overall product branding beyond spacing needed to fit the wider library.
+
+---
+
+## Implementation Units
+
+### U1. Persistent document tag contract
+
+- **Goal:** Add bounded, normalized tag metadata to documents without changing existing records or content behavior.
+- **Requirements:** R5, R7.
+- **Dependencies:** None.
+- **Files:** `db/migrate/20260626110000_add_tags_to_documents.rb`, `db/schema.rb`, `app/models/document.rb`, `test/models/document_test.rb`.
+- **Approach:** Add a non-null JSON-array column with an empty default. Normalize whitespace, discard blanks, and deduplicate case-insensitively before validation; cap the array at eight tags and each tag at 32 characters at the model boundary so browser and future callers share one contract.
+- **Patterns to follow:** Existing JSON defaults on `documents.provenance_spans`; model-owned normalization near `Document.normalize_display_name`; immutable document-format validation as an example of enforcing storage invariants in `Document`.
+- **Test scenarios:** A document defaults to no tags; whitespace and blank entries normalize away; case-insensitive duplicates collapse while the first display spelling survives; the maximum accepted count and length save; over-limit count or length is rejected; existing documents remain valid after migration.
+- **Verification:** The migrated schema loads from scratch, model tests exercise valid and invalid boundaries, and unrelated document tests remain green.
+
+### U2. Owner-only tag mutation and index presentation props
+
+- **Goal:** Expose stable date/group/tag props and let only owners update tags through the browser flow.
+- **Requirements:** R2, R3, R5, R7, R9.
+- **Dependencies:** U1.
+- **Files:** `config/routes.rb`, `app/controllers/documents_controller.rb`, `test/integration/document_index_test.rb`, `test/integration/ownership_flow_test.rb`, `test/integration/home_claim_test.rb`.
+- **Approach:** Centralize index-row serialization in the controller so owned and recent rows receive the same safe metadata shape. Derive `this_week` versus `earlier` and a compact date label with `Time.zone`, add a dedicated PATCH action, enforce `owned_by?` for both account and guest ownership, and return keyed Inertia errors on invalid or unauthorized updates.
+- **Patterns to follow:** Explicit `render inertia: ... props:` in `DocumentsController#index`; ownership checks and redirect/error behavior in `destroy` and `update_editing_lock`; scoped `only: ['yours', 'recent']` reloads in the existing claim flow.
+- **Test scenarios:** Index props include tags, machine date, display date, and the correct boundary group; a guest-token owner and signed-in owner can replace tags; non-owners cannot mutate tags; invalid tags leave persisted values unchanged and return a `tags` error; a missing document redirects safely; recent rows preserve ownership/claim props and never expose ownership tokens.
+- **Verification:** Focused integration tests demonstrate the serialized contract and every authorization branch while existing claim and ownership regressions still pass.
+
+### U3. Scannable grouped library and inline tag editing
+
+- **Goal:** Replace the flat low-contrast rows with a compact, responsive document library that supports time grouping, filtering, and tag editing.
+- **Requirements:** R1-R10.
+- **Dependencies:** U2.
+- **Files:** `app/frontend/pages/documents/index.tsx`, `app/frontend/entrypoints/application.css`, `script/browser_check.mjs`.
+- **Approach:** Introduce small render-only row, group, filter, and tag-editor components inside the page. Render owned documents under stable time headings, truncate the initial earlier set with an accessible reveal button, derive tag filters from owned-document props, and submit per-row edits through keyed `useForm` instances with scroll preservation and scoped prop reloads. Recent rows reuse the clearer title/date/tag treatment while keeping claim and owner affordances.
+- **Patterns to follow:** Existing Inertia `Link`, `useForm`, and `useClaim` behavior in `documents/index.tsx`; existing design tokens and focus-visible rules in `application.css`; SSR-safe rendering conventions from `docs/solutions/architecture-patterns/server-first-instant-paint.md`.
+- **Test scenarios:** No index row displays Markdown or HTML labels; this-week and earlier headings render from server props; only eight earlier rows render before the reveal control is activated; selecting a tag filters both time groups and exposes a useful empty result when needed; adding/removing tags updates chips after the redirect; invalid input keeps the editor open with its error; claim success still moves a recent document to owned; narrow viewport rows wrap without horizontal overflow; keyboard focus reaches filter, edit, save, cancel, claim, and reveal controls; text and control states meet WCAG AA contrast.
+- **Verification:** The focused Rails suite, full TypeScript check, production Vite build, browser smoke checks, and interactive Playwright inspection complete without console, hydration, accessibility, contrast, or overflow errors.
+
+---
+
+## System-Wide Impact
+
+- **Data lifecycle:** The migration is additive and gives every existing document an empty tag array. No backfill or content/Yjs transformation is required.
+- **Authorization:** Tag visibility is read-only public metadata for anyone already able to see a document row; mutation follows document ownership, not the broader collaborative write permission used for content.
+- **SSR and Inertia:** The server continues to own initial page data and all persisted state. React owns only the selected filter, per-row editor visibility, and earlier-list expansion.
+- **Agent parity:** Agents continue to create, read, and edit document content through the existing API. Tagging is intentionally a human-library action in this iteration and does not change agent guide or API contracts.
+- **Performance:** The index retains its current record caps. JSON tag arrays and local filtering add bounded work and no additional index query.
+
+---
+
+## Risks and Dependencies
+
+- **Shared metadata surprise:** Document-level tags are visible to collaborators who encounter the document. The UI should avoid implying that tags are private, and API parity should be reconsidered before tags become workflow-critical.
+- **Migration safety:** A nullable or object-shaped legacy value would complicate rendering. The database default, non-null constraint, normalization, and model tests must keep the value an array.
+- **Authorization drift:** Collaborative write access is broader than ownership. The new action must call the ownership predicate directly and be covered for signed-in, guest-token, and non-owner requests.
+- **Hydration drift:** Browser-local date formatting or week calculations can change the first render. All visible date/group props must be serialized by Rails, with React consuming them verbatim.
+- **Dense mobile rows:** Dates, tags, owner labels, and controls can compete for space. The row layout must use wrapping and title truncation intentionally, then be checked at the existing mobile breakpoints.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given an owner with documents created this week and earlier, when they open the index, then each document appears once under the correct heading with its creation date and no format badge.
+- AE2. Given more earlier documents than the compact threshold, when the owner opens the index, then only the initial earlier set is shown until they activate the reveal control without leaving or scrolling to the top of the page.
+- AE3. Given an owner editing a document’s comma-separated tags, when they save valid values, then normalized chips appear on the row and the tag filter updates after the Inertia redirect.
+- AE4. Given a non-owner who submits a crafted tag update, when the request reaches the server, then no tag changes and the response returns an ownership error through the normal Inertia redirect flow.
+- AE5. Given a selected tag that exists in both time groups, when the owner selects it, then only matching rows remain while the “This week” and “Earlier” hierarchy is preserved.
+- AE6. Given an unclaimed recently opened document, when the user claims it from the revised row, then it moves into the owned library with its date and tags and disappears from Recent.
+
+---
+
+## Sources and Research
+
+- `app/frontend/pages/documents/index.tsx` and `app/frontend/entrypoints/application.css` define the current flat list, format labels, claim control, SSR-safe client islands, and warm-paper visual tokens.
+- `app/controllers/documents_controller.rb` defines the 50-owned/12-recent caps, explicit Inertia props, session recents, account/guest ownership split, and existing mutation authorization patterns.
+- `test/integration/home_claim_test.rb` and `test/integration/ownership_flow_test.rb` provide the regression patterns for list movement, claim races, ownership isolation, and Inertia prop assertions.
+- `docs/solutions/architecture-patterns/server-first-instant-paint.md` establishes the repo’s server-first, hydration-stable rendering posture.
+- `STRATEGY.md` frames the index as the human-facing judgment layer; tag organization supports deliberate retrieval without expanding Thinkroom into an embedded-agent or chat product.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -48,6 +48,34 @@ try {
     fail('landing page still exposes document format labels')
   }
 
+  await landing.getByRole('button', { name: 'New document' }).click()
+  await landing.waitForURL(/\/d\//)
+  await landing.goto(BASE)
+  await landing.getByRole('button', { name: /Add tag/ }).first().click()
+  await landing
+    .getByLabel('Tags')
+    .fill('one, two, three, four, five, six, seven, eight, nine')
+  await landing.getByRole('button', { name: 'Save' }).click()
+  await landing.getByRole('alert').waitFor()
+  if (
+    (await landing.getByLabel('Tags').isVisible()) &&
+    (await landing.getByRole('alert').innerText()).includes('at most 8 tags')
+  ) {
+    ok('invalid tags keep the inline editor open with an error')
+  } else {
+    fail('invalid tags did not remain visible in the inline editor')
+  }
+  await landing.getByLabel('Tags').fill('Research, Planning')
+  await landing.getByRole('button', { name: 'Save' }).click()
+  await landing.locator('.document-tag-editor input').waitFor({ state: 'detached' })
+  if (
+    (await landing.locator('.document-tag', { hasText: 'Research' }).count()) === 1 &&
+    (await landing.locator('.document-tag', { hasText: 'Planning' }).count()) === 1
+  ) {
+    ok('valid tags update the row without leaving the index')
+  } else {
+    fail('saved tags did not update the document row')
+  }
   await landing.close()
 
   const a = await makePage('a')

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -40,6 +40,14 @@ try {
     fail('landing page does not use the approved Thinkroom tagline')
   }
   await landing.locator('.landing-byline', { hasText: 'creator of Compound Engineering' }).waitFor()
+  await landing.getByRole('heading', { name: 'Your documents' }).waitFor()
+  await landing.getByRole('heading', { name: 'Recently opened' }).waitFor()
+  if ((await landing.locator('.format-label').count()) === 0) {
+    ok('landing page organizes documents without format labels')
+  } else {
+    fail('landing page still exposes document format labels')
+  }
+
   await landing.close()
 
   const a = await makePage('a')

--- a/test/integration/document_index_test.rb
+++ b/test/integration/document_index_test.rb
@@ -80,7 +80,9 @@ class DocumentIndexTest < ActionDispatch::IntegrationTest
     )
     establish_identity
 
-    patch document_tags_path(document.slug), params: { tags: [ "Changed" ] }
+    patch document_tags_path(document.slug),
+          params: { tags: [ "Changed" ] },
+          headers: inertia_headers
 
     assert_response :see_other
     assert_equal [ "Original" ], document.reload.tags
@@ -92,12 +94,16 @@ class DocumentIndexTest < ActionDispatch::IntegrationTest
     document = Document.order(:created_at).last
     document.update!(tags: [ "Original" ])
 
-    patch document_tags_path(document.slug), params: {
-      tags: Array.new(Document::MAX_TAGS + 1) { |index| "tag-#{index}" }
-    }
+    patch document_tags_path(document.slug),
+          params: { tags: Array.new(Document::MAX_TAGS + 1) { |index| "tag-#{index}" } },
+          headers: inertia_headers
 
     assert_response :see_other
     assert_equal [ "Original" ], document.reload.tags
+    get root_path, headers: inertia_headers
+    assert_inertia_props do |props|
+      props.dig(:errors, :tags) == "can include at most 8 tags"
+    end
   end
 
   test "tag endpoint rejects non list input and redirects missing documents safely" do
@@ -105,7 +111,9 @@ class DocumentIndexTest < ActionDispatch::IntegrationTest
     post documents_path, params: { name: "Guest owner" }
     document = Document.order(:created_at).last
 
-    patch document_tags_path(document.slug), params: { tags: "not-a-list" }
+    patch document_tags_path(document.slug),
+          params: { tags: "not-a-list" },
+          headers: inertia_headers
     assert_response :see_other
     assert_equal [], document.reload.tags
 
@@ -114,6 +122,14 @@ class DocumentIndexTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def inertia_headers
+    {
+      "X-Inertia" => "true",
+      "X-Inertia-Partial-Component" => "documents/index",
+      "X-Inertia-Partial-Data" => "yours,recent,errors"
+    }
+  end
 
   def create_and_sign_in_user
     user = User.create!(

--- a/test/integration/document_index_test.rb
+++ b/test/integration/document_index_test.rb
@@ -1,0 +1,128 @@
+require "test_helper"
+
+class DocumentIndexTest < ActionDispatch::IntegrationTest
+  def establish_identity
+    get root_path
+    assert_response :success
+  end
+
+  test "index serializes stable date groups and tags for owned and recent documents" do
+    establish_identity
+    week_start = Time.current.beginning_of_week
+    this_week = Document.create!(
+      title: "This week",
+      created_at: week_start + 1.hour,
+      tags: [ "Research" ]
+    )
+    earlier = Document.create!(
+      title: "Earlier",
+      created_at: week_start - 1.second,
+      tags: [ "Archive" ]
+    )
+    recent = Document.create!(
+      title: "Recent",
+      created_at: week_start - 2.days,
+      tags: [ "Shared" ]
+    )
+    post claim_document_path(this_week.slug), params: { name: "Me" }
+    post claim_document_path(earlier.slug), params: { name: "Me" }
+    get document_page_path(recent.slug), headers: { "User-Agent" => "Mozilla/5.0" }
+
+    get root_path
+    assert_inertia_props do |props|
+      week_row = props[:yours].find { |row| row[:slug] == this_week.slug }
+      earlier_row = props[:yours].find { |row| row[:slug] == earlier.slug }
+      recent_row = props[:recent].find { |row| row[:slug] == recent.slug }
+
+      week_row[:age_group] == "this_week" &&
+        week_row[:tags] == [ "Research" ] &&
+        week_row[:created_at] == this_week.created_at.iso8601 &&
+        week_row[:created_label] == this_week.created_at.strftime("%b %-d") &&
+        earlier_row[:age_group] == "earlier" &&
+        recent_row[:age_group] == "earlier" &&
+        recent_row[:tags] == [ "Shared" ] &&
+        recent_row[:claimable] == true
+    end
+  end
+
+  test "guest owner can replace and clear tags" do
+    establish_identity
+    post documents_path, params: { name: "Guest owner" }
+    document = Document.order(:created_at).last
+
+    patch document_tags_path(document.slug), params: {
+      tags: [ " Product   Strategy ", "Research" ]
+    }
+    assert_response :see_other
+    assert_equal [ "Product Strategy", "Research" ], document.reload.tags
+
+    patch document_tags_path(document.slug), params: { tags: [] }
+    assert_response :see_other
+    assert_equal [], document.reload.tags
+  end
+
+  test "signed in owner can replace tags" do
+    user = create_and_sign_in_user
+    document = Document.create!(title: "Account doc", user:, owner_name: user.name)
+
+    patch document_tags_path(document.slug), params: { tags: [ "Planning" ] }
+
+    assert_response :see_other
+    assert_equal [ "Planning" ], document.reload.tags
+  end
+
+  test "non owner cannot change tags" do
+    document = Document.create!(
+      title: "Someone else's",
+      owner_token: "another-browser",
+      owner_name: "Other",
+      tags: [ "Original" ]
+    )
+    establish_identity
+
+    patch document_tags_path(document.slug), params: { tags: [ "Changed" ] }
+
+    assert_response :see_other
+    assert_equal [ "Original" ], document.reload.tags
+  end
+
+  test "invalid tag input leaves persisted tags unchanged" do
+    establish_identity
+    post documents_path, params: { name: "Guest owner" }
+    document = Document.order(:created_at).last
+    document.update!(tags: [ "Original" ])
+
+    patch document_tags_path(document.slug), params: {
+      tags: Array.new(Document::MAX_TAGS + 1) { |index| "tag-#{index}" }
+    }
+
+    assert_response :see_other
+    assert_equal [ "Original" ], document.reload.tags
+  end
+
+  test "tag endpoint rejects non list input and redirects missing documents safely" do
+    establish_identity
+    post documents_path, params: { name: "Guest owner" }
+    document = Document.order(:created_at).last
+
+    patch document_tags_path(document.slug), params: { tags: "not-a-list" }
+    assert_response :see_other
+    assert_equal [], document.reload.tags
+
+    patch document_tags_path("missing"), params: { tags: [ "Ignored" ] }
+    assert_redirected_to root_path
+  end
+
+  private
+
+  def create_and_sign_in_user
+    user = User.create!(
+      name: "Account owner",
+      email: "owner@example.com",
+      password: "thoughtful-passphrase"
+    )
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase" }
+    assert_response :see_other
+    user
+  end
+end

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -55,6 +55,38 @@ class DocumentTest < ActiveSupport::TestCase
     assert doc.errors[:content_format].present?
   end
 
+  test "tags default to an empty list" do
+    assert_equal [], Document.create!(title: "Untagged").tags
+  end
+
+  test "tags normalize whitespace and deduplicate without losing display case" do
+    doc = Document.create!(
+      title: "Tagged",
+      tags: [ "  Product   Strategy ", "product strategy", "", "Research" ]
+    )
+
+    assert_equal [ "Product Strategy", "Research" ], doc.tags
+  end
+
+  test "tags enforce count and length limits" do
+    valid = Document.new(
+      title: "At the boundary",
+      tags: Array.new(Document::MAX_TAGS) { |index| "#{index}-#{"x" * 30}" }
+    )
+    assert valid.valid?
+
+    too_many = Document.new(
+      title: "Too many",
+      tags: Array.new(Document::MAX_TAGS + 1) { |index| "tag-#{index}" }
+    )
+    assert_not too_many.valid?
+    assert_includes too_many.errors[:tags], "can include at most 8 tags"
+
+    too_long = Document.new(title: "Too long", tags: [ "x" * (Document::MAX_TAG_LENGTH + 1) ])
+    assert_not too_long.valid?
+    assert_includes too_long.errors[:tags], "must be 32 characters or fewer"
+  end
+
   test "format-neutral source accessors use existing columns" do
     doc = Document.new(seed_content: "<p>Seed</p>", content_snapshot: "<p>Snapshot</p>")
 


### PR DESCRIPTION
## Summary

- replace the flat, low-contrast document stream with a clearer library grouped into This week and Earlier
- show creation dates, remove Markdown/HTML badges, and collapse long older lists behind an in-place reveal
- add normalized owner-managed document tags, visible chips, and local tag filtering
- preserve recent-document claim and ownership behavior while improving responsive and keyboard-accessible states

## Why

The index becomes difficult to scan as document ownership grows. Format labels add implementation detail without helping retrieval, while the previous list lacked time hierarchy and user-defined organization.

Tags are stored as a bounded JSON array (up to 8 tags, 32 characters each) and mutations repeat guest/account ownership checks on the server. Date labels and week groups are serialized by Rails to keep SSR and hydration deterministic.

## Validation

- `PARALLEL_WORKERS=1 bin/rails test` — 372 runs, 1,756 assertions
- `bin/rubocop` — 111 files, no offenses
- `npm run check`
- `bin/vite build`
- browser-tested on desktop and 390px mobile: grouping, eight-row reveal, tag filtering, valid/invalid tag editing, keyboard focus, contrast, overflow, and console errors

The production build retains existing CSS `::highlight` and large-chunk warnings.