### PR TITLE
Make document width responsive and adjustable

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -73,9 +73,9 @@ class DocumentsController < InertiaController
     seed_granted = initial_render? && !prefetch_request? && !link_preview_request && document.try_claim_seed
 
     render inertia: "documents/show", props: {
-      # UI prefs ride server-readable cookies so SSR renders panel/focus/mode at
-      # their stored values on first paint — no post-hydration flip for users
-      # who closed the panel, enabled focus, or picked a non-Edit mode. The
+      # UI prefs ride server-readable cookies so SSR renders panel/focus/mode/
+      # width at their stored values on first paint — no post-hydration flip for
+      # users who closed the panel, enabled focus, or resized the document. The
       # client writes these cookies on change (see show.tsx). mode for the demo
       # doc is forced to "edit" client-side (modeLocked), so any stale cookie is
       # ignored there.
@@ -393,11 +393,13 @@ class DocumentsController < InertiaController
   end
 
   # Cookie-backed UI prefs, read server-side so SSR's first paint matches the
-  # user's stored panel/focus/mode (no flip). Defaults match the historical
+  # user's stored panel/focus/mode/width (no flip). Defaults match the historical
   # localStorage fallbacks: panel open, focus off, Edit mode. Cookies are
-  # "1"/"0" flags and a "edit|suggest|comment|read" mode string; anything else
-  # falls back to the default.
+  # "1"/"0" flags, a "edit|suggest|comment|read" mode string, and a clamped
+  # pixel width; anything else falls back to the default.
   UI_MODES = %w[edit suggest comment read].freeze
+  MIN_DOCUMENT_WIDTH = 576
+  MAX_DOCUMENT_WIDTH = 1120
   LINK_PREVIEW_USER_AGENTS = /(?:
     facebookexternalhit|facebot|twitterbot|linkedinbot|slackbot-linkexpanding|
     discordbot|whatsapp|telegrambot|googlebot|bingbot|pinterestbot|embedly|
@@ -405,10 +407,12 @@ class DocumentsController < InertiaController
   )/ix
 
   def ui_prefs
+    document_width = Integer(cookies[:pruf_width], exception: false)
     {
       panel_open: cookies[:pruf_panel] != "0",
       focus_mode: cookies[:pruf_focus] == "1",
-      mode: UI_MODES.include?(cookies[:pruf_mode]) ? cookies[:pruf_mode] : "edit"
+      mode: UI_MODES.include?(cookies[:pruf_mode]) ? cookies[:pruf_mode] : "edit",
+      document_width: document_width&.clamp(MIN_DOCUMENT_WIDTH, MAX_DOCUMENT_WIDTH)
     }
   end
 

--- a/app/frontend/components/document_width_handle.tsx
+++ b/app/frontend/components/document_width_handle.tsx
@@ -1,0 +1,139 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+export const MIN_DOCUMENT_WIDTH = 576
+export const MAX_DOCUMENT_WIDTH = 1120
+
+interface Props {
+  width: number | null
+  onChange: (width: number) => void
+  onCommit: (width: number) => void
+  onReset: () => void
+}
+
+interface DragState {
+  pointerId: number
+  startX: number
+  startWidth: number
+  maxWidth: number
+}
+
+const clampWidth = (width: number, maxWidth = MAX_DOCUMENT_WIDTH) =>
+  Math.round(Math.min(Math.max(width, MIN_DOCUMENT_WIDTH), maxWidth))
+
+/** The desktop document edge: drag it, or use arrows, to resize the prose. */
+export function DocumentWidthHandle({ width, onChange, onCommit, onReset }: Props) {
+  const handleRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<DragState | null>(null)
+  const lastWidthRef = useRef<number | null>(width)
+  const [measuredWidth, setMeasuredWidth] = useState(MIN_DOCUMENT_WIDTH)
+  const [dragging, setDragging] = useState(false)
+  lastWidthRef.current = width
+
+  const documentElement = () =>
+    handleRef.current?.previousElementSibling instanceof HTMLElement
+      ? handleRef.current.previousElementSibling
+      : null
+
+  // A saved preference can be wider than the space available on this screen.
+  // Start interactions from the visible edge, not the off-screen preference,
+  // so the first ArrowLeft or leftward drag always moves immediately.
+  const currentWidth = () => documentElement()?.getBoundingClientRect().width ?? width ?? measuredWidth
+
+  const usableMaxWidth = () => {
+    const body = handleRef.current?.closest('.doc-body')
+    if (!(body instanceof HTMLElement)) return MAX_DOCUMENT_WIDTH
+
+    const rail = body.querySelector('.doc-rail')
+    const gutter = handleRef.current?.nextElementSibling
+    const railWidth = rail instanceof HTMLElement && getComputedStyle(rail).display !== 'none'
+      ? rail.getBoundingClientRect().width
+      : 0
+    const gutterWidth = gutter instanceof HTMLElement
+      ? gutter.getBoundingClientRect().width
+      : 0
+
+    return Math.max(
+      MIN_DOCUMENT_WIDTH,
+      Math.min(MAX_DOCUMENT_WIDTH, body.getBoundingClientRect().width - railWidth - gutterWidth),
+    )
+  }
+
+  useLayoutEffect(() => {
+    const documentMain = documentElement()
+    if (!documentMain || typeof ResizeObserver === 'undefined') return
+
+    const update = () => setMeasuredWidth(Math.round(documentMain.getBoundingClientRect().width))
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(documentMain)
+    return () => observer.disconnect()
+  }, [])
+
+  const finishDrag = (pointerId: number) => {
+    if (dragRef.current?.pointerId !== pointerId) return
+    dragRef.current = null
+    setDragging(false)
+    if (lastWidthRef.current !== null) onCommit(lastWidthRef.current)
+  }
+
+  const displayedWidth = Math.round(measuredWidth)
+
+  return (
+    <div
+      ref={handleRef}
+      className={`document-width-handle ${dragging ? 'is-dragging' : ''}`}
+      role="separator"
+      aria-label="Document width"
+      aria-orientation="vertical"
+      aria-valuemin={MIN_DOCUMENT_WIDTH}
+      aria-valuemax={MAX_DOCUMENT_WIDTH}
+      aria-valuenow={displayedWidth}
+      aria-valuetext={`${displayedWidth} pixels. Press Home or double-click to reset.`}
+      tabIndex={0}
+      title="Drag to resize · Arrow keys adjust · Double-click resets"
+      onDoubleClick={(event) => {
+        event.preventDefault()
+        onReset()
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Home') {
+          event.preventDefault()
+          onReset()
+          return
+        }
+        if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+        event.preventDefault()
+        const direction = event.key === 'ArrowRight' ? 1 : -1
+        const step = event.shiftKey ? 64 : 16
+        const nextWidth = clampWidth(currentWidth() + direction * step, usableMaxWidth())
+        lastWidthRef.current = nextWidth
+        onChange(nextWidth)
+        onCommit(nextWidth)
+      }}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return
+        event.preventDefault()
+        event.currentTarget.setPointerCapture(event.pointerId)
+        dragRef.current = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startWidth: currentWidth(),
+          maxWidth: usableMaxWidth(),
+        }
+        setDragging(true)
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current
+        if (!drag || drag.pointerId !== event.pointerId) return
+        const nextWidth = clampWidth(drag.startWidth + event.clientX - drag.startX, drag.maxWidth)
+        lastWidthRef.current = nextWidth
+        onChange(nextWidth)
+      }}
+      onPointerUp={(event) => finishDrag(event.pointerId)}
+      onPointerCancel={(event) => finishDrag(event.pointerId)}
+    >
+      <span aria-hidden>•••</span>
+    </div>
+  )
+}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -35,6 +35,7 @@
 
   --code-bg: #f3f0e9;
   --measure: 44rem;
+  --document-width: var(--measure);
 
   --sketch-surface: #fffef9;
   --sketch-surface-muted: #fffaf1;
@@ -1001,7 +1002,7 @@ a:focus-visible {
   align-items: stretch;
   min-width: 0;
   flex: 1;
-  max-width: calc(var(--measure) + 15rem);
+  max-width: calc(var(--document-width) + 15rem);
 }
 
 .margin-gutter {
@@ -1017,7 +1018,7 @@ a:focus-visible {
 
 /* Mobile keeps the gutter as a slim marker strip — suggestions stay
  * discoverable at their anchors; the cards live in a bottom sheet. */
-@media (max-width: 64rem) {
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
   .margin-gutter,
   .doc-canvas.is-focus .margin-gutter {
     width: 1.75rem;
@@ -1027,8 +1028,65 @@ a:focus-visible {
 .doc-main {
   flex: 1;
   min-width: 0;
-  max-width: var(--measure);
+  max-width: var(--document-width);
   padding: 3rem 2rem 6rem;
+}
+
+/* A zero-width flex item keeps the grip exactly on the document edge without
+ * stealing space from prose or the suggestion gutter. It is deliberately
+ * quiet, but visible enough to advertise that the edge can move. */
+.document-width-handle {
+  position: relative;
+  z-index: 5;
+  width: 0;
+  flex: none;
+  align-self: stretch;
+  color: var(--ink-faint);
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+  outline: none;
+}
+
+.document-width-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -12px;
+  width: 24px;
+}
+
+.document-width-handle span {
+  position: sticky;
+  top: calc(50vh - 1.5rem);
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 40px;
+  margin-left: -9px;
+  border: 1px solid color-mix(in srgb, var(--ink-faint) 38%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-raised) 90%, transparent);
+  box-shadow: 0 1px 5px rgb(0 0 0 / 0.05);
+  font: 600 7px/1 var(--font-ui);
+  letter-spacing: -1px;
+  writing-mode: vertical-rl;
+  opacity: 0.48;
+  transition: opacity 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.document-width-handle:hover span,
+.document-width-handle:focus-visible span,
+.document-width-handle.is-dragging span {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  opacity: 1;
+}
+
+.document-width-handle:focus-visible span {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* ----------------------------- Editor typography ------------------------- */
@@ -1349,7 +1407,7 @@ a:focus-visible {
   display: none;
 }
 
-@media (max-width: 64rem) {
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
   .doc-rail {
     display: none;
   }
@@ -2479,7 +2537,7 @@ a:focus-visible {
   white-space: nowrap;
 }
 
-@media (max-width: 64rem) {
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
   .identity-name {
     max-width: 5.5rem;
   }
@@ -2515,7 +2573,7 @@ a:focus-visible {
   color: var(--accent);
 }
 
-@media (max-width: 64rem) {
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
   .ownership-owner {
     max-width: 6rem;
   }
@@ -2991,7 +3049,7 @@ a:focus-visible {
 }
 
 /* --------------------------------- Mobile --------------------------------- */
-@media (max-width: 64rem) {
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
   /* No rail, no margin cards — their toggles go too. */
   .chrome-toggle {
     display: none;
@@ -3020,13 +3078,19 @@ a:focus-visible {
    * instead of forcing horizontal overflow. */
   .doc-canvas {
     width: 100%;
+    max-width: none;
   }
 
   .doc-main {
     flex: 1;
     width: auto;
     min-width: 0;
+    max-width: none;
     padding: 2rem 1.25rem calc(7rem + env(safe-area-inset-bottom));
+  }
+
+  .document-width-handle {
+    display: none;
   }
 
   .milkdown .ProseMirror {

--- a/app/frontend/lib/cookies.ts
+++ b/app/frontend/lib/cookies.ts
@@ -1,7 +1,7 @@
 /**
  * Server-readable UI-pref persistence. Cookies (not localStorage) are the
- * source of truth for first paint so SSR can render panel/focus/mode at their
- * stored values — no post-hydration flip. Mirrors the theme cookie convention
+ * source of truth for first paint so SSR can render panel/focus/mode/width at
+ * their stored values — no post-hydration flip. Mirrors the theme cookie convention
  * in theme_picker.tsx: path=/, SameSite=Lax, one-year max-age.
  */
 const ONE_YEAR_SECONDS = 31536000

--- a/app/frontend/pages/documents/show.css
+++ b/app/frontend/pages/documents/show.css
@@ -1,7 +1,13 @@
 /* Read mode is the clean document surface: no review gutters or provenance
  * decoration, and unresolved tracked edits render as ordinary reading copy. */
 .doc-page.is-read-mode .doc-canvas {
-  max-width: var(--measure);
+  max-width: var(--document-width);
+}
+
+@media (max-width: 72rem), (hover: none) and (pointer: coarse) {
+  .doc-page.is-read-mode .doc-canvas {
+    max-width: none;
+  }
 }
 
 .doc-page.is-read-mode .milkdown .prov--ai,

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { Head, Link, router, usePoll } from '@inertiajs/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { TextSelection } from '@milkdown/kit/prose/state'
@@ -58,6 +58,7 @@ import { IdentityChip } from '../../components/identity_chip'
 import { type OwnershipPayload } from '../../components/ownership_chip'
 import { ClaimBanner } from '../../components/claim_banner'
 import { HeaderMenu } from '../../components/header_menu'
+import { DocumentWidthHandle } from '../../components/document_width_handle'
 import {
   MODE_SHORTCUTS,
   ModeControl,
@@ -111,6 +112,7 @@ export interface DocumentProps {
     panel_open: boolean
     focus_mode: boolean
     mode: EditorMode
+    document_width: number | null
   }
   ownership: OwnershipPayload
   suggestions: SuggestionPayload[]
@@ -229,12 +231,13 @@ export default function DocumentShow({
   const [composerAnchor, setComposerAnchor] = useState<string | null>(null)
   const viewRef = useRef<EditorView | null>(null)
   // Hydration-safe init from server-rendered cookie prefs: SSR and the client's
-  // first render derive panel/focus/mode from the same `ui` props, so a user
+  // first render derive panel/focus/mode/width from the same `ui` props, so a user
   // who closed the panel (etc.) sees it closed at first paint — no flip. The
   // client writes the cookie on change (effects below); cookies, not
   // localStorage, are now the source of truth for first paint.
   const [panelOpen, setPanelOpen] = useState(ui.panel_open)
   const [focusMode, setFocusMode] = useState(ui.focus_mode)
+  const [documentWidth, setDocumentWidth] = useState<number | null>(ui.document_width)
   // Demo doc always opens in Edit and stays locked there — a stale mode cookie
   // can't override it (the server also defaults it; this is the client guard).
   const demoModeLocked = doc.slug === 'demo'
@@ -273,12 +276,13 @@ export default function DocumentShow({
     if (effectiveMode !== 'comment') setCommentTarget(null)
   }, [effectiveMode])
 
-  // ≤64rem: rail and margin cards give way to anchor markers, a bottom dock,
-  // and sheets — the full product, rearranged for one hand. Masked by isClient
+  // Compact or coarse-pointer screens: rail and margin cards give way to
+  // anchor markers, a bottom dock, and sheets — the full product, rearranged
+  // for one hand. The pointer branch catches wide landscape iPads. Masked by isClient
   // so the first render is the desktop layout on both server and client (the
   // matchMedia read happens only after mount) — the responsive collapse then
   // applies one frame later, matching the editor mount.
-  const rawIsMobile = useMediaQuery('(max-width: 64rem)')
+  const rawIsMobile = useMediaQuery('(max-width: 72rem), (hover: none) and (pointer: coarse)')
   const isMobile = isClient && rawIsMobile
   const [activeSheet, setActiveSheet] = useState<SheetKind | null>(null)
   const [sheetFocusId, setSheetFocusId] = useState<number | null>(null)
@@ -1045,6 +1049,9 @@ export default function DocumentShow({
       <Head title={documentTitle} />
       <div
         className={`doc-page ${panelOpen ? '' : 'is-panel-hidden'} ${isReading ? 'is-read-mode' : ''}`}
+        style={documentWidth === null
+          ? undefined
+          : ({ '--document-width': `${documentWidth}px` } as CSSProperties)}
       >
         <header className="doc-header">
           <div className="doc-header-left">
@@ -1195,6 +1202,15 @@ export default function DocumentShow({
                 </div>
               </div>
             </article>
+            <DocumentWidthHandle
+              width={documentWidth}
+              onChange={setDocumentWidth}
+              onCommit={(width) => setCookie('pruf_width', String(width))}
+              onReset={() => {
+                setDocumentWidth(null)
+                setCookie('pruf_width', 'default')
+              }}
+            />
             {!isReading && (
               <div className="margin-gutter">
                 <MarginInlineSuggestions

--- a/docs/plans/2026-06-26-008-feat-resizable-document-width-plan.md
+++ b/docs/plans/2026-06-26-008-feat-resizable-document-width-plan.md
@@ -1,0 +1,78 @@
+---
+title: "feat: Make document width responsive and user-resizable"
+type: feat
+date: 2026-06-26
+issue: 72
+---
+
+# feat: Make document width responsive and user-resizable
+
+## Summary
+
+Let desktop readers widen the document with a quiet, accessible edge handle, remember that preference without a reload jump, and remove the stale desktop max-width constraints that currently leave the document narrow on iPad and mobile layouts.
+
+## Problem Frame
+
+The document uses `--measure` for both readable prose and the total Read-mode canvas. At the existing 64rem responsive breakpoint the canvas is assigned `width: 100%`, but neither `.doc-main` nor the higher-specificity Read-mode canvas drops its desktop `max-width`. At tablet widths this produces a narrow column with unused space even though the layout has already removed the desktop rail and converted review cards to sheets. Landscape iPads can also exceed a width-only breakpoint, so the compact layout must account for coarse-pointer devices.
+
+On larger screens the fixed measure is good for ordinary prose but gives the user no way to make a table, sketch, code sample, or deliberately spacious document easier to work with. Tables already scroll safely inside their wrapper; widening the whole document lets them use available space without introducing a second, content-specific layout model that could collide with suggestion markers and anchored review UI.
+
+## Requirements
+
+- R1. On sufficiently wide desktop screens, a quiet but persistent handle at the prose edge lets the user widen or narrow the document continuously within safe bounds.
+- R2. The handle supports keyboard resizing and exposes its current value and bounds to assistive technology.
+- R3. The chosen width persists across documents and renders from the server on the next visit, avoiding a post-hydration layout jump.
+- R4. Double-clicking the handle resets to the active theme's default measure.
+- R5. Edit, Suggest, Comment, and Read modes use the same chosen document width.
+- R6. At the compact breakpoint and on coarse-pointer devices, the document and Read-mode canvas fill the available width; the desktop handle is absent and cannot create horizontal overflow.
+- R7. Tables continue to fit the chosen column and retain horizontal scrolling when their minimum content width still exceeds the available space.
+- R8. The side rail, suggestion gutter, floating review UI, print layout, and both themes continue to behave correctly.
+
+## Key Decisions
+
+- KTD1. Resize the whole document, not individual tables. The document already has one stable prose/gutter geometry used by anchored review UI; a table-only breakout would overlap the 15rem suggestion gutter or require a second anchor coordinate system.
+- KTD2. Store an optional pixel width in a plain `pruf_width` cookie and include the sanitized value in the existing `ui` prop. Numeric values are clamped server-side; absent/invalid values mean “theme default.” This preserves SSR/client first-paint agreement while still allowing each theme's default measure to differ.
+- KTD3. Put the zero-width handle in the flex flow immediately after `.doc-main`. Its visual hit target can straddle the exact prose edge without consuming layout width or relying on duplicated position calculations. In Read mode it remains at the canvas edge; in review modes it precedes the existing margin gutter.
+- KTD4. Use an interactive ARIA separator with Pointer Events and pointer capture, plus Arrow keys in one-rem steps (Shift+Arrow for larger steps). Home and double-click reset. The handle is CSS-hidden until the viewport has enough room for desktop document + gutter/rail geometry, so tablet layouts stay direct and full-width.
+- KTD5. Keep the existing table overflow wrapper. Widening the document naturally gives a wide table more room; exceptionally wide tables still scroll rather than forcing page overflow.
+
+## Implementation Units
+
+### U1. Server-backed width preference
+
+- **Files:** `app/controllers/documents_controller.rb`, `app/frontend/pages/documents/show.tsx`, integration tests
+- **Approach:** Parse and clamp `pruf_width` into the existing `ui` prop, initialize width state from it, apply `--document-width` on `.doc-page`, and commit changes back to the cookie. `nil` leaves the CSS theme default intact.
+- **Verification:** Valid values survive a reload; invalid, undersized, and oversized cookie values cannot escape the supported range; SSR markup and hydration start from the same width.
+
+### U2. Accessible document-edge resize handle
+
+- **Files:** new `app/frontend/components/document_width_handle.tsx`, `app/frontend/pages/documents/show.tsx`, `app/frontend/entrypoints/application.css`
+- **Approach:** Render a zero-width interactive separator after the article. Dragging derives the next width from horizontal pointer movement, clamped to mirrored server/client limits and the usable desktop canvas. Arrow keys resize, Home/double-click reset, and ARIA value metadata names the control. Keep a restrained vertical grip visible at rest and strengthen it on hover/focus/active.
+- **Verification:** Drag and keyboard interaction change both `.doc-main` and Read-mode canvas widths; the gutter/rail remain adjacent; reset returns to the theme measure; no horizontal page overflow appears.
+
+### U3. Tablet/mobile full-width repair
+
+- **Files:** `app/frontend/entrypoints/application.css`, `app/frontend/pages/documents/show.css`
+- **Approach:** Move the compact breakpoint to 72rem (the first width at which rail + gutter + minimum prose can coexist) and include coarse-pointer devices so landscape iPads are covered. Explicitly remove max-width from `.doc-canvas`, `.doc-main`, and the higher-specificity Read-mode canvas rule. Hide the desktop handle and keep the existing slim review-marker gutter and bottom-sheet behavior.
+- **Verification:** At 1024px, 768px, and 390px the canvas fills the viewport, the prose consumes all space not reserved for the marker strip, Read mode is equally full-width, and `scrollWidth === clientWidth`.
+
+### U4. Focused regression coverage
+
+- **Files:** `script/browser_check.mjs`
+- **Approach:** Extend the browser regression with default geometry, keyboard resizing, cookie persistence/reload, reset, Read-mode parity, table containment/scroll behavior, and 1024/768/390 viewport assertions. Keep existing mode, panel, editor, and deletion coverage intact.
+- **Verification:** The focused browser script and full unit/type/lint/build suite pass.
+
+## Acceptance Examples
+
+- AE1. Given a desktop document at its default width, when the user drags the edge handle 160px right, then the prose and table become wider, the suggestion gutter moves with the edge, and the page does not horizontally overflow.
+- AE2. Given a saved custom width, when another document loads, then its first rendered frame uses that width without a narrow-to-wide hydration jump.
+- AE3. Given a custom width, when the user double-clicks the handle, then the Thinkroom theme returns to 44rem and Whitey returns to 47rem.
+- AE4. Given an iPad-width viewport, when the document is in Edit or Read mode, then the canvas uses the available viewport width and no resize handle or horizontal page scrollbar appears.
+- AE5. Given a table whose content is wider than the resized column, then the table wrapper scrolls horizontally while the page itself remains contained.
+
+## Risks
+
+- The configured preference can be wider than the current desktop's usable space when the side rail is open. The flex layout must be allowed to shrink to available width, and the handle's drag maximum must use the current canvas/rail geometry rather than only a global constant.
+- A pointer drag can emit many updates. Apply visual state on animation frames and persist only on commit, not on every pointermove.
+- The Read-mode max-width rule lives in page-local CSS and has higher specificity than the global responsive rule. It needs its own responsive override or the iPad bug will survive in Read mode.
+- Theme defaults differ. Reset must clear the custom override instead of writing one theme's pixel default into the cookie.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -271,10 +271,7 @@ try {
   // tracked as suggestions. Attr-only task transactions must bypass the
   // suggest-changes transform or the native control toggles without changing
   // ProseMirror/Yjs and silently reverts on reload.
-  await taskA.evaluate(
-    (slug) => localStorage.setItem(`pruf:mode:${slug}`, 'suggest'),
-    taskDoc.slug,
-  )
+  await taskA.context().addCookies([{ name: 'pruf_mode', value: 'suggest', url: BASE }])
   await taskA.reload()
   await taskA.waitForSelector('.doc-status--live', { timeout: 15000 })
   await taskA.waitForFunction(
@@ -1473,6 +1470,186 @@ try {
     fail('demo doc changed mode through a locked shortcut')
   }
   await demoPage.close()
+
+  // --- Document width: desktop resize + tablet/mobile full-width geometry ---
+  const widthDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Width check',
+        content: [
+          '# Width check',
+          '',
+          '| A deliberately wide column | Another deliberately wide column | Third wide column |',
+          '| --- | --- | --- |',
+          '| unbreakable-width-check-aaaaaaaaaaaaaaaa | unbreakable-width-check-bbbbbbbbbbbbbbbb | unbreakable-width-check-cccccccccccccccc |',
+        ].join('\n'),
+      }),
+    })
+  ).json()
+  const widthContext = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+  const widthPage = await widthContext.newPage()
+  await widthPage.goto(`${BASE}/d/${widthDoc.slug}`)
+  await widthPage.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await widthPage.waitForSelector('.document-width-handle')
+
+  const defaultWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  await widthContext.addCookies([{ name: 'pruf_width', value: '1120', url: BASE }])
+  await widthPage.reload()
+  await widthPage.waitForSelector('.doc-status--live', { timeout: 15000 })
+  const constrainedWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  await widthPage.locator('.document-width-handle').focus()
+  await widthPage.keyboard.press('ArrowLeft')
+  const constrainedStep = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  if (constrainedStep === constrainedWidth - 16) {
+    ok('a saved width wider than the screen resizes from its visible edge immediately')
+  } else {
+    fail(`constrained width did not move immediately: ${constrainedWidth}px -> ${constrainedStep}px`)
+  }
+  await widthPage.locator('.document-width-handle span').dblclick()
+
+  await widthPage.locator('.document-width-handle').focus()
+  await widthPage.keyboard.press('ArrowRight')
+  const keyboardWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  const widthCookie = (await widthContext.cookies()).find((cookie) => cookie.name === 'pruf_width')
+  if (keyboardWidth === defaultWidth + 16 && widthCookie?.value === String(keyboardWidth)) {
+    ok('document width handle resizes by keyboard and persists the preference')
+  } else {
+    fail(`document keyboard resize diverged: default=${defaultWidth}, next=${keyboardWidth}, cookie=${widthCookie?.value}`)
+  }
+
+  const handleBox = await widthPage.locator('.document-width-handle span').boundingBox()
+  if (!handleBox) {
+    fail('document width handle has no draggable bounds')
+  } else {
+    await widthPage.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+    await widthPage.mouse.down()
+    await widthPage.mouse.move(handleBox.x + handleBox.width / 2 + 64, handleBox.y + handleBox.height / 2)
+    await widthPage.mouse.up()
+    const draggedWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+    if (draggedWidth === keyboardWidth + 64) ok('document edge drag resizes the prose continuously')
+    else fail(`document edge drag expected ${keyboardWidth + 64}px, got ${draggedWidth}px`)
+  }
+
+  const beforeReloadWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  await widthPage.reload()
+  await widthPage.waitForSelector('.doc-status--live', { timeout: 15000 })
+  const reloadedWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  if (reloadedWidth === beforeReloadWidth) ok('custom document width survives reload at first paint')
+  else fail(`custom width changed on reload: ${beforeReloadWidth}px -> ${reloadedWidth}px`)
+
+  const tableContained = await widthPage.evaluate(() => {
+    const wrapper = document.querySelector('.milkdown-table-block .table-wrapper')
+    return Boolean(wrapper) &&
+      document.documentElement.scrollWidth === document.documentElement.clientWidth &&
+      wrapper.scrollWidth >= wrapper.clientWidth
+  })
+  if (tableContained) ok('wide table stays in its scroll wrapper without page overflow')
+  else fail('wide table escaped its wrapper or forced page overflow')
+
+  await widthPage.click('.mode-control-trigger')
+  await widthPage.locator('.mode-control-option', { hasText: 'Read' }).click()
+  const readGeometry = await widthPage.evaluate(() => ({
+    main: document.querySelector('.doc-main').getBoundingClientRect().width,
+    canvas: document.querySelector('.doc-canvas').getBoundingClientRect().width,
+  }))
+  if (readGeometry.main === beforeReloadWidth && readGeometry.canvas === beforeReloadWidth) {
+    ok('Read mode uses the same custom document width')
+  } else {
+    fail(`Read mode width diverged: ${JSON.stringify(readGeometry)}`)
+  }
+
+  for (const viewport of [1152, 1024, 768, 390]) {
+    await widthPage.setViewportSize({ width: viewport, height: 900 })
+    const geometry = await widthPage.evaluate(() => ({
+      viewport: window.innerWidth,
+      canvas: document.querySelector('.doc-canvas').getBoundingClientRect().width,
+      main: document.querySelector('.doc-main').getBoundingClientRect().width,
+      handle: getComputedStyle(document.querySelector('.document-width-handle')).display,
+      overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    }))
+    if (
+      geometry.canvas === geometry.viewport &&
+      geometry.main === geometry.viewport &&
+      geometry.handle === 'none' &&
+      geometry.overflow === 0
+    ) {
+      ok(`Read mode fills the ${viewport}px viewport without resize chrome or overflow`)
+    } else {
+      fail(`Read mode ${viewport}px geometry diverged: ${JSON.stringify(geometry)}`)
+    }
+  }
+
+  await widthPage.setViewportSize({ width: 1024, height: 900 })
+  await widthPage.click('.mode-control-trigger')
+  await widthPage.locator('.mode-control-option', { hasText: 'Edit' }).click()
+  const tabletEditGeometry = await widthPage.evaluate(() => ({
+    viewport: window.innerWidth,
+    canvas: document.querySelector('.doc-canvas').getBoundingClientRect().width,
+    main: document.querySelector('.doc-main').getBoundingClientRect().width,
+    gutter: document.querySelector('.margin-gutter').getBoundingClientRect().width,
+    handle: getComputedStyle(document.querySelector('.document-width-handle')).display,
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }))
+  if (
+    tabletEditGeometry.canvas === tabletEditGeometry.viewport &&
+    tabletEditGeometry.main + tabletEditGeometry.gutter === tabletEditGeometry.viewport &&
+    tabletEditGeometry.handle === 'none' &&
+    tabletEditGeometry.overflow === 0
+  ) {
+    ok('Edit mode fills the iPad-width viewport around its review marker strip')
+  } else {
+    fail(`Edit mode iPad geometry diverged: ${JSON.stringify(tabletEditGeometry)}`)
+  }
+
+  await widthPage.setViewportSize({ width: 1440, height: 900 })
+  await widthPage.locator('.document-width-handle span').dblclick()
+  const resetGeometry = await widthPage.evaluate(() => ({
+    width: document.querySelector('.doc-main').getBoundingClientRect().width,
+    style: document.querySelector('.doc-page').style.getPropertyValue('--document-width'),
+  }))
+  if (resetGeometry.width === defaultWidth && resetGeometry.style === '') {
+    ok('double-click resets document width to the active theme measure')
+  } else {
+    fail(`document width reset diverged: ${JSON.stringify(resetGeometry)}`)
+  }
+  await widthPage.evaluate(() => { document.documentElement.dataset.theme = 'whitey' })
+  const whiteyDefaultWidth = await widthPage.locator('.doc-main').evaluate((el) => el.getBoundingClientRect().width)
+  if (whiteyDefaultWidth === 752) ok('width reset preserves Whitey’s wider theme measure')
+  else fail(`Whitey default width expected 752px, got ${whiteyDefaultWidth}px`)
+  await widthContext.close()
+
+  const ipadContext = await browser.newContext({
+    viewport: { width: 1366, height: 1024 },
+    hasTouch: true,
+    isMobile: true,
+    userAgent: 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+  })
+  const ipadPage = await ipadContext.newPage()
+  await ipadPage.goto(`${BASE}/d/${widthDoc.slug}`)
+  await ipadPage.waitForSelector('.doc-canvas')
+  const ipadGeometry = await ipadPage.evaluate(() => ({
+    coarse: matchMedia('(hover: none) and (pointer: coarse)').matches,
+    viewport: window.innerWidth,
+    canvas: document.querySelector('.doc-canvas').getBoundingClientRect().width,
+    main: document.querySelector('.doc-main').getBoundingClientRect().width,
+    gutter: document.querySelector('.margin-gutter').getBoundingClientRect().width,
+    handle: getComputedStyle(document.querySelector('.document-width-handle')).display,
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }))
+  if (
+    ipadGeometry.coarse &&
+    ipadGeometry.canvas === ipadGeometry.viewport &&
+    ipadGeometry.main + ipadGeometry.gutter === ipadGeometry.viewport &&
+    ipadGeometry.handle === 'none' &&
+    ipadGeometry.overflow === 0
+  ) {
+    ok('wide landscape iPad uses the full-width compact layout')
+  } else {
+    fail(`landscape iPad geometry diverged: ${JSON.stringify(ipadGeometry)}`)
+  }
+  await ipadContext.close()
 
   // --- Floating chrome placement: measured, centered, never covering ---
   const placeDoc = await (

--- a/test/integration/document_ui_preferences_test.rb
+++ b/test/integration/document_ui_preferences_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class DocumentUiPreferencesTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(title: "Preferences", seed_markdown: "# Preferences")
+  end
+
+  test "document width preference is exposed for first paint" do
+    cookies[:pruf_width] = "864"
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props { |props| props.dig(:ui, :document_width) == 864 }
+  end
+
+  test "document width preference is clamped to safe bounds" do
+    cookies[:pruf_width] = "20"
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props { |props| props.dig(:ui, :document_width) == 576 }
+
+    cookies[:pruf_width] = "9000"
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props { |props| props.dig(:ui, :document_width) == 1120 }
+  end
+
+  test "invalid document width preference uses the theme default" do
+    cookies[:pruf_width] = "default"
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props { |props| props.dig(:ui, :document_width).nil? }
+  end
+
+  private
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+end


### PR DESCRIPTION
Closes #72

## Summary
- add an accessible desktop document-edge handle with drag, keyboard, reset, and cookie-backed SSR persistence
- make Edit and Read layouts truly full-width at tablet/mobile sizes
- use the compact layout for coarse-pointer devices so wide landscape iPads are covered
- keep wide tables contained in their existing horizontal scroll wrapper

## Verification
- `bin/vite build --clear --mode=test && bin/rails test` (392 runs, 1,827 assertions)
- `bin/rubocop`
- `npm run check`
- `bin/vite build`
- agent-browser: drag/keyboard resize, constrained-width edge case, reload persistence, reset, Edit/Read parity, 1152/1024/768/390 geometry, no overflow/errors
- modern 1366px coarse-pointer iPad simulation: full canvas, hidden desktop handle, zero overflow

The full legacy `script/browser_check.mjs` still exits earlier on pre-existing sketch-renderer assertions; the width regression is added there and the complete width flow was verified independently.