### PR TITLE
feat: add minimal document link previews

### DIFF
--- a/app/controllers/document_og_images_controller.rb
+++ b/app/controllers/document_og_images_controller.rb
@@ -1,0 +1,21 @@
+class DocumentOgImagesController < ActionController::Base
+  # This GET-only public asset must not run Inertia's XSRF after-action: those
+  # cookies make otherwise public image responses private to intermediary caches.
+  self.allow_forgery_protection = false
+
+  def show
+    document = Document.find_by!(slug: params[:slug])
+    expires_in 1.day, public: true, stale_while_revalidate: 1.hour
+
+    return unless stale?(
+      etag: DocumentOgImage.cache_key(document),
+      last_modified: document.updated_at,
+      public: true
+    )
+
+    send_data DocumentOgImage.call(document),
+              type: "image/png",
+              disposition: "inline",
+              filename: "#{document.slug}-preview.png"
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -50,16 +50,18 @@ class DocumentsController < InertiaController
   # the guide invisibly so even a raw text fetch of the page surfaces it.
   def show
     document = Document.find_by!(slug: params[:slug])
+    link_preview_request = link_preview_user_agent?
 
     if request.format.json? || params[:format] == "json"
       return render json: AgentGuide.state(document, request.base_url)
     end
-    if params[:format] == "txt" || agent_user_agent?
+    if params[:format] == "txt" || (agent_user_agent? && !link_preview_request)
       return render plain: AgentGuide.text(document, request.base_url)
     end
 
-    remember_recent(document)
+    remember_recent(document) unless link_preview_request
     @agent_guide = AgentGuide.text(document, request.base_url)
+    @open_graph = document_open_graph(document)
 
     # Claim the seed at page-render time so a fresh document paints its
     # template from props instead of waiting for the WebSocket round-trip.
@@ -68,7 +70,7 @@ class DocumentsController < InertiaController
     # reloads and prefetch-shaped requests are also excluded: only an
     # initial render mounts an editor that will actually apply the grant,
     # and a burned grant blocks the channel fallback for SEED_CLAIM_TIMEOUT.
-    seed_granted = initial_render? && !prefetch_request? && document.try_claim_seed
+    seed_granted = initial_render? && !prefetch_request? && !link_preview_request && document.try_claim_seed
 
     render inertia: "documents/show", props: {
       # UI prefs ride server-readable cookies so SSR renders panel/focus/mode at
@@ -396,6 +398,11 @@ class DocumentsController < InertiaController
   # "1"/"0" flags and a "edit|suggest|comment|read" mode string; anything else
   # falls back to the default.
   UI_MODES = %w[edit suggest comment read].freeze
+  LINK_PREVIEW_USER_AGENTS = /(?:
+    facebookexternalhit|facebot|twitterbot|linkedinbot|slackbot-linkexpanding|
+    discordbot|whatsapp|telegrambot|googlebot|bingbot|pinterestbot|embedly|
+    iframely|opengraph
+  )/ix
 
   def ui_prefs
     {
@@ -403,6 +410,24 @@ class DocumentsController < InertiaController
       focus_mode: cookies[:pruf_focus] == "1",
       mode: UI_MODES.include?(cookies[:pruf_mode]) ? cookies[:pruf_mode] : "edit"
     }
+  end
+
+  def document_open_graph(document)
+    preview = DocumentSocialPreview.new(document)
+    {
+      title: preview.title,
+      description: preview.description,
+      url: document_page_url(document.slug),
+      image_url: document_og_image_url(
+        document.slug,
+        v: DocumentOgImage.url_version(document)
+      ),
+      image_alt: "Document preview: #{preview.title}"
+    }
+  end
+
+  def link_preview_user_agent?
+    request.user_agent.to_s.match?(LINK_PREVIEW_USER_AGENTS)
   end
 
   # Browsers identify as Mozilla/...; curl, wget, httpx, ruby, etc. don't.

--- a/app/services/document_og_image.rb
+++ b/app/services/document_og_image.rb
@@ -1,0 +1,118 @@
+class DocumentOgImage
+  WIDTH = 1200
+  HEIGHT = 630
+  VERSION = "1"
+  TITLE_LINE_WIDTH = 15.5
+  TITLE_MAX_LINES = 3
+  DESCRIPTION_LINE_WIDTH = 33.0
+  DESCRIPTION_MAX_LINES = 3
+
+  class << self
+    def call(document)
+      Rails.cache.fetch(cache_key(document)) do
+        Vips::Image
+          .svgload_buffer(svg(document), access: :sequential)
+          .write_to_buffer(".png", compression: 6, strip: true)
+      end
+    end
+
+    def cache_key(document)
+      [ "document-og-image", VERSION, document.cache_key_with_version ]
+    end
+
+    def url_version(document)
+      "#{VERSION}-#{document.updated_at.utc.strftime("%Y%m%d%H%M%S%6N")}"
+    end
+
+    private
+
+    def svg(document)
+      preview = DocumentSocialPreview.new(document)
+      title_lines = wrap(preview.title, width: TITLE_LINE_WIDTH, maximum: TITLE_MAX_LINES)
+      description_lines = wrap(
+        preview.description,
+        width: DESCRIPTION_LINE_WIDTH,
+        maximum: DESCRIPTION_MAX_LINES
+      )
+      description_y = 154 + (title_lines.length * 76) + 36
+
+      <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
+          <rect width="#{WIDTH}" height="#{HEIGHT}" fill="#fbfaf8"/>
+          <line x1="96" y1="88" x2="1104" y2="88" stroke="#d8d5cf" stroke-width="2"/>
+          <line x1="96" y1="542" x2="1104" y2="542" stroke="#d8d5cf" stroke-width="2"/>
+          <text x="96" y="154" fill="#252525" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="64" font-weight="600" letter-spacing="-1.2">
+            #{tspans(title_lines, x: 96, line_height: 76)}
+          </text>
+          <text x="96" y="#{description_y}" fill="#666666" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="30" font-weight="400">
+            #{tspans(description_lines, x: 96, line_height: 42)}
+          </text>
+        </svg>
+      SVG
+    end
+
+    def tspans(lines, x:, line_height:)
+      lines.map.with_index do |line, index|
+        dy = index.zero? ? 0 : line_height
+        %(<tspan x="#{x}" dy="#{dy}">#{ERB::Util.html_escape(line)}</tspan>)
+      end.join("\n")
+    end
+
+    def wrap(text, width:, maximum:)
+      tokens = text.to_s.split(/\s+/).flat_map { |word| split_long_word(word, width) }
+      lines = []
+      current = +""
+
+      tokens.each do |token|
+        candidate = current.empty? ? token : "#{current} #{token}"
+        if visual_width(candidate) <= width
+          current = candidate
+        else
+          lines << current unless current.empty?
+          current = token
+        end
+      end
+      lines << current unless current.empty?
+      lines = [ "Untitled" ] if lines.empty?
+      return lines if lines.length <= maximum
+
+      visible = lines.first(maximum)
+      visible[-1] = ellipsize(visible[-1], width)
+      visible
+    end
+
+    def split_long_word(word, width)
+      return [ word ] if visual_width(word) <= width
+
+      word.scan(/\X/).each_with_object([ +"" ]) do |grapheme, chunks|
+        candidate = "#{chunks.last}#{grapheme}"
+        if chunks.last.empty? || visual_width(candidate) <= width
+          chunks[-1] = candidate
+        else
+          chunks << grapheme
+        end
+      end
+    end
+
+    def visual_width(text)
+      text.scan(/\X/).sum { |grapheme| grapheme_width(grapheme) }
+    end
+
+    def grapheme_width(grapheme)
+      return 0.32 if grapheme.match?(/\s/)
+      return 1.0 if grapheme.match?(/[MW@%&#]/)
+      return 1.0 if grapheme.match?(/\p{Han}|\p{Hiragana}|\p{Katakana}|\p{Hangul}/)
+      return 1.0 if grapheme.codepoints.any? { |codepoint| codepoint >= 0x1F000 }
+      return 0.32 if grapheme.match?(/[ilI1|!.,:;'`]/)
+      return 0.68 if grapheme.match?(/[A-Z0-9]/)
+
+      0.56
+    end
+
+    def ellipsize(text, width)
+      graphemes = text.scan(/\X/)
+      graphemes.pop while graphemes.any? && visual_width("#{graphemes.join}…") > width
+      "#{graphemes.join.rstrip}…"
+    end
+  end
+end

--- a/app/services/document_plain_text.rb
+++ b/app/services/document_plain_text.rb
@@ -7,7 +7,7 @@ class DocumentPlainText
 
   class << self
     def call(format:, content:)
-      source = content.to_s
+      source = content.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�")
       html = if format == "html"
         source
       else

--- a/app/services/document_social_preview.rb
+++ b/app/services/document_social_preview.rb
@@ -1,0 +1,33 @@
+class DocumentSocialPreview
+  TITLE_MAX_GRAPHEMES = 160
+  DESCRIPTION_MAX_GRAPHEMES = 240
+
+  attr_reader :title, :description
+
+  def initialize(document)
+    raw_title = document.display_title.to_s.squish.presence || "Untitled"
+    @title = bound(raw_title, TITLE_MAX_GRAPHEMES)
+    @description = description_for(document, raw_title)
+  end
+
+  private
+
+  def description_for(document, raw_title)
+    plain_text = document.plain_text.to_s.squish
+    excerpt = if plain_text == raw_title || plain_text.start_with?("#{raw_title} ")
+      plain_text.delete_prefix(raw_title).strip
+    else
+      plain_text
+    end
+    bound(excerpt.presence || title, DESCRIPTION_MAX_GRAPHEMES)
+  end
+
+  def bound(text, maximum)
+    graphemes = text.scan(/\X/)
+    return text if graphemes.length <= maximum
+
+    clipped = graphemes.first(maximum - 1).join.rstrip
+    word_boundary = clipped.sub(/\s+\S*\z/, "").presence
+    "#{word_boundary || clipped}…"
+  end
+end

--- a/app/services/document_title.rb
+++ b/app/services/document_title.rb
@@ -3,11 +3,12 @@ class DocumentTitle
 
   class << self
     def call(format:, content:)
+      source = content.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�")
       html = if format == "html"
-        content.to_s
+        source
       else
         Commonmarker.to_html(
-          content.to_s,
+          source,
           plugins: { table: true, strikethrough: true, tasklist: true }
         )
       end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,24 @@
   <head>
     <title data-inertia><%= content_for(:title) || "Thinkroom" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <% if @open_graph.present? %>
+      <%= tag.link rel: "canonical", href: @open_graph[:url] %>
+      <%= tag.meta property: "og:type", content: "article" %>
+      <%= tag.meta property: "og:title", content: @open_graph[:title] %>
+      <%= tag.meta property: "og:description", content: @open_graph[:description] %>
+      <%= tag.meta property: "og:url", content: @open_graph[:url] %>
+      <%= tag.meta property: "og:image", content: @open_graph[:image_url] %>
+      <%= tag.meta property: "og:image:secure_url", content: @open_graph[:image_url] %>
+      <%= tag.meta property: "og:image:type", content: "image/png" %>
+      <%= tag.meta property: "og:image:width", content: DocumentOgImage::WIDTH %>
+      <%= tag.meta property: "og:image:height", content: DocumentOgImage::HEIGHT %>
+      <%= tag.meta property: "og:image:alt", content: @open_graph[:image_alt] %>
+      <%= tag.meta name: "twitter:card", content: "summary_large_image" %>
+      <%= tag.meta name: "twitter:title", content: @open_graph[:title] %>
+      <%= tag.meta name: "twitter:description", content: @open_graph[:description] %>
+      <%= tag.meta name: "twitter:image", content: @open_graph[:image_url] %>
+      <%= tag.meta name: "twitter:image:alt", content: @open_graph[:image_alt] %>
+    <% end %>
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Thinkroom">
     <meta name="mobile-web-app-capable" content="yes">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   match "/auth/:provider/callback", to: "oauth_callbacks#create", via: %i[get post]
   get "/auth/failure", to: "oauth_callbacks#failure"
 
+  get "d/:slug/og.png", to: "document_og_images#show", as: :document_og_image
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
   patch "d/:slug/tags", to: "documents#update_tags", as: :document_tags

--- a/docs/plans/2026-06-26-005-feat-document-og-images-plan.md
+++ b/docs/plans/2026-06-26-005-feat-document-og-images-plan.md
@@ -1,0 +1,133 @@
+---
+title: "feat: Add minimal document link previews"
+type: feat
+date: 2026-06-26
+---
+
+# feat: Add minimal document link previews
+
+## Summary
+
+Give every shared document URL server-rendered Open Graph and Twitter metadata plus a dynamic 1200×630 PNG containing the document title and a short excerpt. Keep the image deliberately unbranded and visually neutral so a pasted Thinkroom URL reads as the document itself, not as an advertisement for the application.
+
+---
+
+## Problem Frame
+
+Document pages currently expose only the browser title. Messaging apps and social networks therefore have no image, excerpt, canonical URL, or explicit content type when they unfurl a shared document URL. The preview should be available from the first HTML response because crawlers do not run the hydrated editor and may not execute JavaScript at all.
+
+The active reading theme is a viewer-local cookie. A social crawler fetching the shared URL does not receive the sharer's cookie, so it cannot reliably reproduce that person's theme unless Thinkroom starts encoding theme in shared URLs or persisting it on each document. This change intentionally avoids either product-level behavior change and uses one stable minimal visual treatment.
+
+## Requirements
+
+### Metadata
+
+- R1. A browser or recognized link-preview crawler request for `/d/:slug` includes `og:type`, `og:title`, `og:description`, `og:url`, `og:image`, `og:image:width`, `og:image:height`, and `og:image:alt` in the initial server response.
+- R2. The response includes the equivalent large-image Twitter card metadata.
+- R3. Metadata uses the server-derived display title and a bounded plain-text excerpt from the current document content; all user-authored values remain safely escaped.
+- R4. The canonical and image URLs are absolute, preserve the request host and HTTPS scheme in production, and version the image URL when document content changes.
+
+### Image
+
+- R5. The image endpoint returns a valid 1200×630 PNG suitable for link unfurlers, with the document title as the visual hierarchy and an optional excerpt beneath it.
+- R6. The image includes no Thinkroom wordmark, logo, author attribution, ownership data, tags, collaboration state, or application chrome.
+- R7. Long, blank, Unicode, Markdown, and HTML document content produces a bounded image without overflow, raw markup, or rendering errors.
+- R8. Image responses are publicly cacheable and keyed by the document version so repeated crawler requests do not repeatedly rasterize unchanged content or remain stale after edits.
+
+### Existing behavior
+
+- R9. Explicit text/JSON document responses and curl-like agent discovery remain unchanged, while recognized social unfurlers receive metadata HTML without claiming a seed, adding a recent document, or otherwise mutating document state.
+- R10. Unknown document image URLs return the normal 404 response and do not leak other document data.
+
+## Assumptions
+
+- The requested preview applies to shared document URLs, not the landing page.
+- Stable neutral styling is preferable to changing shared-link semantics solely to carry a viewer-local theme.
+- PNG is the delivery format because social preview consumers support it consistently; SVG remains an internal rendering source only.
+- A short document excerpt is useful when present, but a title-only image remains valid for blank or title-only documents.
+
+## Key Technical Decisions
+
+- KTD1. **Render metadata on the server and distinguish unfurlers from agents.** `DocumentsController#show` will prepare an Open Graph payload before the Inertia render, and the application layout will emit it ahead of the hydrated head tags. A narrow allowlist of known link-preview user agents will receive HTML even though they do not identify as Mozilla; existing curl/wget-style agent discovery will remain plain text.
+- KTD2. **Use a dedicated public image endpoint.** `/d/:slug/og.png` will load the same document and return an inline PNG with explicit dimensions and cache validators.
+- KTD3. **Rasterize a small escaped SVG with ruby-vips.** The project already ships `ruby-vips` and libvips in production. SVG keeps the visual template auditable while PNG provides crawler compatibility without another image dependency.
+- KTD4. **Share one title/excerpt projection.** A small service will derive bounded display copy from `display_title` and `plain_text`, remove a duplicated leading title from the excerpt, and feed both HTML metadata and the image renderer.
+- KTD5. **Version by document cache key.** The metadata image URL will include `updated_at`, and the generated PNG will be cached by `cache_key_with_version` plus a renderer version. HTTP ETags provide a second validation layer.
+
+## Scope Boundaries
+
+### Included
+
+- Document-page Open Graph and Twitter card tags.
+- Dynamic document PNG generation, caching, versioned image URLs, and accessible alt text.
+- Unit/integration coverage for copy projection, raster dimensions, metadata, caching headers, and 404 behavior.
+
+### Outside this change
+
+- Landing-page cards, per-user or per-document theme persistence, theme query parameters in copied links, branding, logos, author portraits, screenshot rendering, background jobs, or third-party image services.
+- Changing document privacy, slug access, content storage, editor state, exports, or collaboration behavior.
+
+## Implementation Units
+
+### U1. Bounded social-preview projection and PNG renderer
+
+- **Goal:** Produce safe, stable preview copy and a valid minimal PNG for any document content.
+- **Requirements:** R3, R5-R8.
+- **Dependencies:** None.
+- **Files:** `app/services/document_social_preview.rb`, `app/services/document_og_image.rb`, `test/services/document_social_preview_test.rb`, `test/services/document_og_image_test.rb`.
+- **Approach:** Derive the display title from the existing server projection, derive a plain-text excerpt with the duplicated leading title removed, and truncate both at word/grapheme boundaries. Build an escaped SVG with a neutral paper surface, fine rule, large title lines, and smaller excerpt lines; rasterize it through ruby-vips and cache the result by renderer/document version.
+- **Test scenarios:** Markdown and HTML input; raw markup and XML-sensitive characters; Unicode graphemes; long title/excerpt wrapping; title-only and blank bodies; PNG signature and exact 1200×630 dimensions; stable cached output for an unchanged document.
+- **Verification:** Service tests load the generated bytes with libvips and confirm the dimensions without exceptions or clipped line counts.
+
+### U2. Public OG image endpoint
+
+- **Goal:** Serve the generated image at a predictable absolute URL with crawler-friendly response semantics.
+- **Requirements:** R4, R5, R8, R10.
+- **Dependencies:** U1.
+- **Files:** `config/routes.rb`, `app/controllers/document_og_images_controller.rb`, `test/integration/document_og_image_test.rb`.
+- **Approach:** Add `/d/:slug/og.png` through a small `ActionController::Base` asset controller, look up by slug, return the cached PNG inline as `image/png`, attach a public cache policy and ETag, and retain normal `RecordNotFound` handling. Keeping the endpoint outside the application/Inertia controller hooks prevents both ownership and XSRF session cookies from weakening public caching.
+- **Test scenarios:** Existing document returns 200, PNG media type and inline disposition, public cache header and ETag, conditional GET returns 304, unknown slug returns 404, no ownership cookie is minted, and the endpoint does not claim a seed or mutate document state.
+- **Verification:** Integration tests and a local `curl`/image inspection confirm response headers, bytes, and dimensions.
+
+### U3. Server-first document metadata
+
+- **Goal:** Make every document HTML response self-sufficient for link unfurlers.
+- **Requirements:** R1-R4, R6, R9.
+- **Dependencies:** U1, U2.
+- **Files:** `app/controllers/documents_controller.rb`, `app/views/layouts/application.html.erb`, `test/integration/document_open_graph_test.rb`, `test/integration/agent_discovery_test.rb`.
+- **Approach:** Build a document-only metadata hash before the Inertia render and emit Open Graph/Twitter tags conditionally in the layout. Use request-aware Rails URL helpers, the versioned image path, exact image dimensions, and title-based alt text. Recognize common Facebook, X/Twitter, LinkedIn, Slack, Discord, WhatsApp, and generic OpenGraph preview user agents as HTML unfurlers; exclude those requests from recent-list and seed-claim side effects. Preserve explicit JSON/text and ordinary non-browser agent responses.
+- **Test scenarios:** Initial browser HTML contains escaped title/excerpt and absolute canonical/image URLs; host follows both production domains; image URL version changes after a content update; no Thinkroom branding appears in the image alt/copy; representative non-Mozilla social crawlers receive HTML metadata without claiming a seed; curl still receives the agent guide; explicit JSON/text representations remain unchanged.
+- **Verification:** Integration assertions inspect the raw response head, and the browser pipeline confirms the rendered document still loads with no console errors.
+
+## System-Wide Impact
+
+- **Data:** No schema or document mutation. Preview data is derived from the current persisted snapshot/seed.
+- **SSR/hydration:** Metadata exists before Inertia SSR/client hydration and does not participate in React state, so there is no head flash or hydration branch.
+- **Security/privacy:** The endpoint exposes only content already available at the public slug. HTML/SVG values are escaped, image generation receives bounded strings, and asset fetches do not mint ownership cookies.
+- **Performance:** PNG rasterization is cached by document version and served with validators. The document HTML adds only a small set of meta tags.
+- **Agent parity:** Programmatic JSON/text branches return before metadata setup and retain their existing self-describing contract.
+
+## Risks and Dependencies
+
+- **libvips SVG support:** Production must include the SVG loader used by ruby-vips. Mitigation: exercise the same renderer in the Docker/Kamal build and production smoke test; the production image already installs libvips.
+- **Social crawler caching:** Crawlers may cache an old preview independently. Mitigation: include the document version in `og:image` so edits produce a new URL.
+- **Text measurement:** SVG has no browser layout engine. Mitigation: bound lines conservatively with deterministic word/grapheme wrapping and test worst-case content.
+- **Metadata duplication:** Inertia also manages the document `<title>`. Mitigation: add only social metadata to the Rails layout and keep the existing Inertia title path unchanged.
+- **Crawler classification:** Existing non-Mozilla requests are intentionally treated as agents, but most social unfurlers are also non-Mozilla. Mitigation: use a deliberately narrow, tested preview-bot allowlist and preserve explicit format negotiation as the stronger signal.
+
+## Acceptance Examples
+
+- AE1. Given a document titled “Quarterly plan” with body text, when its URL is unfurled, then the card contains that title, a short plain-text excerpt, and a 1200×630 image with no Thinkroom branding.
+- AE2. Given a document whose title contains `&` and whose body contains Markdown/HTML, when the raw page head and image are fetched, then values are escaped and no source markup appears.
+- AE3. Given an edited document, when a crawler refetches its page, then `og:image` has a new version parameter and resolves to the updated preview.
+- AE4. Given a missing slug, when `/d/missing/og.png` is requested, then the response is 404.
+
+## Sources and Research
+
+- GitHub issue #69 requests minimal, attractive OG images centered on the document title, without Thinkroom branding; theme matching is optional.
+- `app/views/layouts/application.html.erb` is the server-owned head and already renders before the Inertia SSR head.
+- `DocumentsController#show` already derives `display_title`, sanitized preview HTML, and agent-specific early responses from the current persisted document.
+- `DocumentsController#agent_user_agent?` currently sends every non-Mozilla user agent to the plain-text agent guide, so social crawler user agents require an explicit HTML carve-out and must remain excluded from seed claims.
+- `DocumentPlainText` provides the format-independent, sketch-aware text projection needed for a safe excerpt.
+- `Gemfile` and the production Docker image already include `ruby-vips`/libvips.
+- `docs/solutions/architecture-patterns/server-first-instant-paint.md` establishes the project rule that known document projections should be delivered on the first server response rather than waiting for client code.

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -32,6 +32,20 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "/api/docs/#{@document.slug}"
   end
 
+  test "link preview crawlers get metadata HTML without claiming or adding a recent" do
+    @document.update!(title: "Crawler preview", seed_markdown: "# Crawler preview\n\nCard body")
+
+    get "/d/#{@document.slug}", headers: { "User-Agent" => "Twitterbot/1.0" }
+
+    assert_response :success
+    assert_equal "text/html", response.media_type
+    assert_includes response.body, 'property="og:image"'
+    assert_nil @document.reload.seed_claimed_at
+
+    get root_path, headers: { "User-Agent" => "Mozilla/5.0" }
+    refute_includes response.body, "Crawler preview"
+  end
+
   test "JSON accept on the share URL returns machine-readable state + endpoints" do
     get "/d/#{@document.slug}", headers: {
       "Accept" => "application/json",

--- a/test/integration/document_og_image_test.rb
+++ b/test/integration/document_og_image_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class DocumentOgImageIntegrationTest < ActionDispatch::IntegrationTest
+  PNG_BYTES = "\x89PNG\r\n\x1A\nstub".b
+
+  setup do
+    @document = Document.create!(
+      title: "Preview image",
+      seed_content: "# Preview image\n\nA concise card description."
+    )
+  end
+
+  test "serves a public inline PNG without minting an ownership cookie" do
+    with_stubbed_image do
+      get document_og_image_path(@document.slug), headers: { "User-Agent" => "Twitterbot/1.0" }
+    end
+
+    assert_response :success
+    assert_equal "image/png", response.media_type
+    assert response.body.b.start_with?("\x89PNG\r\n\x1A\n".b)
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Cache-Control"], "public"
+    assert response.headers["ETag"].present?
+    assert response.headers["Set-Cookie"].blank?
+    assert_not DocumentOgImagesController.allow_forgery_protection
+    assert_nil @document.reload.seed_claimed_at
+  end
+
+  test "honors the image ETag" do
+    with_stubbed_image do
+      get document_og_image_path(@document.slug)
+      etag = response.headers.fetch("ETag")
+
+      get document_og_image_path(@document.slug), headers: { "If-None-Match" => etag }
+    end
+
+    assert_response :not_modified
+    assert_empty response.body
+  end
+
+  test "returns 404 for an unknown document" do
+    get document_og_image_path("missing")
+
+    assert_response :not_found
+  end
+
+  private
+
+  def with_stubbed_image
+    original = DocumentOgImage.method(:call)
+    DocumentOgImage.define_singleton_method(:call) { |_document| PNG_BYTES }
+    yield
+  ensure
+    DocumentOgImage.define_singleton_method(:call, original)
+  end
+end

--- a/test/integration/document_open_graph_test.rb
+++ b/test/integration/document_open_graph_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class DocumentOpenGraphTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(
+      title: "Stored title",
+      seed_content: "# Product & market\n\nA focused explanation with <unsafe> source text."
+    )
+  end
+
+  test "document HTML exposes escaped Open Graph and Twitter metadata" do
+    host! "thinkroom.kieranklaassen.com"
+    https!
+    get document_page_path(@document.slug), headers: browser
+
+    assert_response :success
+    page = Nokogiri::HTML5(response.body)
+    image_url = property(page, "og:image")
+
+    assert_equal "article", property(page, "og:type")
+    assert_equal "Product & market", property(page, "og:title")
+    assert_equal "A focused explanation with source text.", property(page, "og:description")
+    assert_equal "https://thinkroom.kieranklaassen.com/d/#{@document.slug}", property(page, "og:url")
+    assert_equal "1200", property(page, "og:image:width")
+    assert_equal "630", property(page, "og:image:height")
+    assert_equal "summary_large_image", named(page, "twitter:card")
+    assert_equal property(page, "og:title"), named(page, "twitter:title")
+    assert_equal image_url, named(page, "twitter:image")
+    assert_equal URI(image_url).path, document_og_image_path(@document.slug)
+    assert URI(image_url).query.include?("v=")
+    refute_includes property(page, "og:image:alt"), "Thinkroom"
+    assert_equal property(page, "og:url"), page.at_css('link[rel="canonical"]')["href"]
+  end
+
+  test "the image URL version changes after a document update" do
+    get document_page_path(@document.slug), headers: browser
+    first_url = property(Nokogiri::HTML5(response.body), "og:image")
+
+    travel 1.second do
+      @document.update!(content_snapshot: "# Revised title\n\nRevised body")
+    end
+    get document_page_path(@document.slug), headers: browser
+    second_url = property(Nokogiri::HTML5(response.body), "og:image")
+
+    refute_equal first_url, second_url
+  end
+
+  private
+
+  def browser
+    {
+      "User-Agent" => "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36",
+      "Accept" => "text/html"
+    }
+  end
+
+  def property(page, name)
+    page.at_css(%(meta[property="#{name}"]))&.[]("content")
+  end
+
+  def named(page, name)
+    page.at_css(%(meta[name="#{name}"]))&.[]("content")
+  end
+end

--- a/test/services/document_og_image_test.rb
+++ b/test/services/document_og_image_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "open3"
+
+class DocumentOgImageServiceTest < ActiveSupport::TestCase
+  test "renders a social-compatible PNG at the declared dimensions" do
+    script = <<~'RUBY'
+      document = Document.new(
+        title: "Fallback",
+        content_format: "markdown",
+        seed_content: "# A minimal <plan> & review\n\nText with symbols: © → ✓"
+      )
+      png = DocumentOgImage.call(document)
+      image = Vips::Image.new_from_buffer(png, "")
+      puts JSON.generate(
+        png: png.start_with?("\x89PNG\r\n\x1A\n".b),
+        width: image.width,
+        height: image.height
+      )
+    RUBY
+
+    stdout, stderr, status = Open3.capture3(
+      { "RAILS_ENV" => "test" }, Rails.root.join("bin/rails").to_s, "runner", script
+    )
+    assert status.success?, stderr
+    result = JSON.parse(stdout)
+
+    assert result["png"]
+    assert_equal DocumentOgImage::WIDTH, result["width"]
+    assert_equal DocumentOgImage::HEIGHT, result["height"]
+  end
+
+  test "cache identity and URL version change with the document version" do
+    document = Document.create!(title: "First", seed_content: "Body")
+    first_key = DocumentOgImage.cache_key(document)
+    first_version = DocumentOgImage.url_version(document)
+
+    travel 1.second do
+      document.update!(title: "Second")
+    end
+
+    refute_equal first_key, DocumentOgImage.cache_key(document)
+    refute_equal first_version, DocumentOgImage.url_version(document)
+  end
+
+  test "wraps wide glyphs within the image's visual line budget" do
+    lines = DocumentOgImage.send(
+      :wrap,
+      "W" * 80,
+      width: DocumentOgImage::TITLE_LINE_WIDTH,
+      maximum: DocumentOgImage::TITLE_MAX_LINES
+    )
+
+    assert_equal DocumentOgImage::TITLE_MAX_LINES, lines.length
+    assert lines.last.end_with?("…")
+    assert lines.all? do |line|
+      DocumentOgImage.send(:visual_width, line) <= DocumentOgImage::TITLE_LINE_WIDTH
+    end
+  end
+end

--- a/test/services/document_plain_text_test.rb
+++ b/test/services/document_plain_text_test.rb
@@ -24,6 +24,18 @@ class DocumentPlainTextTest < ActiveSupport::TestCase
                  DocumentPlainText.call(format: "html", content: source)
   end
 
+  test "normalizes blank and binary content to UTF-8" do
+    assert_equal "", DocumentPlainText.call(format: "markdown", content: nil)
+    assert_equal "ASCII", DocumentPlainText.call(
+      format: "markdown",
+      content: "ASCII".dup.force_encoding(Encoding::BINARY)
+    )
+    assert_equal "bad � byte", DocumentPlainText.call(
+      format: "markdown",
+      content: "bad \xFF byte".b
+    )
+  end
+
   test "markdown Thinkroom markup contributes content but not tags" do
     source = 'Before <span data-provenance data-kind="ai">robot</span> ' \
       'and <ins data-suggestion-id="x">new</ins>'

--- a/test/services/document_social_preview_test.rb
+++ b/test/services/document_social_preview_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class DocumentSocialPreviewTest < ActiveSupport::TestCase
+  test "uses the display title and removes it from the body excerpt" do
+    document = Document.create!(
+      title: "Stored fallback",
+      seed_content: "# Product & market\n\nA focused explanation of the opportunity."
+    )
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_equal "Product & market", preview.title
+    assert_equal "A focused explanation of the opportunity.", preview.description
+  end
+
+  test "projects HTML and sketch-aware content to plain text" do
+    document = Document.create!(
+      title: "HTML fallback",
+      content_format: "html",
+      seed_content: "<h1>Launch notes</h1><p>Ship <strong>carefully</strong> &amp; learn.</p>"
+    )
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_equal "Launch notes", preview.title
+    assert_equal "Ship carefully & learn.", preview.description
+    refute_includes preview.description, "<strong>"
+  end
+
+  test "bounds long unicode copy without splitting a grapheme" do
+    grapheme = "e\u0301"
+    document = Document.create!(
+      title: grapheme * 220,
+      seed_content: "Plain body"
+    )
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_operator preview.title.scan(/\X/).length, :<=,
+                    DocumentSocialPreview::TITLE_MAX_GRAPHEMES
+    assert_equal grapheme, preview.title.scan(/\X/).last(2).first
+    assert_equal "…", preview.title.scan(/\X/).last
+  end
+
+  test "falls back to the title for a title-only document" do
+    document = Document.create!(title: "Only title", seed_content: "")
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_equal "Only title", preview.title
+    assert_equal "Only title", preview.description
+  end
+
+  test "removes an unbounded long heading before truncating the excerpt" do
+    heading = "A" * 200
+    document = Document.create!(
+      title: "Fallback",
+      seed_content: "# #{heading}\n\nThe actual body should lead the card."
+    )
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert preview.title.end_with?("…")
+    assert_equal "The actual body should lead the card.", preview.description
+  end
+
+  test "does not remove a stored title that is only a body-word prefix" do
+    document = Document.create!(title: "Plan", seed_content: "Planet-scale ideas need context.")
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_equal "Plan", preview.title
+    assert_equal "Planet-scale ideas need context.", preview.description
+  end
+end

--- a/test/services/document_title_test.rb
+++ b/test/services/document_title_test.rb
@@ -23,4 +23,11 @@ class DocumentTitleTest < ActiveSupport::TestCase
     assert_nil DocumentTitle.call(format: "markdown", content: "## Section\n\nBody")
     assert_nil DocumentTitle.call(format: "html", content: "<h1> </h1><p>Body</p>")
   end
+
+  test "normalizes binary source to UTF-8" do
+    assert_equal "bad � title", DocumentTitle.call(
+      format: "markdown",
+      content: "# bad \xFF title".b
+    )
+  end
 end


### PR DESCRIPTION
## Summary

Shared documents now unfurl as the document itself: title, short plain-text excerpt, canonical URL, and a minimal unbranded 1200×630 card. Known link-preview crawlers receive server-rendered metadata without claiming a seed or adding a recent, while curl-style agents keep the existing plain-text participation guide.

The image is a cacheable, versioned PNG generated from bounded UTF-8 document projections, so edits produce a fresh preview URL and adversarial or unusually wide text stays contained.

## Validation

- `bin/rails test` — 389 runs, 1,823 assertions, 0 failures
- `bin/rubocop` — 118 files, 0 offenses
- `npm run check`
- Headless `agent-browser` pipeline: document metadata, Twitterbot HTML routing, 1200×630 image rendering, cookie-free image session, and zero console/page errors
- Direct image inspection confirmed a valid RGBA PNG and the intended minimal title/excerpt layout

## Post-Deploy Monitoring & Validation

- Watch `DocumentsController#show` and `DocumentOgImagesController#show` logs during the validation window. Healthy behavior is document HTTP 200 with absolute OG/Twitter tags and image HTTP 200 as `image/png` with public caching and no `Set-Cookie`.
- Treat missing metadata, a plain-text response to a known unfurler, libvips/image 5xx responses, incorrect dimensions, or ownership/XSRF cookies on the image endpoint as deployment failures.
- Roll back if document pages regress or preview images fail consistently. Validate immediately after deploy and once more after the first production unfurl smoke test. Owner: Kieran.

Closes #69

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
