### PR TITLE
Clarify document menus and simplify home

### DIFF
--- a/app/frontend/components/header_menu.tsx
+++ b/app/frontend/components/header_menu.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Link, router } from '@inertiajs/react'
 import { useMediaQuery } from '../lib/use_media_query'
 import { useDismissable } from '../lib/use_dismissable'
 import { OwnershipChip, type OwnershipPayload } from './ownership_chip'
 import { FeedbackButton } from './feedback_button'
+import { ThemePicker } from './theme_picker'
 import type { AccountPayload } from '../types/viewer'
 
 interface Props {
@@ -19,7 +20,7 @@ interface Props {
 }
 
 /**
- * The header's `⋯` overflow menu — content layer over the same popover
+ * The header's `⋯` document-options dialog — content layer over the same popover
  * mechanics as SharePopover (anchored absolute panel, outside-mousedown +
  * Escape to close). Holds the secondary chrome (Panel/Focus toggles,
  * Feedback) and the ownership section: "Yours" + delete confirm, "Owned by
@@ -40,6 +41,10 @@ export function HeaderMenu({
   const [lockFailed, setLockFailed] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  const viewLabelId = useId()
+  const accessLabelId = useId()
+  const accountLabelId = useId()
+  const helpLabelId = useId()
   // Same constraint as SharePopover: the sticky header's backdrop-filter is
   // the containing block for fixed descendants — the mobile sheet must
   // portal to body.
@@ -56,7 +61,7 @@ export function HeaderMenu({
       <button
         className="chrome-toggle header-menu-trigger"
         aria-expanded={open}
-        aria-haspopup="menu"
+        aria-haspopup="dialog"
         aria-label="More options"
         title="More options"
         onClick={() => setOpen((v) => !v)}
@@ -69,42 +74,46 @@ export function HeaderMenu({
             <div
               className="share-popover header-menu-popover"
               ref={popoverRef}
-              role="menu"
+              role="dialog"
               aria-label="Document options"
               onClick={(event) => event.stopPropagation()}
             >
-              <button
-                className="header-menu-item"
-                role="menuitemcheckbox"
-                aria-checked={panelOpen}
-                onClick={onTogglePanel}
-              >
-                <span className="header-menu-check" aria-hidden>
-                  {panelOpen ? '✓' : ''}
-                </span>
-                Side panel
-                <span className="header-menu-hint">⌘\</span>
-              </button>
-              <button
-                className="header-menu-item"
-                role="menuitemcheckbox"
-                aria-checked={focusMode}
-                onClick={onToggleFocus}
-              >
-                <span className="header-menu-check" aria-hidden>
-                  {focusMode ? '✓' : ''}
-                </span>
-                Suggestion focus
-                <span className="header-menu-hint">⌘.</span>
-              </button>
+              <div className="header-menu-group" role="group" aria-labelledby={viewLabelId}>
+                <div className="header-menu-label" id={viewLabelId}>View</div>
+                <button
+                  className="header-menu-item"
+                  aria-pressed={panelOpen}
+                  onClick={onTogglePanel}
+                >
+                  <span className="header-menu-check" aria-hidden>
+                    {panelOpen ? '✓' : ''}
+                  </span>
+                  Side panel
+                  <span className="header-menu-hint">⌘\</span>
+                </button>
+                <button
+                  className="header-menu-item"
+                  aria-pressed={focusMode}
+                  onClick={onToggleFocus}
+                >
+                  <span className="header-menu-check" aria-hidden>
+                    {focusMode ? '✓' : ''}
+                  </span>
+                  Suggestion focus
+                  <span className="header-menu-hint">⌘.</span>
+                </button>
+                <div className="header-menu-theme">
+                  <span>Theme</span>
+                  <ThemePicker />
+                </div>
+              </div>
               {showOwnership && (
-                <>
-                  <div className="header-menu-sep" role="separator" />
+                <div className="header-menu-group" role="group" aria-labelledby={accessLabelId}>
+                  <div className="header-menu-label" id={accessLabelId}>Access</div>
                   {ownership.yours && (
                     <button
                       className="header-menu-item"
-                      role="menuitemcheckbox"
-                      aria-checked={ownership.editing_locked}
+                      aria-pressed={ownership.editing_locked}
                       disabled={lockUpdating}
                       onClick={() => {
                         const locked = !ownership.editing_locked
@@ -142,20 +151,22 @@ export function HeaderMenu({
                     </div>
                   )}
                   <OwnershipChip slug={slug} ownership={ownership} claimerName={claimerName} />
-                </>
+                </div>
               )}
               {account && (
-                <>
-                  <div className="header-menu-sep" role="separator" />
+                <div className="header-menu-group" role="group" aria-labelledby={accountLabelId}>
+                  <div className="header-menu-label" id={accountLabelId}>Account</div>
                   <div className="header-menu-account" title={account.email}>{account.name}</div>
                   <Link href="/logout" method="delete" as="button" className="header-menu-item">
                     <span className="header-menu-check" aria-hidden>↪</span>
                     Sign out
                   </Link>
-                </>
+                </div>
               )}
-              <div className="header-menu-sep" role="separator" />
-              <FeedbackButton />
+              <div className="header-menu-group" role="group" aria-labelledby={helpLabelId}>
+                <div className="header-menu-label" id={helpLabelId}>Help</div>
+                <FeedbackButton />
+              </div>
             </div>
           )
           return isMobile

--- a/app/frontend/components/share_popover.tsx
+++ b/app/frontend/components/share_popover.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useMediaQuery } from '../lib/use_media_query'
 import { useDismissable } from '../lib/use_dismissable'
-import { ThemePicker } from './theme_picker'
 
 /** Share is two audiences, one URL: humans get the editor, agents fetching the
  *  same link discover the API. The popover teaches both — copy the link for a
@@ -83,8 +82,8 @@ export function SharePopover({
       onClick={(event) => event.stopPropagation()}
     >
       <div className="share-section">
-        <div className="share-section-title">People</div>
-        <p className="share-section-hint">Anyone with the link joins this live document.</p>
+        <div className="share-section-title">Share link</div>
+        <p className="share-section-hint">Anyone with the link can open and join this live document.</p>
         <div className="share-copy-row">
           <code className="share-url">{url}</code>
           <button className="share-copy" onClick={() => copy('link', url)}>
@@ -94,15 +93,15 @@ export function SharePopover({
       </div>
       <div className="share-section share-section--agent">
         <div className="share-section-title">
-          Your agent
+          Agent invite
           <span className={`share-agent-dot ${agentsActive > 0 ? 'is-on' : ''}`} />
           <span className="share-agent-state">
-            {agentsActive > 0 ? `${agentsActive} active now` : 'same URL, different audience'}
+            {agentsActive > 0 ? `${agentsActive} active now` : 'for an API-capable agent'}
           </span>
         </div>
         <p className="share-section-hint">
-          Agents fetching this link discover the API: state, suggestions, comments,
-          presence — identified by <code>X-Agent-Name</code>.
+          Give an agent this invite to discover the document API and join as an
+          attributed collaborator.
         </p>
         <button className="share-copy share-copy--wide" onClick={() => copy('agent', agentInvite)}>
           {copied === 'agent' ? 'Copied — paste it to your agent' : 'Copy agent invite'}
@@ -143,12 +142,6 @@ export function SharePopover({
           </p>
         )}
       </div>
-      {/* The header stays minimal — the reading theme lives here, on every
-          surface (desktop popover and mobile sheet alike). */}
-      <div className="share-section share-section--theme">
-        <div className="share-section-title">Theme</div>
-        <ThemePicker />
-      </div>
     </div>
   )
 
@@ -157,6 +150,7 @@ export function SharePopover({
       <button
         className="share-button"
         aria-expanded={open}
+        aria-haspopup="dialog"
         onClick={() => setOpen((v) => !v)}
       >
         Share

--- a/app/frontend/components/theme_picker.tsx
+++ b/app/frontend/components/theme_picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 export type ThemeName = 'proof' | 'whitey'
 
@@ -22,11 +22,9 @@ function applyTheme(theme: ThemeName): void {
 }
 
 export function ThemePicker() {
-  const [theme, setTheme] = useState<ThemeName>('proof')
-
-  useEffect(() => {
-    setTheme(currentTheme())
-  }, [])
+  const [theme, setTheme] = useState<ThemeName>(() =>
+    typeof document === 'undefined' ? 'proof' : currentTheme(),
+  )
 
   const pick = (next: ThemeName) => {
     setTheme(next)
@@ -34,7 +32,7 @@ export function ThemePicker() {
   }
 
   return (
-    <span className="theme-picker" role="radiogroup" aria-label="Reading theme">
+    <span className="theme-picker" role="radiogroup" aria-label="Theme">
       {(['proof', 'whitey'] as ThemeName[]).map((name) => (
         <button
           key={name}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -314,14 +314,6 @@ a:focus-visible {
   justify-content: center;
 }
 
-.landing-recent-heading {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--ink-faint);
-  margin-bottom: 0.5rem;
-}
-
 /* ---------------------------- Document library -------------------------- */
 .document-library {
   --document-library-muted: color-mix(in srgb, var(--ink-soft) 88%, var(--ink));
@@ -664,6 +656,58 @@ a:focus-visible {
 .landing-agent {
   margin-top: 2.5rem;
   text-align: left;
+}
+
+.landing-agent-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid color-mix(in srgb, var(--ink) 18%, var(--line));
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 18%, var(--line));
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 650;
+  cursor: pointer;
+  list-style: none;
+}
+
+.landing-agent-summary::-webkit-details-marker {
+  display: none;
+}
+
+.landing-agent-summary:hover {
+  color: var(--ink);
+}
+
+.landing-agent-summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.landing-agent-summary-action {
+  margin-left: auto;
+  color: var(--ink-faint);
+  font-size: 0.68rem;
+  font-weight: 550;
+}
+
+.landing-agent-summary-action--open,
+.landing-agent:not([open]) .landing-agent-content {
+  display: none;
+}
+
+.landing-agent[open] .landing-agent-summary-action--closed {
+  display: none;
+}
+
+.landing-agent[open] .landing-agent-summary-action--open {
+  display: inline;
+}
+
+.landing-agent-content {
+  padding-top: 0.9rem;
 }
 
 .landing-agent-hint {
@@ -2212,15 +2256,31 @@ a:focus-visible {
   padding: 0.28rem 0.5rem;
 }
 
-/* The ⋯ menu is a real menu: full-width rows, hover, no nested buttons.
- * OwnershipChip's chrome-toggles and the riffrec feedback button are
- * restyled into the same row register by scope. */
+/* The ⋯ surface is a grouped document-options dialog. OwnershipChip's
+ * chrome-toggles and the riffrec feedback button are restyled into the same
+ * full-width row register by scope. */
 .header-menu-popover {
-  width: 14.5rem;
+  width: 16.5rem;
   padding: 0.35rem;
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
+}
+
+.header-menu-group {
+  padding: 0.3rem;
+}
+
+.header-menu-group + .header-menu-group {
+  border-top: 1px solid var(--line);
+}
+
+.header-menu-label {
+  padding: 0.2rem 0.55rem 0.3rem;
+  color: var(--ink-faint);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .header-menu-item,
@@ -2273,12 +2333,6 @@ a:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-.header-menu-sep {
-  height: 1px;
-  background: var(--line);
-  margin: 0.3rem 0.35rem;
-}
-
 .header-menu-account {
   overflow: hidden;
   padding: 0.35rem 0.55rem 0.1rem;
@@ -2286,6 +2340,27 @@ a:focus-visible {
   font-size: 0.68rem;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.header-menu-theme {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.5rem 0.55rem 0.4rem;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 550;
+}
+
+.header-menu-theme .theme-picker {
+  display: flex;
+  width: 100%;
+}
+
+.header-menu-theme .theme-option {
+  flex: 1;
+  justify-content: center;
+  min-height: 2.25rem;
+  font-size: 0.74rem;
 }
 
 .header-menu-popover .ownership-owner {
@@ -2736,27 +2811,9 @@ a:focus-visible {
   background: var(--surface);
 }
 
-/* Reading theme lives in the share surface on every breakpoint —
- * the header stays minimal. */
-.share-section--theme {
-  border-top: 1px solid var(--line);
-}
-
 .share-section--export {
   border-top: 1px solid var(--line);
   background: var(--surface);
-}
-
-.share-popover .theme-picker {
-  display: flex;
-  width: 100%;
-}
-
-.share-popover .theme-option {
-  flex: 1;
-  justify-content: center;
-  min-height: 2.25rem;
-  font-size: 0.78rem;
 }
 
 .share-section-title {
@@ -2774,10 +2831,6 @@ a:focus-visible {
   font-size: 0.7rem;
   line-height: 1.45;
   color: var(--ink-faint);
-}
-
-.share-section-hint code {
-  font-size: 0.66rem;
 }
 
 .share-copy-row {
@@ -3143,7 +3196,7 @@ a:focus-visible {
     display: none;
   }
 
-  .share-popover .theme-option {
+  .header-menu-theme .theme-option {
     min-height: 44px;
   }
 
@@ -3846,6 +3899,15 @@ a:focus-visible {
 }
 
 @media (hover: none), (pointer: coarse) {
+  .header-menu-item,
+  .header-menu-status,
+  .header-menu-popover .chrome-toggle,
+  .header-menu-popover .feedback-button > button,
+  .header-menu-theme .theme-option,
+  .share-copy {
+    min-height: 44px;
+  }
+
   .sketch-download-button {
     min-width: 44px;
     min-height: 44px;

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -352,34 +352,40 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
             )}
           </section>
 
-          <section className="document-library document-library--recent" aria-labelledby="recent-documents-heading">
-            <div className="document-library-heading">
-              <div>
-                <h2 id="recent-documents-heading">Recently opened</h2>
-                <p>Documents from this browser</p>
+          {recent.length > 0 && (
+            <section className="document-library document-library--recent" aria-labelledby="recent-documents-heading">
+              <div className="document-library-heading">
+                <div>
+                  <h2 id="recent-documents-heading">Recently opened</h2>
+                  <p>Documents from this browser</p>
+                </div>
+              </div>
+              <DocumentGroup title="Recent" documents={recent} claimerName={claimerName} />
+            </section>
+          )}
+
+          <details className="landing-agent">
+            <summary className="landing-agent-summary">
+              <span>Have an agent start a doc</span>
+              <span className="landing-agent-summary-action landing-agent-summary-action--closed">
+                Show instructions
+              </span>
+              <span className="landing-agent-summary-action landing-agent-summary-action--open">
+                Hide instructions
+              </span>
+            </summary>
+            <div className="landing-agent-content">
+              <p className="landing-agent-hint">
+                Paste this to any agent that can make HTTP requests:
+              </p>
+              <div className="landing-agent-block">
+                <code>{agentInstruction}</code>
+                <button className="share-copy" onClick={copyInstruction}>
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
               </div>
             </div>
-            {recent.length > 0 ? (
-              <DocumentGroup title="Recent" documents={recent} claimerName={claimerName} />
-            ) : (
-              <p className="document-library-empty">
-                Documents you open in this browser show up here.
-              </p>
-            )}
-          </section>
-
-          <section className="landing-agent">
-            <h2 className="landing-recent-heading">Have an agent start a doc</h2>
-            <p className="landing-agent-hint">
-              Paste this to any agent that can make HTTP requests:
-            </p>
-            <div className="landing-agent-block">
-              <code>{agentInstruction}</code>
-              <button className="share-copy" onClick={copyInstruction}>
-                {copied ? 'Copied' : 'Copy'}
-              </button>
-            </div>
-          </section>
+          </details>
         </main>
         <footer className="landing-footer">
           <a

--- a/docs/plans/2026-06-26-009-feat-menu-home-ux-audit-plan.md
+++ b/docs/plans/2026-06-26-009-feat-menu-home-ux-audit-plan.md
@@ -1,0 +1,76 @@
+---
+title: "feat: Clarify document menus and simplify the home page"
+type: feat
+date: 2026-06-26
+issue: 75
+---
+
+# feat: Clarify document menus and simplify the home page
+
+## Summary
+
+Make Share about sharing and exporting, move the personal Theme preference into a clearly grouped document menu, and simplify the home page by removing redundant empty-state sections and progressively disclosing technical agent instructions.
+
+## Audit Findings
+
+1. **Share mixes unrelated concerns.** Human collaboration, agent collaboration, export, and personal appearance all live in one popover. Theme does not affect what recipients receive, so it does not belong under Share.
+2. **The overflow menu has no information hierarchy.** Side panel, suggestion focus, access controls, account state, deletion, and feedback appear as one list separated only by rules. The popover also claims `role="menu"` while embedding confirmations and other richer controls, which do not follow menu-item interaction semantics.
+3. **Share labels describe audiences inconsistently.** “People” and “Your agent” are less direct than “Share link” and “Agent invite,” and the agent explanation exposes protocol detail before the user asks for it.
+4. **The empty home repeats absence.** A new visitor sees empty “Your documents” and empty “Recently opened” sections back to back.
+5. **Technical setup competes with primary work.** The full agent API prompt is always expanded even though creating or opening a document is the main home-page action.
+
+## Requirements
+
+- R1. Theme is removed from Share and appears in the three-dot document menu.
+- R2. The document menu visibly groups view/appearance, access/ownership, account, and help concerns where those groups exist.
+- R3. The document popover uses dialog semantics suitable for its mixed controls, with an accurate trigger relationship and accessible group labels.
+- R4. Theme switching remains instant, persists across reloads, and retains touch-sized controls in the mobile menu sheet.
+- R5. Share contains only link sharing, agent invitation, and export/print actions, with concise task-oriented labels and copy.
+- R6. The home page omits “Recently opened” when there are no recent documents instead of showing a second empty state.
+- R7. Agent creation instructions remain available on the home page but are collapsed by default behind a native, keyboard-accessible disclosure.
+- R8. Existing ownership, editing-lock, account, feedback, export, copy, responsive-sheet, and theme behavior remain intact.
+
+## Key Decisions
+
+- KTD1. Keep Share and the document menu as separate entry points. Share remains a primary header action because collaboration is common; settings and secondary actions stay behind the three dots.
+- KTD2. Change the overflow surface from `role="menu"` to `role="dialog"`. It contains a radiogroup, ownership confirmation, account action, and feedback recorder—not a uniform command menu—so dialog semantics are more truthful and require no fake arrow-key menu model.
+- KTD3. Add lightweight section labels only where they clarify a real boundary. “View” owns panel/focus/theme, “Access” owns lock/ownership, “Account” appears for signed-in users, and “Help” owns feedback.
+- KTD4. Reuse `ThemePicker`; do not create another theme state path. Menu-specific CSS makes its two choices full-width and touch-sized.
+- KTD5. Use native `<details>/<summary>` for agent instructions. It provides disclosure semantics, keyboard support, and a no-JavaScript fallback without adding state machinery.
+- KTD6. Preserve the home document library introduced by the index redesign. This audit changes hierarchy and progressive disclosure, not grouping, dates, tags, or ownership behavior.
+
+## Implementation Units
+
+### U1. Share and document-menu information architecture
+
+- **Files:** `app/frontend/components/share_popover.tsx`, `app/frontend/components/header_menu.tsx`, `app/frontend/entrypoints/application.css`
+- **Approach:** Remove Theme from Share; rename its audience sections to “Share link” and “Agent invite” with shorter explanatory copy. Add a labelled View group containing panel/focus controls and ThemePicker to HeaderMenu. Group access, account, and help content, and change the trigger/popover to dialog semantics.
+- **Verification:** Share has no Theme control; the three-dot surface has exactly one Theme radiogroup; ownership/account/feedback render in the correct groups; theme changes instantly and persists; Escape/outside click still dismiss.
+
+### U2. Home-page progressive disclosure
+
+- **Files:** `app/frontend/pages/documents/index.tsx`, `app/frontend/entrypoints/application.css`
+- **Approach:** Render Recently opened only when it has content. Convert the always-expanded agent section into a quiet native disclosure with the full copy block inside. Keep sign-in, feedback, primary creation, document groups, tags, GitHub, and creator credit unchanged.
+- **Verification:** A fresh browser sees one document empty state and a collapsed agent disclosure; a browser with recents sees the recent library; opening the disclosure reveals a copyable instruction.
+
+### U3. Browser regression coverage
+
+- **Files:** `script/browser_check.mjs`
+- **Approach:** Update landing assertions for the conditional recent section and collapsed disclosure. Assert Share contains collaboration/export but no Theme, the document dialog contains grouped Theme controls, theme switching persists, and the mobile menu sheet keeps 44px targets without overflow.
+- **Verification:** Focused agent-browser checks pass at desktop and 390px; existing automated regression assertions reflect the new hierarchy.
+
+## Acceptance Examples
+
+- AE1. Given a document, when Share opens, then it presents Share link, Agent invite, and Export—and no Theme control.
+- AE2. Given the same document, when the three-dot button opens, then View contains side panel, suggestion focus, and Theme; changing to Whitey updates the mounted page immediately and survives reload.
+- AE3. Given a signed-in owner, then Access and Account are distinct, labelled groups and delete remains behind its confirmation.
+- AE4. Given a fresh browser on the home page, then only Your documents presents an empty state; Recently opened is absent and “Have an agent start a doc” is collapsed.
+- AE5. Given a 390px viewport, then Share and the document menu portal into full-width bottom sheets, their controls remain touch-sized, and the page has no horizontal overflow.
+
+## Risks
+
+- Moving Theme could accidentally leave share-scoped CSS as the only source of full-width/touch sizing. Add explicit header-menu theme styles before removing the share selectors.
+- Group labels inside a dialog must not become focusable noise. Use visible text plus `role="group"`/`aria-labelledby`, while keeping only actual controls in the tab order.
+- Hiding an empty recent library must not hide real claimable or non-owned recents. The condition is exactly `recent.length > 0`.
+- Native disclosure markers vary by browser. Replace only the visual marker, retain native summary semantics, and provide a clear open-state indicator.
+

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -41,7 +41,23 @@ try {
   }
   await landing.locator('.landing-byline', { hasText: 'creator of Compound Engineering' }).waitFor()
   await landing.getByRole('heading', { name: 'Your documents' }).waitFor()
-  await landing.getByRole('heading', { name: 'Recently opened' }).waitFor()
+  if ((await landing.getByRole('heading', { name: 'Recently opened' }).count()) === 0) {
+    ok('fresh home omits the redundant empty recently-opened section')
+  } else {
+    fail('fresh home still renders an empty recently-opened section')
+  }
+  const agentDisclosure = landing.locator('.landing-agent')
+  if (
+    !(await agentDisclosure.evaluate((el) => el.open)) &&
+    (await landing.locator('.landing-agent-content').evaluate((el) => getComputedStyle(el).display)) === 'none'
+  ) {
+    ok('agent creation instructions are collapsed by default')
+  } else {
+    fail('agent creation instructions compete with the primary home content')
+  }
+  await landing.locator('.landing-agent-summary').click()
+  await landing.locator('.landing-agent-block').waitFor({ state: 'visible' })
+  ok('agent creation disclosure reveals the copyable instructions')
   if ((await landing.locator('.format-label').count()) === 0) {
     ok('landing page organizes documents without format labels')
   } else {
@@ -1108,10 +1124,29 @@ try {
     .waitFor({ state: 'attached', timeout: 10000 })
   ok('image synced live to window B')
 
-  // --- Theme switch: instant, persistent ---
-  // The theme picker lives inside the Share popover since the header
-  // consolidation — open it first.
+  // --- Share/menu hierarchy + theme switch: instant, persistent ---
   await a.locator('.share-button').click()
+  if (
+    (await a.locator('.share-section-title', { hasText: 'Share link' }).count()) === 1 &&
+    (await a.locator('.share-section-title', { hasText: 'Agent invite' }).count()) === 1 &&
+    (await a.locator('.share-section-title', { hasText: 'Export' }).count()) === 1 &&
+    (await a.locator('.share-popover .theme-picker').count()) === 0
+  ) {
+    ok('Share contains collaboration and export without personal appearance')
+  } else {
+    fail('Share information architecture still mixes unrelated controls')
+  }
+  await a.keyboard.press('Escape')
+  await a.locator('.header-menu-trigger').click()
+  if (
+    (await a.locator('.header-menu-popover').getAttribute('role')) === 'dialog' &&
+    (await a.locator('.header-menu-label', { hasText: 'View' }).count()) === 1 &&
+    (await a.locator('.header-menu-theme .theme-picker').count()) === 1
+  ) {
+    ok('document options groups view controls and Theme in a dialog')
+  } else {
+    fail('document options did not expose the audited hierarchy')
+  }
   await a.locator('.theme-option', { hasText: 'Whitey' }).click()
   const themeNow = await a.evaluate(() => document.documentElement.dataset.theme)
   if (themeNow === 'whitey') ok('theme switched instantly (optimistic, no reload)')
@@ -1121,9 +1156,32 @@ try {
   const themeAfter = await a.evaluate(() => document.documentElement.dataset.theme)
   if (themeAfter === 'whitey') ok('theme persisted across reload')
   else fail(`theme lost on reload: ${themeAfter}`)
-  await a.locator('.share-button').click()
+  await a.locator('.header-menu-trigger').click()
   await a.locator('.theme-option', { hasText: 'Thinkroom' }).click()
   await a.keyboard.press('Escape')
+
+  await a.setViewportSize({ width: 390, height: 844 })
+  await a.locator('.header-menu-trigger').click()
+  const mobileMenuGeometry = await a.evaluate(() => ({
+    portaled: Boolean(document.querySelector('body > .share-backdrop .header-menu-popover')),
+    width: document.querySelector('.header-menu-popover')?.getBoundingClientRect().width,
+    themeHeights: Array.from(document.querySelectorAll('.header-menu-theme .theme-option')).map(
+      (el) => el.getBoundingClientRect().height,
+    ),
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }))
+  if (
+    mobileMenuGeometry.portaled &&
+    mobileMenuGeometry.width === 390 &&
+    mobileMenuGeometry.themeHeights.every((height) => height >= 44) &&
+    mobileMenuGeometry.overflow === 0
+  ) {
+    ok('mobile document options use a full-width, touch-sized sheet')
+  } else {
+    fail(`mobile document options geometry diverged: ${JSON.stringify(mobileMenuGeometry)}`)
+  }
+  await a.keyboard.press('Escape')
+  await a.setViewportSize({ width: 1280, height: 900 })
 
   // --- Agent loop: an agent joins over plain HTTP while humans watch ---
   const agentHeaders = { 'X-Agent-Name': 'Scout', 'Content-Type': 'application/json' }


### PR DESCRIPTION
Closes #75

## Summary
- move Theme from Share into a grouped document-options dialog
- simplify Share to link sharing, agent invitation, and export
- label View, Access, Account, and Help groups and keep touch targets usable on coarse-pointer devices
- hide the redundant empty Recently opened section and collapse agent API instructions by default
- preserve instant, reload-safe theme switching without an initial active-state flash

## Verification
- `bin/vite build --clear --mode=test && bin/rails test` (392 runs, 1,827 assertions)
- `bin/rubocop`
- `npm run check`
- `bin/vite build`
- agent-browser desktop/390px: fresh-home hierarchy, keyboard disclosure, Share/menu separation, owned Access group, Theme persistence, full-width mobile sheet, 44px theme targets, zero overflow/errors

The full legacy `script/browser_check.mjs` remains blocked earlier by pre-existing sketch-renderer assertions; the updated menu/home regression is recorded there and the affected flow was verified independently.