### PR TITLE
fix: make sketches follow the reading theme

### DIFF
--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -35,6 +35,41 @@
 
   --code-bg: #f3f0e9;
   --measure: 44rem;
+
+  --sketch-surface: #fffef9;
+  --sketch-surface-muted: #fffaf1;
+  --sketch-border: rgb(65 51 32 / 12%);
+  --sketch-border-soft: rgb(65 51 32 / 10%);
+  --sketch-caption-ink: #6f6a60;
+  --sketch-radius: 12px;
+  --sketch-radius-mobile: 9px;
+  --sketch-inner-radius: 11px;
+  --sketch-island-radius: 10px;
+  --sketch-control-radius: 7px;
+  --sketch-shadow:
+    0 1px 1px rgb(38 28 16 / 5%),
+    0 7px 18px rgb(38 28 16 / 7%);
+  --sketch-shadow-hover:
+    0 1px 1px rgb(38 28 16 / 5%),
+    0 10px 23px rgb(38 28 16 / 9%);
+  --sketch-shadow-selected:
+    0 0 0 2px color-mix(in srgb, var(--accent-soft) 45%, transparent),
+    0 8px 22px rgb(38 28 16 / 8%);
+  --sketch-edge:
+    inset 0 1px rgb(255 255 255 / 72%),
+    inset 0 -1px rgb(65 51 32 / 6%);
+  --sketch-island-shadow: 0 5px 16px rgb(38 28 16 / 8%);
+  --sketch-control-shadow: 0 3px 10px rgb(38 28 16 / 9%);
+  --sketch-texture: radial-gradient(rgb(83 63 36 / 5%) 0.55px, transparent 0.55px);
+  --sketch-texture-size: 5px 5px;
+  --sketch-resize-border: rgb(65 51 32 / 9%);
+  --sketch-resize-thumb: rgb(65 51 32 / 18%);
+  --sketch-resize-thumb-active: rgb(65 51 32 / 34%);
+  --sketch-danger: #a1372c;
+  --sketch-danger-border: rgb(161 55 44 / 35%);
+  --sketch-danger-soft-border: rgb(161 55 44 / 18%);
+  --sketch-danger-hover-border: rgb(161 55 44 / 22%);
+  --sketch-danger-hover-bg: #f6ddd5;
 }
 
 /* Whitey — homage to Typora's Whitey theme: clean white, minimal chrome,
@@ -65,6 +100,33 @@
 
   --code-bg: #f8f8f8;
   --measure: 47rem;
+
+  --sketch-surface: #ffffff;
+  --sketch-surface-muted: #f8f8f8;
+  --sketch-border: rgb(43 43 43 / 18%);
+  --sketch-border-soft: rgb(43 43 43 / 12%);
+  --sketch-caption-ink: #666666;
+  --sketch-radius: 0px;
+  --sketch-radius-mobile: 0px;
+  --sketch-inner-radius: 0px;
+  --sketch-island-radius: 0px;
+  --sketch-control-radius: 0px;
+  --sketch-shadow: none;
+  --sketch-shadow-hover: none;
+  --sketch-shadow-selected: 0 0 0 2px rgb(65 131 196 / 18%);
+  --sketch-edge: none;
+  --sketch-island-shadow: none;
+  --sketch-control-shadow: none;
+  --sketch-texture: none;
+  --sketch-texture-size: auto;
+  --sketch-resize-border: rgb(43 43 43 / 14%);
+  --sketch-resize-thumb: rgb(43 43 43 / 28%);
+  --sketch-resize-thumb-active: rgb(43 43 43 / 50%);
+  --sketch-danger: #4f4f4f;
+  --sketch-danger-border: rgb(43 43 43 / 28%);
+  --sketch-danger-soft-border: rgb(43 43 43 / 14%);
+  --sketch-danger-hover-border: rgb(43 43 43 / 42%);
+  --sketch-danger-hover-bg: #eeeeee;
 }
 
 [data-theme='whitey'] .milkdown .ProseMirror {
@@ -3122,10 +3184,8 @@ a:focus-visible {
 
 .thinkroom-sketch.is-editing {
   cursor: default;
-  border-color: rgb(65 51 32 / 12%);
-  box-shadow:
-    0 1px 1px rgb(38 28 16 / 5%),
-    0 7px 18px rgb(38 28 16 / 7%);
+  border-color: var(--sketch-border);
+  box-shadow: var(--sketch-shadow);
 }
 
 .thinkroom-sketch.is-editing .thinkroom-sketch-preview {
@@ -3139,16 +3199,16 @@ a:focus-visible {
 .thinkroom-sketch-editor {
   position: relative;
   overflow: visible;
-  border-radius: 11px;
-  background: #fffef9;
+  border-radius: var(--sketch-inner-radius);
+  background: var(--sketch-surface);
 }
 
 .sketch-inline-canvas {
   position: relative;
   min-height: 180px;
   overflow: hidden;
-  border-radius: 11px 11px 0 0;
-  background: #fffef9;
+  border-radius: var(--sketch-inner-radius) var(--sketch-inner-radius) 0 0;
+  background: var(--sketch-surface);
   touch-action: none;
 }
 
@@ -3176,13 +3236,13 @@ a:focus-visible {
 
 .thinkroom-sketch-editor .excalidraw .Island {
   border: 1px solid color-mix(in srgb, var(--ink) 9%, transparent);
-  border-radius: 10px;
-  box-shadow: 0 5px 16px rgb(38 28 16 / 8%);
+  border-radius: var(--sketch-island-radius);
+  box-shadow: var(--sketch-island-shadow);
 }
 
 .thinkroom-sketch-editor .excalidraw .ToolIcon__icon,
 .thinkroom-sketch-editor .excalidraw .dropdown-menu-button {
-  border-radius: 7px;
+  border-radius: var(--sketch-control-radius);
 }
 
 /* Thinkroom sketches stay intentionally small: drawing tools, not the
@@ -3209,9 +3269,9 @@ a:focus-visible {
   display: grid;
   place-items: center;
   height: 20px;
-  border-top: 1px solid rgb(65 51 32 / 9%);
+  border-top: 1px solid var(--sketch-resize-border);
   border-radius: 0;
-  background: #fffaf1;
+  background: var(--sketch-surface-muted);
   cursor: row-resize;
   touch-action: none;
 }
@@ -3219,13 +3279,13 @@ a:focus-visible {
 .sketch-resize-handle span {
   width: 38px;
   height: 4px;
-  border-radius: 999px;
-  background: rgb(65 51 32 / 18%);
+  border-radius: var(--sketch-control-radius);
+  background: var(--sketch-resize-thumb);
 }
 
 .sketch-resize-handle:hover span,
 .sketch-resize-handle:focus-visible span {
-  background: rgb(65 51 32 / 34%);
+  background: var(--sketch-resize-thumb-active);
 }
 
 .sketch-resize-handle:focus-visible {
@@ -3259,7 +3319,7 @@ a:focus-visible {
 .sketch-button {
   min-height: 34px;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--sketch-control-radius);
   background: var(--surface-raised);
   color: var(--ink);
   padding: 6px 11px;
@@ -3278,15 +3338,15 @@ a:focus-visible {
 }
 
 .sketch-button-danger {
-  border-color: rgb(161 55 44 / 35%);
-  color: #a1372c;
+  border-color: var(--sketch-danger-border);
+  color: var(--sketch-danger);
 }
 
 .sketch-error {
   margin: 0;
-  border-top: 1px solid rgb(161 55 44 / 18%);
+  border-top: 1px solid var(--sketch-danger-soft-border);
   padding: 7px 10px;
-  color: #a1372c;
+  color: var(--sketch-danger);
   font-size: 12px;
 }
 
@@ -3296,12 +3356,10 @@ a:focus-visible {
   width: 100%;
   margin: 24px 0;
   overflow: visible;
-  border: 1px solid rgb(65 51 32 / 12%);
-  border-radius: 12px;
-  background: #fffef9;
-  box-shadow:
-    0 1px 1px rgb(38 28 16 / 5%),
-    0 7px 18px rgb(38 28 16 / 7%);
+  border: 1px solid var(--sketch-border);
+  border-radius: var(--sketch-radius);
+  background: var(--sketch-surface);
+  box-shadow: var(--sketch-shadow);
 }
 
 /* A fine inset edge keeps the paper tactile without reading as a stack. */
@@ -3310,9 +3368,7 @@ a:focus-visible {
   z-index: 3;
   inset: 0;
   border-radius: inherit;
-  box-shadow:
-    inset 0 1px rgb(255 255 255 / 72%),
-    inset 0 -1px rgb(65 51 32 / 6%);
+  box-shadow: var(--sketch-edge);
   content: '';
   pointer-events: none;
 }
@@ -3338,23 +3394,17 @@ a:focus-visible {
 
 .thinkroom-sketch.is-editable:hover:not(.is-editing) {
   border-color: color-mix(in srgb, var(--ink) 42%, transparent);
-  box-shadow:
-    0 1px 1px rgb(38 28 16 / 5%),
-    0 10px 23px rgb(38 28 16 / 9%);
+  box-shadow: var(--sketch-shadow-hover);
 }
 
 .thinkroom-sketch.is-selected {
   border-color: color-mix(in srgb, var(--accent) 34%, transparent);
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--accent-soft) 45%, transparent),
-    0 8px 22px rgb(38 28 16 / 8%);
+  box-shadow: var(--sketch-shadow-selected);
 }
 
 .thinkroom-sketch.is-editing.is-selected {
-  border-color: rgb(65 51 32 / 12%);
-  box-shadow:
-    0 1px 1px rgb(38 28 16 / 5%),
-    0 7px 18px rgb(38 28 16 / 7%);
+  border-color: var(--sketch-border);
+  box-shadow: var(--sketch-shadow);
 }
 
 .sketch-delete-tape {
@@ -3388,9 +3438,9 @@ a:focus-visible {
 }
 
 .sketch-delete-tape:hover {
-  border-color: rgb(161 55 44 / 22%);
-  background: #f6ddd5;
-  color: #a1372c;
+  border-color: var(--sketch-danger-hover-border);
+  background: var(--sketch-danger-hover-bg);
+  color: var(--sketch-danger);
 }
 
 .sketch-delete-tape:focus-visible {
@@ -3404,11 +3454,11 @@ a:focus-visible {
   top: 12px;
   right: 12px;
   min-height: 32px;
-  border: 1px solid rgb(65 51 32 / 14%);
-  border-radius: 7px;
-  background: rgb(255 254 249 / 92%);
-  box-shadow: 0 3px 10px rgb(38 28 16 / 9%);
-  color: var(--ink-soft);
+  border: 1px solid var(--sketch-border);
+  border-radius: var(--sketch-control-radius);
+  background: color-mix(in srgb, var(--sketch-surface) 92%, transparent);
+  box-shadow: var(--sketch-control-shadow);
+  color: var(--sketch-caption-ink);
   padding: 6px 10px;
   font: 600 11px/1 var(--font-ui);
   cursor: pointer;
@@ -3430,7 +3480,7 @@ a:focus-visible {
 
 .sketch-download-button:hover {
   border-color: color-mix(in srgb, var(--accent) 32%, transparent);
-  background: #fffef9;
+  background: var(--sketch-surface);
 }
 
 .sketch-download-button:focus-visible {
@@ -3448,10 +3498,10 @@ a:focus-visible {
   place-items: center;
   min-height: 180px;
   overflow: hidden;
-  border-radius: 11px 11px 0 0;
-  background-color: #fffef9;
-  background-image: radial-gradient(rgb(83 63 36 / 5%) 0.55px, transparent 0.55px);
-  background-size: 5px 5px;
+  border-radius: var(--sketch-inner-radius) var(--sketch-inner-radius) 0 0;
+  background-color: var(--sketch-surface);
+  background-image: var(--sketch-texture);
+  background-size: var(--sketch-texture-size);
 }
 
 .sketch-preview-svg {
@@ -3463,11 +3513,11 @@ a:focus-visible {
 .thinkroom-sketch-caption {
   min-height: 34px;
   margin: 0;
-  border-top: 1px solid rgb(65 51 32 / 10%);
-  border-radius: 0 0 11px 11px;
-  background: #fffaf1;
+  border-top: 1px solid var(--sketch-border-soft);
+  border-radius: 0 0 var(--sketch-inner-radius) var(--sketch-inner-radius);
+  background: var(--sketch-surface-muted);
   padding: 9px 12px;
-  color: var(--ink-soft);
+  color: var(--sketch-caption-ink);
   font: 500 12px/1.3 var(--font-ui);
 }
 
@@ -3476,7 +3526,7 @@ a:focus-visible {
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--ink-soft);
+  color: var(--sketch-caption-ink);
   font: inherit;
 }
 
@@ -3485,8 +3535,42 @@ a:focus-visible {
 }
 
 .thinkroom-sketch-caption.is-editable:focus-within {
-  background: color-mix(in srgb, #fffaf1 82%, var(--accent-soft));
+  background: color-mix(in srgb, var(--sketch-surface-muted) 82%, var(--accent-soft));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+[data-theme='whitey'] .thinkroom-sketch::after {
+  display: none;
+}
+
+[data-theme='whitey'] .thinkroom-sketch.is-editable {
+  transition: none;
+}
+
+[data-theme='whitey'] .thinkroom-sketch-editor .sketch-inline-canvas .excalidraw {
+  --button-gray-1: #f8f8f8;
+  --button-gray-2: #eeeeee;
+  --button-gray-3: #e3e3e3;
+  --color-on-primary-container: #2b2b2b;
+  --color-surface-primary-container: #eeeeee;
+}
+
+[data-theme='whitey'] .sketch-delete-tape {
+  top: 12px;
+  right: auto;
+  left: 12px;
+  border-color: var(--sketch-border);
+  border-radius: var(--sketch-control-radius);
+  background: color-mix(in srgb, var(--sketch-surface) 94%, transparent);
+  box-shadow: var(--sketch-control-shadow);
+  color: var(--sketch-caption-ink);
+  transform: none;
+}
+
+[data-theme='whitey'] .sketch-delete-tape:hover {
+  border-color: var(--sketch-danger-hover-border);
+  background: var(--sketch-danger-hover-bg);
+  color: var(--sketch-danger);
 }
 
 .thinkroom-sketch-caption.is-empty:not(.is-editable) {
@@ -3640,7 +3724,7 @@ a:focus-visible {
 }
 
 @media (max-width: 700px) {
-  .thinkroom-sketch { margin: 18px 0; border-radius: 9px; }
+  .thinkroom-sketch { margin: 18px 0; border-radius: var(--sketch-radius-mobile); }
   .thinkroom-sketch-preview { min-height: 150px; }
 }
 

--- a/docs/plans/2026-06-26-004-fix-whitey-sketch-theme-plan.md
+++ b/docs/plans/2026-06-26-004-fix-whitey-sketch-theme-plan.md
@@ -1,0 +1,140 @@
+---
+title: "fix: Make sketches belong to the active theme"
+type: fix
+date: 2026-06-26
+---
+
+# fix: Make sketches belong to the active theme
+
+## Summary
+
+Make inline sketches visually disappear into the Whitey document theme: square geometry, neutral surfaces, restrained Swiss-style borders and controls, and no warm paper, tape, dots, or brown shadows. Keep the current tactile sticky-note treatment in the Thinkroom theme and leave sketch scenes, persistence, layout, and editing behavior unchanged.
+
+---
+
+## Problem Frame
+
+The document themes already diverge at the page-token level, but the inline-sketch CSS is mostly hard-coded to the warm Thinkroom palette. As a result, Whitey documents still contain rounded cream paper, a dotted texture, tan tape, brown shadows, and warm editing chrome. The sketch looks pasted onto the page instead of belonging to Whitey's white, minimal, sans-serif system.
+
+The same wrapper moves between preview and editing states, and the active theme can change instantly through `document.documentElement.dataset.theme`. The fix therefore needs one coherent sketch presentation contract that reacts to the existing theme selector without remounting the editor, rewriting scene data, or changing the fixed paper dimensions that protect first paint and collaboration.
+
+---
+
+## Requirements
+
+### Theme identity
+
+- R1. In the default Thinkroom theme, inline sketches retain their current warm paper, dotted texture, rounded shape, tape, depth, and tactile controls.
+- R2. In the Whitey theme, sketch preview and editing surfaces use only neutral white/gray/black colors derived from the theme, with no cream, tan, brown, or warm accent treatment.
+- R3. Whitey sketches use square outer, preview, caption, canvas, resize, Excalidraw island, and sketch-control geometry, with no tape or paper shadow.
+- R4. Whitey's caption and controls use the existing sans-serif UI type and restrained borders so the sketch reads as part of the document rather than a decorative card.
+
+### State and behavior continuity
+
+- R5. Switching themes updates an already-mounted sketch immediately in preview and edit states; it does not require reload or sketch remount.
+- R6. Preview, selected, hover, editing, focus, loading, error, delete, download, resize, read-mode, and print behavior remain usable in both themes; caption and action text maintain at least WCAG AA 4.5:1 contrast against their surfaces.
+- R7. Existing sketch height, viewport fitting, exact SVG rendering, persistence, synchronization, accessibility labels, keyboard activation, and scene/source formats are unchanged.
+- R8. Whitey styling remains square and neutral at the existing narrow-screen breakpoint and does not introduce horizontal overflow or smaller touch targets.
+
+---
+
+## Assumptions
+
+- The issue's “YD” theme refers to the existing `whitey` theme key and Whitey/Typora-inspired design.
+- “Disappears” means the sketch becomes visually native to the document theme, not that its boundary, caption, edit affordances, or accessible controls are removed.
+- Swiss means square geometry, flat hierarchy, neutral surfaces, crisp rules, and sans-serif control typography; it does not require a new font dependency or a redesign of Excalidraw's drawing content.
+- Scene elements keep their authored colors. Theme styling applies to the sketch container and editor chrome, not to user-created marks inside the exported SVG.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Introduce sketch-local presentation tokens with Whitey overrides.** Define the warm defaults alongside the global design tokens, override them under `[data-theme='whitey']`, and have the shared sketch rules consume them. This keeps both themes explicit without duplicating the entire sketch stylesheet or relying on React theme state.
+- KTD2. **Keep theme selection CSS-driven.** The existing `data-theme` mutation already restyles the page instantly. Theme-scoped custom properties and the tape pseudo-element selector will update mounted previews and the active Excalidraw portal in place.
+- KTD3. **Preserve DOM and sketch data contracts.** No class-name, scene-schema, ProseMirror node, height, viewport, or persistence changes are needed. The work is presentation-only except for a browser regression that reads computed styles.
+- KTD4. **Move Whitey's delete affordance off the tape position.** Thinkroom keeps the centered tape delete control; Whitey receives a square neutral control in the upper-left while download remains upper-right, avoiding overlap and removing the last tape metaphor.
+- KTD5. **Test semantic visual invariants rather than screenshot pixels.** Browser checks will assert tape visibility, geometry, shadow, and representative surface colors in both preview and edit states. Those checks directly encode the issue while avoiding brittle whole-page image diffs.
+
+---
+
+## Scope Boundaries
+
+### Included
+
+- Theme-specific sketch container, preview, caption, editor, resize handle, Excalidraw toolbar island, delete, and download presentation.
+- Responsive preservation of square Whitey geometry.
+- Browser regression coverage for live theme changes and preview/edit computed styles.
+
+### Outside this change
+
+- Altering Excalidraw scenes, authored element colors, serialization, Markdown/HTML sketch source, exported SVG output, or the document export pipeline.
+- Renaming themes, adding a third theme, introducing a font package, or redesigning the overall editor and theme picker.
+- Changing sketch dimensions, viewport fitting, loading strategy, collaboration, read-mode permissions, or insertion flows.
+
+---
+
+## Implementation Units
+
+### U1. Theme-aware sketch presentation tokens and styles
+
+- **Goal:** Express Thinkroom's existing tactile sketch treatment and Whitey's neutral Swiss treatment through one theme-reactive CSS contract.
+- **Requirements:** R1-R6, R8.
+- **Dependencies:** None.
+- **Files:** `app/frontend/entrypoints/application.css`.
+- **Approach:** Add sketch-specific custom properties to `:root` for surfaces, borders, shadows, radii, texture, and control chrome; override them under `[data-theme='whitey']`. Replace hard-coded warm values in the sketch wrapper, preview, caption, editor, canvas, resize handle, selected/editing states, and toolbar islands with those properties. Hide `::after` tape in Whitey, neutralize `::before`, and reposition/restyle the delete affordance as a square top-left control. Update the mobile radius rule to consume a theme token so Whitey cannot regain rounding below 700px.
+- **Patterns to follow:** The existing global token/Whitey override blocks at the top of `application.css`; existing theme-scoped provenance and comment selectors; the UI guideline preference for the lightest sufficient surface separation and responsive invariants.
+- **Test scenarios:** Thinkroom retains tape, warm surface, radius, and shadow; Whitey has no tape, zero radius, no paper shadow/texture, neutral preview and caption surfaces, neutral selected/editing borders, square editor chrome, and distinct non-overlapping delete/download controls; caption and action text reach a 4.5:1 contrast ratio and both themes retain visible focus and hover states; Whitey stays square at a narrow viewport.
+- **Verification:** Type/build checks pass and live browser inspection shows an already-mounted sketch switching cleanly between the two visual systems in preview and edit states.
+
+### U2. Browser regression for both theme states
+
+- **Goal:** Prevent warm paper or rounded geometry from leaking back into Whitey while protecting the Thinkroom identity.
+- **Requirements:** R1-R8.
+- **Dependencies:** U1.
+- **Files:** `script/browser_check.mjs`.
+- **Approach:** Extend the existing inline-sketch scenario before deletion. Toggle the mounted document's `data-theme` to Whitey, read computed styles from the wrapper, pseudo-element, preview, caption, editor/canvas, resize handle, and representative Excalidraw island/control, and assert the neutral/square/flat invariants and text contrast. Exercise both closed and editing states at the existing 1280px viewport, then add a narrow-viewport pass for the responsive invariant. Restore Thinkroom and assert tape, rounding, and warm depth return without reload; leave all existing persistence, exact-render, read-mode, and deletion checks intact.
+- **Patterns to follow:** Existing geometry and first-frame assertions in the sketch section of `script/browser_check.mjs`; the later theme switch/persistence scenario for `data-theme` behavior; existing `ok`/`fail` reporting style.
+- **Test scenarios:** Whitey restyles a closed persisted sketch immediately; opening that same sketch preserves neutral square editor chrome; a narrow Whitey viewport remains square and overflow-free; switching back restores the tactile Thinkroom paper; scene content and height remain unchanged across theme switches.
+- **Verification:** `script/browser_check.mjs` completes with the new theme-specific sketch assertions and all existing sketch/theme checks green.
+
+---
+
+## System-Wide Impact
+
+- **Data and collaboration:** None. Theme changes remain browser presentation state; no Yjs, database, Markdown, HTML, or API payload changes.
+- **SSR and hydration:** The server already emits `data-theme` before the app mounts. CSS variables apply to the static preview and hydrated editor consistently, so no new client-only first frame is introduced.
+- **Accessibility:** Existing labels, keyboard actions, focus rings, and touch sizing remain. Neutral Whitey controls must keep sufficient contrast and visible focus against white surfaces.
+- **Performance:** A small set of CSS custom properties and selectors replaces hard-coded declarations. No new JavaScript, assets, font downloads, or render work is added.
+- **Agent parity:** Agents continue to read and write the same sketch source. The change affects only how humans see that source in each theme.
+
+---
+
+## Risks and Dependencies
+
+- **Incomplete warm-color removal:** A single hard-coded cream/brown value in edit, selected, or control states could keep the sketch visually inconsistent. Mitigation: inventory every selector in the sketch CSS block and assert representative preview and editing computed styles.
+- **Responsive selector precedence:** The existing mobile rule directly sets a radius and could override Whitey. Mitigation: route mobile geometry through a theme-specific variable and cover a narrow viewport.
+- **Excalidraw internal selector drift:** `.Island` and `.ToolIcon__icon` are library-owned classes. Mitigation: keep overrides cosmetic, verify the current installed version, and avoid depending on internal markup for core behavior.
+- **Control overlap after removing tape:** Repositioned delete and existing download controls share the sketch overlay. Mitigation: assign opposite corners and inspect hover/focus at desktop and coarse-pointer sizes.
+- **Browser test brittleness:** Browser engines serialize colors differently. Mitigation: compare normalized computed values or semantic properties rather than source CSS strings and avoid whole-page pixel snapshots.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a Whitey document containing a saved sketch, when it first appears, then the sketch is square, flat, white/neutral, and tape-free while the drawing and caption remain visible.
+- AE2. Given that Whitey sketch, when the owner opens it, then the canvas, resize bar, toolbar islands, caption, and controls remain square and neutral with no warm paper leaking through.
+- AE3. Given an already-mounted sketch, when the user switches between Whitey and Thinkroom, then the presentation changes immediately without altering the drawing, title, height, or editability.
+- AE4. Given a Whitey sketch on a narrow screen, when the layout crosses the existing 700px breakpoint, then the sketch stays square, fits the document width, and keeps usable overlay controls.
+- AE5. Given a Thinkroom document, when the same sketch is viewed after this change, then its rounded cream paper, dotted texture, tape, and tactile depth remain intact.
+
+---
+
+## Sources and Research
+
+- GitHub issue #68, `theme fixes`, defines the target: the Whitey/YD sketch should disappear into its theme through square Swiss styling with no warm colors.
+- `app/frontend/entrypoints/application.css` defines the global `proof`/`whitey` token system and all current sketch presentation, including the hard-coded cream surfaces, tape pseudo-element, brown shadows, radii, edit states, and mobile radius override.
+- `app/frontend/editor/sketch/node_view.ts` establishes the stable wrapper, preview, caption, delete, download, editor-mount classes and instant in-place lifecycle that CSS can safely theme.
+- `app/frontend/editor/sketch/sketch_inline.tsx` establishes the active editor and resize structure; no React theme state is needed.
+- `script/browser_check.mjs` already covers sketch insertion, exact SVG preview, fixed height, reload, Retina rendering, read mode, deletion, and instant theme switching; the new visual invariants belong in that flow.
+- `docs/plans/2026-06-24-002-feat-inline-excalidraw-sketches-plan.md` and `docs/plans/2026-06-25-003-fix-sketch-height-clamp-plan.md` document the sketch behavior and layout contracts this CSS-only fix must preserve.
+- `STRATEGY.md` favors focused interfaces for deliberate human modes; making sketches native to each reading theme improves that focus without expanding product scope.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -101,7 +101,7 @@ try {
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Shortcut check', markdown: 'Start here.' }),
+      body: JSON.stringify({ title: 'Shortcut check', content: 'Start here.' }),
     })
   ).json()
   const c = await browser.newPage()
@@ -127,7 +127,7 @@ try {
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Original title', markdown: '# Original title\n\nBody.\n' }),
+      body: JSON.stringify({ title: 'Original title', content: '# Original title\n\nBody.\n' }),
     })
   ).json()
   const titleA = await browser.newPage()
@@ -182,7 +182,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Task list check',
-        markdown: '- [ ] First task\n- [x] Second task\n',
+        content: '- [ ] First task\n- [x] Second task\n',
       }),
     })
   ).json()
@@ -235,7 +235,7 @@ try {
   let taskMarkdown = ''
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const taskState = await (await fetch(`${BASE}/api/docs/${taskDoc.slug}`)).json()
-    taskMarkdown = taskState.markdown ?? ''
+    taskMarkdown = taskState.content ?? ''
     const plainTaskMarkdown = taskMarkdown.replace(/<\/?(?:span|ins|del)[^>]*>/g, '')
     if (/^[*-] \[x\] First task/m.test(plainTaskMarkdown)) break
     await taskA.waitForTimeout(300)
@@ -292,7 +292,7 @@ try {
   let suggestTaskMarkdown = ''
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const taskState = await (await fetch(`${BASE}/api/docs/${taskDoc.slug}`)).json()
-    suggestTaskMarkdown = (taskState.markdown ?? '').replace(/<\/?(?:span|ins|del)[^>]*>/g, '')
+    suggestTaskMarkdown = (taskState.content ?? '').replace(/<\/?(?:span|ins|del)[^>]*>/g, '')
     if (/^[*-] \[x\] First task/m.test(suggestTaskMarkdown)) break
     await taskA.waitForTimeout(300)
   }
@@ -311,7 +311,7 @@ try {
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Sketch check', markdown: '# Sketch check\n\nBody.\n' }),
+      body: JSON.stringify({ title: 'Sketch check', content: '# Sketch check\n\nBody.\n' }),
     })
   ).json()
   const sketchA = await browser.newPage({ viewport: { width: 1280, height: 900 } })
@@ -326,7 +326,10 @@ try {
   ])
   await sketchA.locator('.milkdown .ProseMirror').click()
   await sketchA.keyboard.press('Meta+ArrowDown')
-  await sketchA.getByRole('button', { name: 'Sketch', exact: true }).click()
+  await sketchA.keyboard.press('Enter')
+  await sketchA.keyboard.type('/')
+  await sketchA.locator('.thinkroom-slash-menu[data-visible="true"]').waitFor({ timeout: 5000 })
+  await sketchA.keyboard.type('sketch')
   await sketchA.locator('.thinkroom-sketch.is-editing .excalidraw').waitFor({ timeout: 15000 })
   ok('sketch action inserts and lazy-loads an inline Excalidraw canvas')
   await sketchA.getByTitle('Rectangle — R or 2').click()
@@ -344,6 +347,164 @@ try {
   await sketchA.getByRole('textbox', { name: 'Sketch title' }).fill(sketchDescription)
   await sketchA.locator('.doc-title').click()
   await sketchA.locator('.thinkroom-sketch .sketch-preview-svg[data-renderer="excalidraw"]').waitFor({ timeout: 15000 })
+  await sketchA.evaluate(() => { document.documentElement.dataset.theme = 'whitey' })
+  await sketchA.locator('.thinkroom-sketch').hover()
+  await sketchA.locator('.sketch-delete-tape').hover()
+  const whiteyPreviewTheme = await sketchA.locator('.thinkroom-sketch').evaluate((node) => {
+    const preview = node.querySelector('.thinkroom-sketch-preview')
+    const caption = node.querySelector('.thinkroom-sketch-caption')
+    const title = node.querySelector('.thinkroom-sketch-title')
+    const download = node.querySelector('.sketch-download-button')
+    const deleteButton = node.querySelector('.sketch-delete-tape')
+    if (!preview || !caption || !title || !download || !deleteButton) return null
+
+    const parseColor = (value) => {
+      const rgb = value.match(/^rgba?\(([^)]+)\)$/)
+      if (rgb) {
+        const values = rgb[1].split(/[\s,/]+/).filter(Boolean).map(Number)
+        return [values[0] / 255, values[1] / 255, values[2] / 255, values[3] ?? 1]
+      }
+      const srgb = value.match(/^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\)$/)
+      return srgb ? [Number(srgb[1]), Number(srgb[2]), Number(srgb[3]), Number(srgb[4] ?? 1)] : null
+    }
+    const contrast = (foreground, background) => {
+      const fg = parseColor(foreground)
+      const bg = parseColor(background)
+      if (!fg || !bg) return 0
+      const blended = fg.slice(0, 3).map((channel, index) => channel * fg[3] + bg[index] * (1 - fg[3]))
+      const luminance = (channels) => channels.reduce((sum, channel, index) => {
+        const linear = channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+        return sum + linear * [0.2126, 0.7152, 0.0722][index]
+      }, 0)
+      const lighter = Math.max(luminance(blended), luminance(bg))
+      const darker = Math.min(luminance(blended), luminance(bg))
+      return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    const wrapperStyle = getComputedStyle(node)
+    const previewStyle = getComputedStyle(preview)
+    const captionStyle = getComputedStyle(caption)
+    const titleStyle = getComputedStyle(title)
+    const downloadStyle = getComputedStyle(download)
+    return {
+      wrapperRadius: wrapperStyle.borderRadius,
+      wrapperShadow: wrapperStyle.boxShadow,
+      tapeDisplay: getComputedStyle(node, '::after').display,
+      previewRadius: previewStyle.borderRadius,
+      previewBackground: previewStyle.backgroundColor,
+      previewTexture: previewStyle.backgroundImage,
+      captionRadius: captionStyle.borderRadius,
+      captionBackground: captionStyle.backgroundColor,
+      captionContrast: contrast(titleStyle.color, captionStyle.backgroundColor),
+      downloadRadius: downloadStyle.borderRadius,
+      downloadContrast: contrast(downloadStyle.color, previewStyle.backgroundColor),
+      deleteRadius: getComputedStyle(deleteButton).borderRadius,
+      deleteLeft: getComputedStyle(deleteButton).left,
+      deleteBackground: getComputedStyle(deleteButton).backgroundColor,
+      deleteColor: getComputedStyle(deleteButton).color,
+    }
+  })
+  if (
+    whiteyPreviewTheme &&
+    whiteyPreviewTheme.wrapperRadius === '0px' &&
+    whiteyPreviewTheme.wrapperShadow === 'none' &&
+    whiteyPreviewTheme.tapeDisplay === 'none' &&
+    whiteyPreviewTheme.previewRadius === '0px' &&
+    whiteyPreviewTheme.previewBackground === 'rgb(255, 255, 255)' &&
+    whiteyPreviewTheme.previewTexture === 'none' &&
+    whiteyPreviewTheme.captionRadius === '0px' &&
+    whiteyPreviewTheme.captionBackground === 'rgb(248, 248, 248)' &&
+    whiteyPreviewTheme.captionContrast >= 4.5 &&
+    whiteyPreviewTheme.downloadRadius === '0px' &&
+    whiteyPreviewTheme.downloadContrast >= 4.5 &&
+    whiteyPreviewTheme.deleteRadius === '0px' &&
+    whiteyPreviewTheme.deleteLeft === '12px' &&
+    whiteyPreviewTheme.deleteBackground === 'rgb(238, 238, 238)' &&
+    whiteyPreviewTheme.deleteColor === 'rgb(79, 79, 79)'
+  ) {
+    ok('Whitey makes saved sketches square, flat, neutral, tape-free, and high contrast')
+  } else {
+    fail(`Whitey preview styling leaked warm paper: ${JSON.stringify(whiteyPreviewTheme)}`)
+  }
+
+  await sketchA.locator('.thinkroom-sketch').click({ position: { x: 100, y: 100 } })
+  await sketchA.locator('.thinkroom-sketch.is-editing .excalidraw').waitFor({ timeout: 15000 })
+  const whiteyEditorTheme = await sketchA.locator('.thinkroom-sketch.is-editing').evaluate((node) => {
+    const selectors = [
+      '.thinkroom-sketch-editor',
+      '.sketch-inline-canvas',
+      '.sketch-resize-handle',
+      '.excalidraw .Island',
+      '.excalidraw .ToolIcon__icon',
+    ]
+    return selectors.map((selector) => {
+      const element = node.querySelector(selector)
+      if (!element) return null
+      const style = getComputedStyle(element)
+      return { selector, radius: style.borderRadius, background: style.backgroundColor, shadow: style.boxShadow }
+    })
+  })
+  if (
+    whiteyEditorTheme.every((style) => style && style.radius === '0px') &&
+    whiteyEditorTheme.filter((style) => style?.selector === '.thinkroom-sketch-editor' || style?.selector === '.sketch-inline-canvas')
+      .every((style) => style.background === 'rgb(255, 255, 255)') &&
+    whiteyEditorTheme.find((style) => style?.selector === '.sketch-resize-handle')?.background === 'rgb(248, 248, 248)' &&
+    whiteyEditorTheme.find((style) => style?.selector === '.excalidraw .Island')?.shadow === 'none' &&
+    whiteyEditorTheme.find((style) => style?.selector === '.excalidraw .ToolIcon__icon')?.background === 'rgb(238, 238, 238)'
+  ) {
+    ok('Whitey keeps the active sketch canvas and drawing tools square and neutral')
+  } else {
+    fail(`Whitey editor styling leaked rounded or warm chrome: ${JSON.stringify(whiteyEditorTheme)}`)
+  }
+  await sketchA.locator('.doc-title').click()
+
+  await sketchA.setViewportSize({ width: 390, height: 844 })
+  const whiteyNarrowLayout = await sketchA.locator('.thinkroom-sketch').evaluate((node) => {
+    const bounds = node.getBoundingClientRect()
+    return {
+      radius: getComputedStyle(node).borderRadius,
+      left: bounds.left,
+      right: bounds.right,
+      viewportWidth: document.documentElement.clientWidth,
+    }
+  })
+  if (
+    whiteyNarrowLayout.radius === '0px' &&
+    whiteyNarrowLayout.left >= -0.1 &&
+    whiteyNarrowLayout.right <= whiteyNarrowLayout.viewportWidth + 0.1
+  ) {
+    ok('Whitey sketches remain square and contained at the narrow breakpoint')
+  } else {
+    fail(`Whitey narrow sketch overflowed or regained rounding: ${JSON.stringify(whiteyNarrowLayout)}`)
+  }
+  await sketchA.setViewportSize({ width: 1280, height: 900 })
+
+  const thinkroomPreviewTheme = await sketchA.locator('.thinkroom-sketch').evaluate((node) => {
+    document.documentElement.dataset.theme = 'proof'
+    const preview = node.querySelector('.thinkroom-sketch-preview')
+    if (!preview) return null
+    const wrapperStyle = getComputedStyle(node)
+    const previewStyle = getComputedStyle(preview)
+    return {
+      wrapperRadius: wrapperStyle.borderRadius,
+      wrapperShadow: wrapperStyle.boxShadow,
+      tapeDisplay: getComputedStyle(node, '::after').display,
+      previewBackground: previewStyle.backgroundColor,
+      previewTexture: previewStyle.backgroundImage,
+    }
+  })
+  if (
+    thinkroomPreviewTheme &&
+    thinkroomPreviewTheme.wrapperRadius === '12px' &&
+    thinkroomPreviewTheme.wrapperShadow !== 'none' &&
+    thinkroomPreviewTheme.tapeDisplay !== 'none' &&
+    thinkroomPreviewTheme.previewBackground === 'rgb(255, 254, 249)' &&
+    thinkroomPreviewTheme.previewTexture !== 'none'
+  ) {
+    ok('switching back restores Thinkroom sketch paper, tape, texture, and depth')
+  } else {
+    fail(`Thinkroom sketch styling did not return: ${JSON.stringify(thinkroomPreviewTheme)}`)
+  }
   const sketchFitsPaper = await sketchA.locator('.thinkroom-sketch').evaluate((node) => {
     const paper = node.querySelector('svg[data-renderer="excalidraw"]')?.getBoundingClientRect()
     const drawing = node.querySelector('[data-excalidraw-scene]')?.getBoundingClientRect()
@@ -519,7 +680,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Empty sketch affordance',
-        markdown: `\`\`\`excalidraw\n${JSON.stringify({
+        content: `\`\`\`excalidraw\n${JSON.stringify({
           id: 'add_sketch_fixture',
           formatVersion: 1,
           description: '',
@@ -579,7 +740,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Malformed sketch check',
-        markdown: `\`\`\`excalidraw\n${malformedSketch}\n\`\`\`\n`,
+        content: `\`\`\`excalidraw\n${malformedSketch}\n\`\`\`\n`,
       }),
     })
   ).json()
@@ -602,7 +763,10 @@ try {
     route.abort(),
   )
   await failedChunkPage.goto(`${BASE}/d/${malformedDoc.slug}`)
-  await failedChunkPage.getByRole('button', { name: 'Sketch', exact: true }).click()
+  await failedChunkPage.locator('.milkdown .ProseMirror').click()
+  await failedChunkPage.keyboard.press('Meta+ArrowDown')
+  await failedChunkPage.keyboard.press('Enter')
+  await failedChunkPage.keyboard.type('/sketch')
   await failedChunkPage.locator('.sketch-load-error').waitFor({ timeout: 15000 })
   if ((await failedChunkPage.locator('.milkdown .ProseMirror').count()) === 1) {
     ok('canvas chunk failure leaves the document mounted')
@@ -619,7 +783,7 @@ try {
       headers: { 'X-Agent-Name': 'clipboard-check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Clipboard check',
-        markdown:
+        content:
           '# Checklist\n\n- [ ] **Keep formatting**\n\nA [useful link](https://example.com).\n',
       }),
     })
@@ -657,7 +821,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Soft break check',
-        markdown:
+        content:
           '# Soft breaks\n\n**Date:** 2026-06-07\n**Source:** transcripts\n**Goal:** sharper plugin\n\n```\ncode line one\ncode line two\n```\n',
       }),
     })
@@ -717,7 +881,7 @@ try {
   let softPlain = ''
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const softState = await (await fetch(`${BASE}/api/docs/${softDoc.slug}`)).json()
-    softPlain = stripMarkup(softState.markdown)
+    softPlain = stripMarkup(softState.content)
     if (softPlain.includes(expectedMeta)) break
     await sb.waitForTimeout(300)
   }
@@ -743,7 +907,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Frontmatter check',
-        markdown:
+        content:
           '---\ndate: 2026-06-08\ntopic: frontmatter-check\ntags:\n  - alpha\n  - beta\n---\n\n# Frontmatter doc\n\nBody paragraph.\n',
       }),
     })
@@ -794,7 +958,7 @@ try {
   let fmSnapshot = ''
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const fmState = await (await fetch(`${BASE}/api/docs/${fmDoc.slug}`)).json()
-    fmSnapshot = stripMarkup(fmState.markdown)
+    fmSnapshot = stripMarkup(fmState.content)
     if (fmSnapshot.includes('Typed after seed.')) break
     await fmPage.waitForTimeout(300)
   }
@@ -1176,7 +1340,7 @@ try {
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Track changes check', markdown: 'Suggest target alpha beta gamma.' }),
+      body: JSON.stringify({ title: 'Track changes check', content: 'Suggest target alpha beta gamma.' }),
     })
   ).json()
   const winA = await makePage('a')
@@ -1291,7 +1455,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Placement check',
-        markdown: Array.from(
+        content: Array.from(
           { length: 12 },
           (_, i) =>
             `Placement paragraph number ${i} with enough words to span a comfortable line of prose in the editor.`,
@@ -1418,7 +1582,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Persistence check',
-        markdown: 'Persistence paragraph alpha bravo charlie delta echo foxtrot golf hotel.',
+        content: 'Persistence paragraph alpha bravo charlie delta echo foxtrot golf hotel.',
       }),
     })
   ).json()
@@ -1545,7 +1709,7 @@ try {
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: 'Accept all check',
-        markdown:
+        content:
           '# Bulk doc\n\n## Talk outline (~60 minutes: 45 talk + Q&A)\n\nIntro paragraph stays.\n\n### 1. Cold open (3 min)\n\nOriginal cold open copy.\n\n### 2. Receipts (5 min)\n\nOriginal receipts copy.\n',
       }),
     })


### PR DESCRIPTION
## Summary

Sketches in Whitey documents no longer keep Thinkroom's warm paper, rounded corners, tape, and purple controls. Preview, editing, hover, selected-tool, and mobile states now follow the active reading theme immediately, while switching back restores the original Thinkroom treatment.

The browser regression flow also uses the current document payload and slash-menu interaction, so these theme checks exercise the editor behavior users actually see.

## Validation

- `npm run check`
- `bin/vite build --mode test`
- `bin/rails test` — 372 runs, 1,756 assertions, 0 failures
- `node --check script/browser_check.mjs`
- Headless `agent-browser` pass on the document page: Whitey preview/editor, delete hover, selected tools, 390px containment, live theme restoration, and zero console/page errors

## Post-Deploy Monitoring & Validation

- Watch the document-show response and browser console during the deployment window; healthy behavior is HTTP 200 with square neutral Whitey sketches and the warm Thinkroom sketch restored after switching themes.
- Treat missing sketch controls/assets, browser exceptions, or Thinkroom paper/tape styling persisting in Whitey as a deployment failure.
- Roll back if the affected document flow fails or theme state no longer switches cleanly; validate immediately after deploy and again after the first production smoke test. Owner: Kieran.

Closes #68

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
