### PR TITLE
Render sketches in portable Markdown and clipboard exports

### DIFF
--- a/app/frontend/editor/clipboard.ts
+++ b/app/frontend/editor/clipboard.ts
@@ -1,11 +1,24 @@
 import type { Ctx } from '@milkdown/kit/ctx'
-import { editorViewOptionsCtx } from '@milkdown/kit/core'
-import { Fragment, Slice, type Node } from '@milkdown/kit/prose/model'
+import { editorViewOptionsCtx, schemaCtx, serializerCtx } from '@milkdown/kit/core'
+import { DOMSerializer, Fragment, Slice, type Node } from '@milkdown/kit/prose/model'
+import {
+  containsSketch,
+  portableClipboardSerializer,
+  serializePortableMarkdownSync,
+} from './sketch/portable'
 import { SUGGESTION_MARK_NAMES } from './suggest_changes/marks'
 
 const ACTIVITY_MARK_NAMES = new Set(['provenance', ...SUGGESTION_MARK_NAMES])
 
-function stripActivityMarks(fragment: Fragment): Fragment {
+type ClipboardNodeJson = { type?: string; content?: ClipboardNodeJson[] }
+
+const isPureText = (content: ClipboardNodeJson | ClipboardNodeJson[]): boolean => {
+  if (Array.isArray(content)) return content.length === 1 && isPureText(content[0])
+  if (content.content) return isPureText(content.content)
+  return content.type === 'text'
+}
+
+export function stripActivityMarks(fragment: Fragment): Fragment {
   const children: Node[] = []
 
   fragment.forEach((node) => {
@@ -26,6 +39,36 @@ function stripActivityMarks(fragment: Fragment): Fragment {
 export function configureCleanClipboard(ctx: Ctx): void {
   ctx.update(editorViewOptionsCtx, (prev) => ({
     ...prev,
+    // Schema and serializer contexts are not ready during Editor.config.
+    // Resolve them only when the browser actually serializes a copy event.
+    clipboardSerializer: {
+      serializeFragment: (
+        fragment: Fragment,
+        options?: { document?: Document },
+        target?: HTMLElement | DocumentFragment,
+      ) => {
+        const schema = ctx.get(schemaCtx)
+        const serializer = portableClipboardSerializer(
+          schema,
+          prev.clipboardSerializer ?? DOMSerializer.fromSchema(schema),
+        )
+        return serializer.serializeFragment(fragment, options, target)
+      },
+    } as DOMSerializer,
+    clipboardTextSerializer: (slice, view) => {
+      const schema = ctx.get(schemaCtx)
+      const markdownSerializer = ctx.get(serializerCtx)
+      const document = schema.topNodeType.createAndFill(undefined, slice.content)
+      if (!document) return ''
+      if (!containsSketch(document)) {
+        if (prev.clipboardTextSerializer) return prev.clipboardTextSerializer(slice, view)
+        if (isPureText(slice.content.toJSON() as ClipboardNodeJson)) {
+          return slice.content.textBetween(0, slice.content.size, '\n\n')
+        }
+        return markdownSerializer(document)
+      }
+      return serializePortableMarkdownSync(document, schema, markdownSerializer)
+    },
     transformCopied: (slice, view) => {
       const transformed = prev.transformCopied?.(slice, view) ?? slice
       return new Slice(

--- a/app/frontend/editor/document_export.ts
+++ b/app/frontend/editor/document_export.ts
@@ -1,8 +1,9 @@
-import { editorViewCtx, schemaCtx, type Editor } from '@milkdown/kit/core'
-import { getMarkdown } from '@milkdown/kit/utils'
+import { editorViewCtx, schemaCtx, serializerCtx, type Editor } from '@milkdown/kit/core'
 import { downloadBlob } from '../lib/download'
+import { stripActivityMarks } from './clipboard'
 import { serializeHtml } from './document_format'
 import { sketchToSvg } from './sketch/export'
+import { portableSketchFigure, serializePortableMarkdown } from './sketch/portable'
 import { normalizeSketchData } from './sketch/scene'
 
 const EXPORTED_DOCUMENT_STYLES = `
@@ -32,8 +33,25 @@ const safeFilename = (title: string, extension: string): string => {
   return `${base || 'thinkroom-document'}.${extension}`
 }
 
-export function downloadDocumentMarkdown(editor: Editor, title: string): void {
-  const markdown = editor.action((ctx) => getMarkdown()(ctx))
+export async function exportedDocumentMarkdown(editor: Editor): Promise<string> {
+  const exportState = editor.action((ctx) => {
+    const document = ctx.get(editorViewCtx).state.doc
+    return {
+      document: document.copy(stripActivityMarks(document.content)),
+      schema: ctx.get(schemaCtx),
+      serializer: ctx.get(serializerCtx),
+    }
+  })
+  return serializePortableMarkdown(
+    exportState.document,
+    exportState.schema,
+    exportState.serializer,
+    async (data) => sketchToSvg(data.scene),
+  )
+}
+
+export async function downloadDocumentMarkdown(editor: Editor, title: string): Promise<void> {
+  const markdown = await exportedDocumentMarkdown(editor)
   downloadBlob(
     new Blob([markdown], { type: 'text/markdown;charset=utf-8' }),
     safeFilename(title, 'md'),
@@ -95,11 +113,12 @@ export async function exportedDocumentHtml(editor: Editor, title: string): Promi
       const data = sketchDataFromFigure(figure)
       if (!data) return
       const svg = await sketchToSvg(data.scene)
-      svg.setAttribute('role', 'img')
-      svg.setAttribute('aria-label', data.description || 'Sketch')
-      const caption = exported.createElement('figcaption')
-      caption.textContent = data.description || 'Sketch'
-      figure.replaceChildren(exported.importNode(svg, true), caption)
+      const portable = portableSketchFigure(data, svg)
+      const children = Array.from(
+        portable.childNodes,
+        (child) => exported.importNode(child, true),
+      )
+      figure.replaceChildren(...children)
       for (const attribute of Array.from(figure.attributes)) {
         if (attribute.name.startsWith('data-') || attribute.name === 'aria-label') {
           figure.removeAttribute(attribute.name)

--- a/app/frontend/editor/sketch/portable.ts
+++ b/app/frontend/editor/sketch/portable.ts
@@ -1,0 +1,137 @@
+import { DOMSerializer, Fragment, type Node, type Schema } from '@milkdown/kit/prose/model'
+import { renderSketchPreview } from './preview'
+import { dataFromSketchNode } from './schema'
+import type { SketchData } from './scene'
+
+type MarkdownSerializer = (document: Node) => string
+type SketchRenderer = (data: SketchData) => SVGSVGElement
+type AsyncSketchRenderer = (data: SketchData) => Promise<SVGSVGElement>
+
+interface PortableSketch {
+  data: SketchData
+  token: string
+}
+
+const placeholderPrefix = (document: Node): string => {
+  let attempt = 0
+  let prefix = ''
+  do {
+    const random = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${attempt}`
+    prefix = `THINKROOM-SKETCH-${random.toUpperCase()}-`
+    attempt += 1
+  } while (document.textContent.includes(prefix))
+  return prefix
+}
+
+const preparePortableDocument = (
+  document: Node,
+  schema: Schema,
+): { document: Node; sketches: PortableSketch[] } => {
+  const sketches: PortableSketch[] = []
+  const prefix = placeholderPrefix(document)
+  const paragraph = schema.nodes.paragraph
+  if (!paragraph) throw new Error('Portable sketch export requires a paragraph node')
+
+  const replaceSketches = (node: Node): Node => {
+    if (node.type.name === 'thinkroomSketch') {
+      const data = dataFromSketchNode(node)
+      if (!data) return node
+      const token = `${prefix}${sketches.length}`
+      sketches.push({ data, token })
+      return paragraph.create(null, schema.text(token))
+    }
+    if (node.isLeaf) return node
+
+    const children: Node[] = []
+    node.forEach((child) => children.push(replaceSketches(child)))
+    return node.copy(Fragment.fromArray(children))
+  }
+
+  return { document: replaceSketches(document), sketches }
+}
+
+/** A semantic, metadata-free figure suitable for downloads and clipboard HTML. */
+export const portableSketchFigure = (
+  data: SketchData,
+  sourceSvg: SVGSVGElement,
+): HTMLElement => {
+  const figure = globalThis.document.createElement('figure')
+  const svg = sourceSvg.cloneNode(true) as SVGSVGElement
+  const label = data.description || 'Sketch'
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+  svg.setAttribute('role', 'img')
+  svg.setAttribute('aria-label', label)
+
+  const caption = globalThis.document.createElement('figcaption')
+  caption.textContent = label
+  figure.append(svg, caption)
+  return figure
+}
+
+const oneLineMarkup = (figure: HTMLElement): string =>
+  figure.outerHTML.replace(/[\r\n]+/g, ' ')
+
+const injectSketches = (
+  markdown: string,
+  sketches: PortableSketch[],
+  figures: HTMLElement[],
+): string => sketches.reduce(
+  (output, sketch, index) => output.replace(sketch.token, oneLineMarkup(figures[index])),
+  markdown,
+)
+
+export async function serializePortableMarkdown(
+  document: Node,
+  schema: Schema,
+  serializer: MarkdownSerializer,
+  render: AsyncSketchRenderer,
+): Promise<string> {
+  const prepared = preparePortableDocument(document, schema)
+  const markdown = serializer(prepared.document)
+  const figures = await Promise.all(
+    prepared.sketches.map(async ({ data }) => portableSketchFigure(data, await render(data))),
+  )
+  return injectSketches(markdown, prepared.sketches, figures)
+}
+
+export function serializePortableMarkdownSync(
+  document: Node,
+  schema: Schema,
+  serializer: MarkdownSerializer,
+  render: SketchRenderer = (data) => renderSketchPreview(data.scene),
+): string {
+  const prepared = preparePortableDocument(document, schema)
+  const markdown = serializer(prepared.document)
+  const figures = prepared.sketches.map(({ data }) => portableSketchFigure(data, render(data)))
+  return injectSketches(markdown, prepared.sketches, figures)
+}
+
+/** Preserve the active clipboard serializer for every ordinary node/mark and
+ * replace only Thinkroom's private sketch node with portable SVG markup. */
+export function portableClipboardSerializer(
+  schema: Schema,
+  base: DOMSerializer = DOMSerializer.fromSchema(schema),
+): DOMSerializer {
+  return new DOMSerializer(
+    {
+      ...base.nodes,
+      thinkroomSketch: (node) => {
+        const data = dataFromSketchNode(node)
+        if (!data) return base.nodes.thinkroomSketch?.(node) ?? ['p', 'Invalid sketch']
+        return portableSketchFigure(data, renderSketchPreview(data.scene))
+      },
+    },
+    base.marks,
+  )
+}
+
+export function containsSketch(document: Node): boolean {
+  if (document.type.name === 'thinkroomSketch') return true
+  let found = false
+  document.descendants((node) => {
+    if (node.type.name !== 'thinkroomSketch') return !found
+    found = true
+    return false
+  })
+  return found
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -248,10 +248,10 @@ export default function DocumentShow({
   // a closure-captured handle goes stale when the editor remounts mid-flight.
   const handleRef = useRef<EditorHandle | null>(null)
   handleRef.current = handle
-  const exportMarkdown = useCallback(() => {
+  const exportMarkdown = useCallback(async () => {
     const live = handleRef.current
     if (!live) throw new Error('Document editor is not ready')
-    downloadDocumentMarkdown(live.editor, documentTitle)
+    await downloadDocumentMarkdown(live.editor, documentTitle)
   }, [documentTitle])
   const exportHtml = useCallback(async () => {
     const live = handleRef.current

--- a/docs/plans/2026-06-26-006-fix-portable-sketch-exports-plan.md
+++ b/docs/plans/2026-06-26-006-fix-portable-sketch-exports-plan.md
@@ -1,0 +1,69 @@
+---
+title: "fix: Render sketches in Markdown exports and copied documents"
+type: fix
+date: 2026-06-26
+issue: 70
+---
+
+# fix: Render sketches in Markdown exports and copied documents
+
+## Summary
+
+Make whole-document Markdown downloads and copy-all output portable. Editable Excalidraw scene fences remain the canonical in-app source, but outward-facing Markdown and clipboard payloads replace those private scene blocks with inline SVG that ordinary Markdown and rich-text consumers can display.
+
+## Problem Frame
+
+Thinkroom's HTML export already renders sketches as SVG, but Markdown export currently calls Milkdown's normal serializer and emits a fenced `excalidraw` JSON payload. That payload is useful only to Thinkroom-aware renderers and looks like garbled code everywhere else. Command-C has the same problem because Milkdown's default text clipboard serializer uses the same Markdown serializer, while its HTML clipboard serializer emits a metadata-only sketch figure.
+
+## Requirements
+
+- R1. A Markdown download replaces every valid Thinkroom sketch with an inline rendered SVG and contains no `excalidraw` fence or raw scene JSON.
+- R2. Prose, headings, links, lists, and other Markdown remain normal Markdown rather than converting the entire document to HTML.
+- R3. Copying a selection that contains a sketch writes rendered SVG in both the plain-text Markdown flavor and rich HTML flavor.
+- R4. Copying ordinary text keeps current clean-clipboard behavior, including removal of Thinkroom provenance and suggestion marks.
+- R5. Multiple sketches preserve document order, descriptions, and surrounding content.
+- R6. Export preparation remains retryable through the existing Share status when SVG rendering fails.
+
+## Key Technical Decisions
+
+- KTD1. Keep editable scene JSON canonical inside Thinkroom; SVG is derived only at export/copy boundaries.
+- KTD2. Build portable Markdown with collision-resistant block placeholders in a temporary ProseMirror document, serialize that document with Milkdown, then replace each placeholder with its SVG. This avoids brittle regular expressions over fenced JSON and preserves normal Markdown serialization around each sketch.
+- KTD3. Use Excalidraw's asynchronous `exportToSvg` for downloaded Markdown, matching standalone HTML and per-sketch downloads. Use the existing synchronous safe preview renderer for the browser's synchronous clipboard serialization path.
+- KTD4. Supply a custom ProseMirror clipboard DOM serializer for sketches while retaining `transformCopied` as the single activity-mark cleanup step. Rich clipboard consumers receive a semantic figure with inline SVG and caption; plain-text consumers receive Markdown with the same figure markup.
+- KTD5. Put the shared figure/serialization logic in a small sketch portability module so Markdown download and both clipboard flavors cannot drift.
+
+## Implementation Units
+
+### U1. Portable sketch serialization
+
+- **Goal:** Turn a ProseMirror document or copied slice into normal Markdown with rendered sketch figures.
+- **Files:** `app/frontend/editor/sketch/portable.ts` (new), `app/frontend/editor/document_export.ts`
+- **Approach:** Walk the document in order, replace valid sketch nodes with unique paragraph placeholders in a temporary tree, serialize through Milkdown, render each sketch, and replace the placeholder with one-line `<figure><svg>…</svg><figcaption>…</figcaption></figure>` markup. Escape accessible caption/label text and omit Thinkroom scene metadata.
+- **Test scenarios:** zero, one, and multiple sketches; prose before/after; repeated or adversarial descriptions; nested block context; render rejection; exported output has SVG/caption but no fence, scene JSON, or `data-scene`.
+
+### U2. Clipboard SVG flavors
+
+- **Goal:** Make select-all + Command-C portable without regressing normal copy.
+- **Files:** `app/frontend/editor/clipboard.ts`, `app/frontend/editor/sketch/portable.ts`
+- **Approach:** Compose the existing `transformCopied`; add a plain-text serializer that uses the copied slice and portable Markdown helper; add a schema-derived DOM serializer whose sketch node renderer emits a semantic figure with synchronous inline SVG. Preserve ordinary nodes/marks and existing plugin behavior.
+- **Test scenarios:** copy-all produces SVG in `text/plain` and `text/html`; raw Excalidraw JSON and internal sketch metadata are absent; provenance/suggestion data remains absent; a prose-only selection is unchanged.
+
+### U3. Regression and browser verification
+
+- **Goal:** Lock the reported flows and verify real clipboard/download behavior.
+- **Files:** `script/export_check.mjs`
+- **Approach:** Update the existing focused export check to assert SVG-only Markdown and both clipboard MIME flavors. Perform the formal browser pass with `agent-browser` against `bin/dev`, covering download content, Command-C, keyboard selection, errors, and production-like read mode.
+- **Verification:** `npm run check`, Rails tests, RuboCop, production Vite build, focused export check assertions, and an `agent-browser` smoke test with no page or console errors.
+
+## Acceptance Examples
+
+- AE1. Given prose, a sketch, and more prose, when Markdown is downloaded, then both prose sections remain Markdown and the middle block is an inline SVG figure rather than an `excalidraw` code fence.
+- AE2. Given a whole document selection containing two sketches, when Command-C is pressed, then clipboard plain text and HTML each contain two SVGs in document order and no scene JSON.
+- AE3. Given a prose-only selection, when copied, then its text and ordinary formatting match current behavior and Thinkroom-only review metadata is absent.
+
+## Risks
+
+- Clipboard serialization is synchronous, while exact Excalidraw export is asynchronous. The existing safe preview renderer is therefore the deterministic clipboard fallback; downloads continue using exact Excalidraw rendering.
+- Inline SVG support depends on a Markdown consumer allowing embedded HTML. This is the broadest portable representation available without external files or data URLs and remains readable as ordinary HTML where Markdown permits inline HTML.
+- Placeholder replacement must be collision-safe and preserve list/container indentation. Keeping the replacement on one line avoids breaking Markdown container structure.
+- Copy is deliberately an outward-facing export boundary: pasting a copied SVG back into Thinkroom does not recreate an editable Excalidraw scene. The canonical editable scene remains available in the live document; retaining private JSON on the clipboard would directly contradict the issue's portability requirement.

--- a/script/export_check.mjs
+++ b/script/export_check.mjs
@@ -137,10 +137,40 @@ try {
   const markdown = await downloadText(markdownDownload)
   assert(markdownDownload.suggestedFilename() === 'export-check.md', 'Markdown uses a safe title filename')
   assert(
-    markdown.includes('Export check') && markdown.includes('```excalidraw'),
-    'Markdown contains current prose and sketch source',
+    markdown.includes('Export check') && markdown.includes('<svg') && markdown.includes('Export flow'),
+    'Markdown contains current prose and a rendered sketch SVG',
     markdown.slice(0, 500),
   )
+  assert(
+    !markdown.includes('```excalidraw') && !markdown.includes('data-scene=') &&
+      !markdown.includes('data-provenance') && !markdown.includes('export-text'),
+    'Markdown omits private sketch source, scene metadata, and activity marks',
+    markdown.slice(0, 500),
+  )
+
+  await page.locator('.milkdown .ProseMirror').focus()
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A')
+  const copied = await page.locator('.doc-live-editor .ProseMirror').evaluate((editor) => {
+    const clipboardData = new DataTransfer()
+    editor.dispatchEvent(new ClipboardEvent('copy', {
+      clipboardData,
+      bubbles: true,
+      cancelable: true,
+    }))
+    return {
+      html: clipboardData.getData('text/html'),
+      text: clipboardData.getData('text/plain'),
+    }
+  })
+  for (const [flavor, content] of Object.entries(copied)) {
+    assert(content.includes('<svg'), `copied ${flavor} contains a rendered sketch SVG`, content.slice(0, 500))
+    assert(
+      !content.includes('```excalidraw') && !content.includes('data-scene=') &&
+        !content.includes('data-provenance') && !content.includes('export-text'),
+      `copied ${flavor} omits private sketch source`,
+      content.slice(0, 500),
+    )
+  }
 
   const htmlEvent = page.waitForEvent('download')
   await exportSection.getByRole('button', { name: 'HTML' }).click()


### PR DESCRIPTION
## Summary

- replace private Excalidraw source fences with inline SVG figures in Markdown downloads
- emit rendered SVG in both plain-text and rich-HTML clipboard flavors
- remove Thinkroom activity metadata from portable Markdown while preserving ordinary copy behavior
- share semantic SVG figure generation with standalone HTML export

## Verification

- `bin/rails test` — 389 runs, 1,823 assertions, 0 failures/errors
- `bin/rubocop` — 118 files, 0 offenses
- `npm run check`
- `bin/vite build`
- `agent-browser` — Markdown download and both clipboard flavors contain SVG, omit scene/activity metadata, and produce no page/console errors

Closes #70