### PR TITLE
Make document mode the primary header state

### DIFF
--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -1,21 +1,40 @@
 import { useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useDismissable } from '../lib/use_dismissable'
+import { useMediaQuery } from '../lib/use_media_query'
 
 export type EditorMode = 'edit' | 'suggest' | 'comment' | 'read'
 
-export const MODE_LABELS: Record<EditorMode, string> = {
-  edit: 'Edit',
-  suggest: 'Suggest',
-  comment: 'Comment',
-  read: 'Read',
-}
+const MODE_OPTIONS: ReadonlyArray<{
+  value: EditorMode
+  label: string
+  hint: string
+  shortcut: number
+}> = [
+  { value: 'edit', label: 'Edit', hint: 'Type directly into the document', shortcut: 1 },
+  {
+    value: 'suggest',
+    label: 'Suggest',
+    hint: 'Type directly — edits appear as tracked suggestions for review',
+    shortcut: 2,
+  },
+  {
+    value: 'comment',
+    label: 'Comment',
+    hint: 'Read-only — click or select text to comment',
+    shortcut: 3,
+  },
+  {
+    value: 'read',
+    label: 'Read',
+    hint: 'Clean reading view — links and checkboxes stay interactive',
+    shortcut: 4,
+  },
+]
 
-const MODE_HINTS: Record<EditorMode, string> = {
-  edit: 'Type directly into the document',
-  suggest: 'Type directly — edits appear as tracked suggestions for review',
-  comment: 'Read-only — click or select text to comment',
-  read: 'Clean reading view — links and checkboxes stay interactive',
-}
+export const MODE_SHORTCUTS = Object.fromEntries(
+  MODE_OPTIONS.map(({ shortcut, value }) => [`Digit${shortcut}`, value]),
+) as Record<string, EditorMode>
 
 interface Props {
   mode: EditorMode
@@ -33,7 +52,44 @@ interface Props {
 export function ModeControl({ mode, onChange, locked = false, lockedReason }: Props) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
-  useDismissable(open, () => setOpen(false), [rootRef])
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const isMobile = useMediaQuery('(max-width: 48rem)')
+  useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
+  const activeMode = MODE_OPTIONS.find(({ value }) => value === mode)!
+
+  const popover = (
+    <div
+      className="share-popover mode-control-popover"
+      ref={popoverRef}
+      role="listbox"
+      aria-label="Editor mode"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {MODE_OPTIONS.map(({ value, label, hint, shortcut }) => (
+        <button
+          key={value}
+          role="option"
+          aria-selected={mode === value}
+          className={`mode-control-option ${mode === value ? 'is-active' : ''}`}
+          onClick={() => {
+            onChange(value)
+            setOpen(false)
+          }}
+        >
+          <span className="mode-control-option-check" aria-hidden="true">
+            {mode === value ? '✓' : ''}
+          </span>
+          <span className="mode-control-option-copy">
+            <span className="mode-control-option-label">{label}</span>
+            <span className="mode-control-option-hint">{hint}</span>
+          </span>
+          <kbd className="mode-control-shortcut" aria-label={`Command or Control ${shortcut}`}>
+            ⌘{shortcut}
+          </kbd>
+        </button>
+      ))}
+    </div>
+  )
 
   return (
     <div className="share-root mode-control" ref={rootRef}>
@@ -41,35 +97,26 @@ export function ModeControl({ mode, onChange, locked = false, lockedReason }: Pr
         className="chrome-toggle mode-control-trigger"
         aria-haspopup="listbox"
         aria-expanded={open}
-        aria-label={`Mode: ${MODE_LABELS[mode]}`}
-        title={locked ? lockedReason ?? 'Mode switching is disabled on the demo doc' : MODE_HINTS[mode]}
+        aria-label={`Mode: ${activeMode.label}`}
+        title={locked ? lockedReason ?? 'Mode switching is disabled on the demo doc' : activeMode.hint}
         disabled={locked}
         onClick={() => setOpen((v) => !v)}
       >
-        {MODE_LABELS[mode]}
+        <span className={`mode-control-dot mode-control-dot--${mode}`} aria-hidden="true" />
+        {activeMode.label} mode
         <span className="mode-control-caret" aria-hidden="true">
           ▾
         </span>
       </button>
-      {open && (
-        <div className="share-popover mode-control-popover" role="listbox" aria-label="Editor mode">
-          {(Object.keys(MODE_LABELS) as EditorMode[]).map((value) => (
-            <button
-              key={value}
-              role="option"
-              aria-selected={mode === value}
-              className={`mode-control-option ${mode === value ? 'is-active' : ''}`}
-              onClick={() => {
-                onChange(value)
-                setOpen(false)
-              }}
-            >
-              <span className="mode-control-option-label">{MODE_LABELS[value]}</span>
-              <span className="mode-control-option-hint">{MODE_HINTS[value]}</span>
-            </button>
-          ))}
-        </div>
-      )}
+      {open &&
+        (isMobile
+          ? createPortal(
+              <div className="share-backdrop" onClick={() => setOpen(false)}>
+                {popover}
+              </div>,
+              document.body,
+            )
+          : popover)}
     </div>
   )
 }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -321,17 +321,6 @@ a:focus-visible {
   margin-bottom: 0.5rem;
 }
 
-.doc-format {
-  flex: none;
-  color: var(--ink-faint);
-  font-family: var(--font-mono);
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 0.045em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
 /* ---------------------------- Document library -------------------------- */
 .document-library {
   --document-library-muted: color-mix(in srgb, var(--ink-soft) 88%, var(--ink));
@@ -945,12 +934,6 @@ a:focus-visible {
   /* Flex items default to min-width:auto — without this the nowrap title
    * refuses to shrink and forces horizontal overflow on narrow screens. */
   min-width: 0;
-}
-
-.doc-format {
-  padding: 0.16rem 0.34rem;
-  border: 1px solid var(--line);
-  border-radius: 4px;
 }
 
 .doc-notice {
@@ -2288,11 +2271,24 @@ a:focus-visible {
   color: var(--ink) !important;
 }
 
-/* Mode switcher (Edit / Suggest / Comment). */
+/* Mode switcher (Edit / Suggest / Comment / Read). */
+.doc-header-left .mode-control {
+  flex: none;
+}
+
+.doc-header-left .mode-control-popover {
+  left: 0;
+  right: auto;
+}
+
 .mode-control-trigger {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+  color: var(--ink);
+  white-space: nowrap;
 }
 
 .mode-control-trigger:disabled {
@@ -2302,6 +2298,27 @@ a:focus-visible {
 
 .mode-control-caret {
   font-size: 0.6rem;
+  color: var(--ink-faint);
+}
+
+.mode-control-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.mode-control-dot--suggest {
+  background: var(--sug-ins-line);
+}
+
+.mode-control-dot--comment {
+  background: var(--prov-pending-line);
+}
+
+.mode-control-dot--read {
+  background: var(--ink-faint);
 }
 
 .mode-control-popover {
@@ -2313,10 +2330,10 @@ a:focus-visible {
 }
 
 .mode-control-option {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.1rem;
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
   width: 100%;
   border: none;
   background: transparent;
@@ -2331,7 +2348,24 @@ a:focus-visible {
 }
 
 .mode-control-option.is-active {
-  background: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface-raised));
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.mode-control-option-check {
+  align-self: start;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.25rem;
+}
+
+.mode-control-option-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
 }
 
 .mode-control-option-label {
@@ -2343,6 +2377,19 @@ a:focus-visible {
 .mode-control-option-hint {
   font-size: 0.7rem;
   color: var(--ink-faint);
+}
+
+.mode-control-shortcut {
+  align-self: center;
+  min-width: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  line-height: 1.35rem;
+  text-align: center;
 }
 
 .selection-toolbar button:disabled {
@@ -2948,6 +2995,12 @@ a:focus-visible {
   /* No rail, no margin cards — their toggles go too. */
   .chrome-toggle {
     display: none;
+  }
+
+  /* Mode is primary document state, not secondary chrome. It stays visible
+   * after moving into the title cluster; only panel/focus toggles collapse. */
+  .mode-control-trigger {
+    display: inline-flex;
   }
 
   /* The overflow menu is the mobile route to ownership and account actions. */

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -58,7 +58,11 @@ import { IdentityChip } from '../../components/identity_chip'
 import { type OwnershipPayload } from '../../components/ownership_chip'
 import { ClaimBanner } from '../../components/claim_banner'
 import { HeaderMenu } from '../../components/header_menu'
-import { ModeControl, type EditorMode } from '../../components/mode_control'
+import {
+  MODE_SHORTCUTS,
+  ModeControl,
+  type EditorMode,
+} from '../../components/mode_control'
 import { SharePopover } from '../../components/share_popover'
 import {
   MobileDock,
@@ -237,6 +241,9 @@ export default function DocumentShow({
   const [mode, setMode] = useState<EditorMode>(demoModeLocked ? 'edit' : ui.mode)
   const effectiveMode: EditorMode = ownership.can_write ? mode : 'read'
   const modeLocked = demoModeLocked || !ownership.can_write
+  const changeMode = useCallback((nextMode: EditorMode) => {
+    if (!modeLocked) setMode(nextMode)
+  }, [modeLocked])
   const isReading = effectiveMode === 'read'
   const connectionIdentity = viewer.account ? `account:${viewer.account.id}` : 'guest'
   const editorSessionKey = `${doc.slug}:${ownership.can_write ? 'write' : 'read'}`
@@ -316,10 +323,18 @@ export default function DocumentShow({
     if (!demoModeLocked) setCookie('pruf_mode', mode)
   }, [mode, demoModeLocked])
 
-  // ⌘\ toggles the side panel, ⌘. toggles suggestion focus.
+  // ⌘1–4 selects Edit/Suggest/Comment/Read. ⌘\ toggles the side panel,
+  // and ⌘. toggles suggestion focus. Control mirrors Command for parity.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey)) return
+      const shortcutMode = MODE_SHORTCUTS[event.code] ?? MODE_SHORTCUTS[`Digit${event.key}`]
+      if (shortcutMode) {
+        if (modeLocked) return
+        event.preventDefault()
+        changeMode(shortcutMode)
+        return
+      }
       const target = event.target as HTMLElement | null
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
       if (event.key === '\\') {
@@ -332,7 +347,7 @@ export default function DocumentShow({
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [])
+  }, [changeMode, modeLocked])
 
   // Human presence from Yjs awareness. Self is filtered out — the
   // IdentityChip represents you; a duplicate avatar next to it is noise.
@@ -1037,9 +1052,16 @@ export default function DocumentShow({
               T.
             </Link>
             <span className="doc-title">{documentTitle}</span>
-            <span className="doc-format" aria-label={`Document format: ${doc.content_format}`}>
-              {doc.content_format === 'html' ? 'HTML' : 'Markdown'}
-            </span>
+            <ModeControl
+              mode={effectiveMode}
+              onChange={changeMode}
+              locked={modeLocked}
+              lockedReason={
+                ownership.can_write
+                  ? undefined
+                  : 'Read only — the document owner locked editing'
+              }
+            />
             <span
               className={`doc-status doc-status--${status}`}
               title={status === 'live' ? 'Connected — edits sync live' : 'Connecting…'}
@@ -1055,7 +1077,7 @@ export default function DocumentShow({
             )}
           </div>
           <div className="doc-header-right">
-            {/* ≤4 groups: identity/presence · (mode control) · Share · ⋯ menu */}
+            {/* ≤3 groups: identity/presence · Share · ⋯ menu */}
             <div className="doc-header-people">
               <IdentityChip
                 identity={identity}
@@ -1075,16 +1097,6 @@ export default function DocumentShow({
                 {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
               </button>
             )}
-            <ModeControl
-              mode={effectiveMode}
-              onChange={setMode}
-              locked={modeLocked}
-              lockedReason={
-                ownership.can_write
-                  ? undefined
-                  : 'Read only — the document owner locked editing'
-              }
-            />
             <SharePopover
               agentsActive={presences.length}
               exportReady={Boolean(handle)}

--- a/docs/plans/2026-06-26-007-feat-header-mode-switcher-plan.md
+++ b/docs/plans/2026-06-26-007-feat-header-mode-switcher-plan.md
@@ -1,0 +1,59 @@
+---
+title: "feat: Make document mode the primary header state"
+type: feat
+date: 2026-06-26
+issue: 71
+---
+
+# feat: Make document mode the primary header state
+
+## Summary
+
+Replace the low-value Markdown/HTML badge beside the document title with a clear mode control, remove the duplicate control from the right-side action cluster, and add Command/Control 1–4 shortcuts for Edit, Suggest, Comment, and Read.
+
+## Problem Frame
+
+The document format badge occupies the most contextual position in the header even though format is immutable and no longer useful during editing. The active interaction mode changes what clicks and typing do, but its control is mixed into the right-side sharing/action cluster. The current dropdown also does not expose keyboard shortcuts or strongly mark the active option.
+
+## Requirements
+
+- R1. The current mode control replaces the Markdown/HTML badge beside the title.
+- R2. The right-side header no longer contains a second mode control.
+- R3. The trigger explicitly reads as a mode and makes the current state glanceable in every state.
+- R4. Command/Control+1, +2, +3, and +4 switch to Edit, Suggest, Comment, and Read respectively.
+- R5. The dropdown displays each shortcut and gives the active mode an unmistakable selected treatment.
+- R6. Shortcuts and clicks respect existing locks: the demo remains Edit-only and a non-writer remains Read-only.
+- R7. Moving the control must not introduce header overflow or an off-screen dropdown on desktop or mobile.
+
+## Key Decisions
+
+- KTD1. Keep `ModeControl` as the single source for labels, order, hints, and shortcuts; the page imports the exported ordered mode list for key handling so UI and behavior cannot drift.
+- KTD2. Use a start-aligned popover when the control sits in the left header. Mobile retains the existing full-width sheet behavior.
+- KTD3. Register shortcuts on `window` and handle both Meta and Control for platform parity. Use `event.code` (`Digit1`–`Digit4`) with a numeric-key fallback and prevent the browser action only when a valid, unlocked mode switch is handled.
+- KTD4. Keep mode state visitor-local and cookie-backed exactly as today; this issue changes navigation and presentation, not collaboration semantics.
+
+## Implementation Units
+
+### U1. Mode control hierarchy and visual state
+
+- **Files:** `app/frontend/components/mode_control.tsx`, `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`
+- **Approach:** Move the existing component after the title, delete the format badge, remove the right-side instance, label the trigger as `<Mode> mode`, add a selected check and shortcut keycap to each option, and start-align the desktop popover.
+- **Verification:** Edit/Suggest/Comment/Read each show the correct trigger label; only one mode control exists; the selected option is visually and semantically active; narrow headers do not overflow.
+
+### U2. Command/Control 1–4 switching
+
+- **Files:** `app/frontend/components/mode_control.tsx`, `app/frontend/pages/documents/show.tsx`, `script/browser_check.mjs`
+- **Approach:** Export the ordered mode definition and map Digit1–Digit4 in the existing global shortcut effect. Route clicks and keys through one lock-aware mode change callback. Extend the focused browser regression script to exercise shortcut switching and locked behavior.
+- **Verification:** 1/2/3/4 select Edit/Suggest/Comment/Read; state persists through the existing cookie path; locked documents do not change.
+
+## Acceptance Examples
+
+- AE1. Given an editable document in Suggest mode, the left side reads “Suggest mode,” the dropdown marks Suggest selected, and the right action cluster contains no mode control.
+- AE2. Given an editable document, pressing Command/Control+3 switches to Comment mode and updates the trigger immediately.
+- AE3. Given a document locked by its owner, pressing Command/Control+1 leaves the viewer in Read mode.
+
+## Risks
+
+- Command/Control+number is reserved by some browser chrome for tab selection. The application handles the shortcut whenever the browser dispatches it to the page; browser-level interception cannot be overridden by web content.
+- The left header is the shrinkable side. The title must remain the only flex item that absorbs width while the mode trigger stays compact and the popover aligns inward.
+

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -1346,6 +1346,24 @@ try {
   const winA = await makePage('a')
   await winA.goto(`${BASE}/d/${trackDoc.slug}`)
   await winA.waitForSelector('.doc-status--live', { timeout: 15000 })
+  if ((await winA.locator('.mode-control-trigger').count()) === 1) {
+    ok('header renders one mode control')
+  } else {
+    fail('header did not render exactly one mode control')
+  }
+  if (await winA.locator('.doc-header-left .mode-control-trigger').isVisible()) {
+    ok('mode control replaced the format badge beside the title')
+  } else {
+    fail('mode control is not in the left header')
+  }
+  await winA.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', {
+    key: '3', code: 'Digit3', metaKey: true, bubbles: true, cancelable: true,
+  })))
+  if ((await winA.locator('.mode-control-trigger').textContent())?.includes('Comment mode')) {
+    ok('Command+3 switches to Comment mode')
+  } else {
+    fail('Command+3 did not switch to Comment mode')
+  }
   const winB = await makePage('b')
   await winB.goto(`${BASE}/d/${trackDoc.slug}`)
   await winB.waitForSelector('.doc-status--live', { timeout: 15000 })
@@ -1446,6 +1464,14 @@ try {
   const demoMode = (await demoPage.locator('.mode-control-trigger').textContent())?.trim()
   if (demoMode?.startsWith('Edit')) ok('demo doc ignored a tampered stored mode (locked to Edit)')
   else fail(`demo doc mode after tamper: "${demoMode}"`)
+  await demoPage.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', {
+    key: '2', code: 'Digit2', metaKey: true, bubbles: true, cancelable: true,
+  })))
+  if ((await demoPage.locator('.mode-control-trigger').textContent())?.includes('Edit mode')) {
+    ok('demo doc ignored the locked Command+2 mode shortcut')
+  } else {
+    fail('demo doc changed mode through a locked shortcut')
+  }
   await demoPage.close()
 
   // --- Floating chrome placement: measured, centered, never covering ---


### PR DESCRIPTION
## Summary

- replace the Markdown/HTML badge beside the title with the active mode control
- remove the duplicate mode control from the right action cluster
- show selected checks, mode-specific state dots, and ⌘1–4 keycaps
- support Meta/Control+1–4 mode switching with existing lock semantics
- keep the primary mode control visible and usable as a mobile bottom sheet

## Verification

- `bin/rails test` — 389 runs, 1,823 assertions, 0 failures/errors
- `bin/rubocop` — 118 files, 0 offenses
- `npm run check`
- `bin/vite build`
- `agent-browser` — desktop + 390px mobile hierarchy, shortcuts, lock behavior, overflow, and console/page errors

Closes #71