### PR TITLE
Make document modes addressable

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -51,6 +51,17 @@ class DocumentsController < InertiaController
   def show
     document = Document.find_by!(slug: params[:slug])
     link_preview_request = link_preview_user_agent?
+    mode = requested_document_mode(document)
+
+    # Mode URLs express an editing capability. If the current viewer cannot
+    # use that capability, send them to the canonical Read URL before the
+    # request can affect recents or claim a pending seed. The demo is the one
+    # intentionally fixed-mode document: it remains Edit at its established
+    # base URL, so alternate demo URLs canonicalize there too.
+    if params[:mode].present? &&
+       (document.slug == "demo" || !document.writable_by?(owner_token, user: current_user))
+      return redirect_to document_page_path(document.slug), status: :see_other
+    end
 
     if request.format.json? || params[:format] == "json"
       return render json: AgentGuide.state(document, request.base_url)
@@ -73,13 +84,11 @@ class DocumentsController < InertiaController
     seed_granted = initial_render? && !prefetch_request? && !link_preview_request && document.try_claim_seed
 
     render inertia: "documents/show", props: {
-      # UI prefs ride server-readable cookies so SSR renders panel/focus/mode/
-      # width at their stored values on first paint — no post-hydration flip for
-      # users who closed the panel, enabled focus, or resized the document. The
-      # client writes these cookies on change (see show.tsx). mode for the demo
-      # doc is forced to "edit" client-side (modeLocked), so any stale cookie is
-      # ignored there.
-      ui: ui_prefs,
+      # Cookie-backed UI prefs and the path-derived mode are both available to
+      # SSR, so the first paint and hydration agree without a client-side flip.
+      # Mode deliberately comes from the URL rather than a browser preference:
+      # links, reloads, and Inertia history are now its source of truth.
+      ui: ui_prefs(mode:),
       document: document.slice(:id, :slug, :title, :content_format).merge(
         seed_content: document.seed_content,
         seed_granted: seed_granted,
@@ -136,7 +145,7 @@ class DocumentsController < InertiaController
       **ownership
     )
     remember_recent(document)
-    redirect_to document_page_path(document.slug), status: :see_other
+    redirect_to document_mode_path(document.slug, "edit"), status: :see_other
   end
 
   # Explicit, deliberate claim — a button click, never a GET side effect, so
@@ -393,11 +402,8 @@ class DocumentsController < InertiaController
   end
 
   # Cookie-backed UI prefs, read server-side so SSR's first paint matches the
-  # user's stored panel/focus/mode/width (no flip). Defaults match the historical
-  # localStorage fallbacks: panel open, focus off, Edit mode. Cookies are
-  # "1"/"0" flags, a "edit|suggest|comment|read" mode string, and a clamped
-  # pixel width; anything else falls back to the default.
-  UI_MODES = %w[edit suggest comment read].freeze
+  # user's stored panel/focus/width (no flip). Mode is path-derived and supplied
+  # by #show. Cookies are "1"/"0" flags plus a clamped pixel width.
   MIN_DOCUMENT_WIDTH = 576
   MAX_DOCUMENT_WIDTH = 1120
   LINK_PREVIEW_USER_AGENTS = /(?:
@@ -406,12 +412,18 @@ class DocumentsController < InertiaController
     iframely|opengraph
   )/ix
 
-  def ui_prefs
+  def requested_document_mode(document)
+    return "edit" if document.slug == "demo"
+
+    params[:mode].presence || "read"
+  end
+
+  def ui_prefs(mode:)
     document_width = Integer(cookies[:pruf_width], exception: false)
     {
       panel_open: cookies[:pruf_panel] != "0",
       focus_mode: cookies[:pruf_focus] == "1",
-      mode: UI_MODES.include?(cookies[:pruf_mode]) ? cookies[:pruf_mode] : "edit",
+      mode:,
       document_width: document_width&.clamp(MIN_DOCUMENT_WIDTH, MAX_DOCUMENT_WIDTH)
     }
   end

--- a/app/frontend/lib/cookies.ts
+++ b/app/frontend/lib/cookies.ts
@@ -1,7 +1,7 @@
 /**
  * Server-readable UI-pref persistence. Cookies (not localStorage) are the
- * source of truth for first paint so SSR can render panel/focus/mode/width at
- * their stored values — no post-hydration flip. Mirrors the theme cookie convention
+ * source of truth for first paint so SSR can render panel/focus/width at their
+ * stored values — no post-hydration flip. Document mode is URL-derived. Mirrors the theme cookie convention
  * in theme_picker.tsx: path=/, SameSite=Lax, one-year max-age.
  */
 const ONE_YEAR_SECONDS = 31536000

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -139,6 +139,9 @@ interface CommentTarget {
   text: string
 }
 
+const documentModePath = (slug: string, mode: EditorMode) =>
+  `/d/${encodeURIComponent(slug)}${mode === 'read' ? '' : `/${mode}`}`
+
 // Server-side anchor cap is 10 KB; a truncated anchor still matches as a
 // prefix within the block (findTextRange matches the exact search string).
 // Single encode + byte slice; a byte-boundary cut mid-codepoint decodes to
@@ -230,23 +233,33 @@ export default function DocumentShow({
   const [suggestionNotice, setSuggestionNotice] = useState<string | null>(null)
   const [composerAnchor, setComposerAnchor] = useState<string | null>(null)
   const viewRef = useRef<EditorView | null>(null)
-  // Hydration-safe init from server-rendered cookie prefs: SSR and the client's
-  // first render derive panel/focus/mode/width from the same `ui` props, so a user
-  // who closed the panel (etc.) sees it closed at first paint — no flip. The
-  // client writes the cookie on change (effects below); cookies, not
-  // localStorage, are now the source of truth for first paint.
+  // Hydration-safe init from server-rendered prefs: cookies supply panel/focus/
+  // width while the URL supplies mode, so SSR and the first client render agree.
   const [panelOpen, setPanelOpen] = useState(ui.panel_open)
   const [focusMode, setFocusMode] = useState(ui.focus_mode)
   const [documentWidth, setDocumentWidth] = useState<number | null>(ui.document_width)
-  // Demo doc always opens in Edit and stays locked there — a stale mode cookie
-  // can't override it (the server also defaults it; this is the client guard).
+  // Demo doc always opens in Edit and stays locked there. Ordinary documents
+  // take mode directly from the Inertia page props/history entry.
   const demoModeLocked = doc.slug === 'demo'
-  const [mode, setMode] = useState<EditorMode>(demoModeLocked ? 'edit' : ui.mode)
+  const mode = demoModeLocked ? 'edit' : ui.mode
   const effectiveMode: EditorMode = ownership.can_write ? mode : 'read'
   const modeLocked = demoModeLocked || !ownership.can_write
   const changeMode = useCallback((nextMode: EditorMode) => {
-    if (!modeLocked) setMode(nextMode)
-  }, [modeLocked])
+    if (modeLocked || nextMode === mode) return
+
+    // This is an Inertia client-side visit: it pushes URL + props into Inertia
+    // history without fetching or remounting the collaborative editor. Native
+    // Back/Forward restores the matching ui.mode from that history entry.
+    router.push<DocumentProps>({
+      url: documentModePath(doc.slug, nextMode),
+      props: (props) => ({
+        ...props,
+        ui: { ...props.ui, mode: nextMode },
+      }),
+      preserveState: true,
+      preserveScroll: true,
+    })
+  }, [doc.slug, mode, modeLocked])
   const isReading = effectiveMode === 'read'
   const connectionIdentity = viewer.account ? `account:${viewer.account.id}` : 'guest'
   const editorSessionKey = `${doc.slug}:${ownership.can_write ? 'write' : 'read'}`
@@ -313,19 +326,32 @@ export default function DocumentShow({
     if (isMobile && composerAnchor !== null) setActiveSheet('comments')
   }, [isMobile, composerAnchor])
 
-  // Persist prefs to server-readable cookies on change so the next first paint
-  // (SSR) matches. No hydration gate is needed: state initializes from the same
-  // cookie-backed props, so the first commit writes back the value it just read
-  // — idempotent, not a clobber. Demo doc never persists mode (it's locked).
+  // Persist cookie-backed prefs on change so their next SSR paint matches.
+  // Mode is intentionally absent: its shareable URL and Inertia history entry
+  // are the durable source of truth now.
   useEffect(() => {
     setCookieFlag('pruf_panel', panelOpen)
   }, [panelOpen])
   useEffect(() => {
     setCookieFlag('pruf_focus', focusMode)
   }, [focusMode])
+
+  // An owner may lock editing while another viewer is on a write-mode URL.
+  // Replace (rather than push) that now-invalid entry with canonical Read so
+  // Back cannot return the viewer to an unavailable mode.
   useEffect(() => {
-    if (!demoModeLocked) setCookie('pruf_mode', mode)
-  }, [mode, demoModeLocked])
+    if (demoModeLocked || ownership.can_write || ui.mode === 'read') return
+
+    router.replace<DocumentProps>({
+      url: documentModePath(doc.slug, 'read'),
+      props: (props) => ({
+        ...props,
+        ui: { ...props.ui, mode: 'read' },
+      }),
+      preserveState: true,
+      preserveScroll: true,
+    })
+  }, [demoModeLocked, doc.slug, ownership.can_write, ui.mode])
 
   // ⌘1–4 selects Edit/Suggest/Comment/Read. ⌘\ toggles the side panel,
   // and ⌘. toggles suggestion focus. Control mirrors Command for parity.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "oauth_callbacks#failure"
 
   get "d/:slug/og.png", to: "document_og_images#show", as: :document_og_image
+  get "d/:slug/:mode", to: "documents#show", as: :document_mode,
+                       constraints: { mode: /edit|suggest|comment/ }
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
   patch "d/:slug/tags", to: "documents#update_tags", as: :document_tags

--- a/docs/plans/2026-06-26-010-feat-mode-urls-plan.md
+++ b/docs/plans/2026-06-26-010-feat-mode-urls-plan.md
@@ -1,0 +1,71 @@
+---
+title: "feat: Make document modes addressable in the URL"
+type: feat
+date: 2026-06-26
+issue: 76
+---
+
+# feat: Make document modes addressable in the URL
+
+## Summary
+
+Make Read the canonical document URL, give Edit, Suggest, and Comment stable mode-specific URLs, and use Inertia client-side history state so switching modes is instant while links, reloads, and browser Back/Forward all restore the intended mode.
+
+## Requirements
+
+- R1. `/d/:slug` opens an ordinary document in Read mode.
+- R2. `/d/:slug/edit`, `/d/:slug/suggest`, and `/d/:slug/comment` open the matching mode.
+- R3. Choosing a mode updates the address bar without a network request, editor remount, scroll reset, or loss of in-progress client state.
+- R4. Browser Back and Forward restore both the URL and active mode.
+- R5. Reloading or directly opening a mode URL restores that mode from the server-rendered Inertia props; a stale mode cookie cannot override the URL.
+- R6. If the viewer cannot write, a direct non-Read URL redirects to `/d/:slug`; if write permission disappears while the page is open, the client replaces the current history entry with the canonical Read URL.
+- R7. The special demo remains locked to Edit at its established `/d/demo` URL; alternate demo mode URLs redirect to that canonical URL.
+- R8. Existing sharing, Open Graph, agent API, collaboration, mode shortcuts, responsive mode control, and document action routes remain intact.
+- R9. Creating a document through the home page redirects its creator to `/d/:slug/edit`, so the creation flow remains immediately actionable even though the canonical document URL is Read.
+
+## Key Decisions
+
+- KTD1. Use explicit constrained Rails routes for `edit|suggest|comment`, keeping the existing named `/d/:slug` route canonical for Read. Do not add `/read` or accept arbitrary mode segments.
+- KTD2. Keep mode inside the existing `ui` Inertia prop, but derive it from the request path rather than `pruf_mode`. This preserves the current component contract and gives SSR and hydration one source of truth.
+- KTD3. Use Inertia 3's client-side `router.push` with both `url` and updated props. That creates real Inertia history entries without issuing HTTP requests; native Back/Forward can therefore restore the saved page props as well as the path.
+- KTD4. Treat all non-Read modes as unavailable when `ownership.can_write` is false, matching the existing locked mode control and `effectiveMode` guard. Authorization-dependent redirects use 303 and are not permanent-cache redirects.
+- KTD5. Preserve the demo exception introduced with document modes. Its fixed Edit behavior remains canonical at `/d/demo`, so mode URLs do not imply choices the control refuses to make.
+- KTD6. Retire mode-cookie persistence. The URL now provides stronger, shareable, reload-safe persistence; panel, focus, theme, and width cookies remain unchanged.
+- KTD7. Keep library/document-share destinations canonical, but treat creation as an editing intent. Only the successful UI create redirect adds `/edit`; API response URLs and ordinary document links remain `/d/:slug`.
+
+## Implementation Units
+
+### U1. Server routing and canonical mode resolution
+
+- **Files:** `config/routes.rb`, `app/controllers/documents_controller.rb`, `test/integration/document_mode_routing_test.rb`
+- **Approach:** Add a constrained mode route before the canonical document route. Resolve the requested mode before rendering, feed it into `ui_prefs`, and redirect unavailable or noncanonical demo mode paths before recent-list, seed-claim, or render side effects. Remove `pruf_mode` parsing and redirect successful UI creation to the new Edit route.
+- **Verification:** Integration tests cover the canonical Read URL, each write-mode URL, unknown modes, locked non-owner redirects, locked owner access, demo canonicalization, the create-to-Edit redirect, and mode props in initial Inertia responses.
+
+### U2. Inertia client-side mode history
+
+- **Files:** `app/frontend/pages/documents/show.tsx`
+- **Approach:** Derive the active mode directly from `ui.mode`. On an allowed change, call `router.push` with the matching mode URL and a copied `ui.mode` prop while preserving state and scroll. Replace a non-Read history entry with the canonical URL if a later ownership update removes write access. Remove the mode-cookie write effect.
+- **Verification:** Choosing modes changes the control and path instantly without a document request or editor remount; Back/Forward restores modes from Inertia history without a document request; keyboard shortcuts use the same path.
+
+### U3. End-to-end browser coverage
+
+- **Files:** `script/browser_check.mjs`
+- **Approach:** Replace mode-cookie setup with mode URLs and add a focused sequence that checks canonical Read, client-side path changes, no mode-navigation document request, Back/Forward restoration, reload persistence, and locked-viewer fallback. Update editable smoke-check pages to enter through `/edit` where necessary.
+- **Verification:** Focused browser checks pass on desktop and the mode control remains usable in the existing responsive sheet flow.
+
+## Acceptance Examples
+
+- AE1. Given a writable document at `/d/abc`, when it loads, then the control says Read mode and the editor is non-editable.
+- AE2. When the viewer chooses Edit, then the control says Edit mode and the address becomes `/d/abc/edit` without requesting a new page or losing the current editor session.
+- AE3. When the viewer then chooses Suggest and presses Back, then the browser returns to `/d/abc/edit` and the control returns to Edit; Forward restores Suggest.
+- AE4. Given `/d/abc/comment` in a fresh tab, then the initial server response and hydrated page both use Comment mode.
+- AE5. Given a locked document opened by a non-owner at `/d/abc/edit`, then the server redirects to `/d/abc` and the page opens in Read mode.
+- AE6. Given `/d/demo/suggest`, then the server redirects to `/d/demo`, which remains locked in Edit mode.
+- AE7. Given the home page, when the viewer creates a document, then the redirect lands on `/d/:slug/edit` ready for typing.
+
+## Risks
+
+- Inertia history can update the path without updating page props. Always push both together; otherwise Back/Forward restores a URL whose control still shows the previous mode.
+- A normal Inertia `visit` would refetch the full document and can remount the collaborative editor. Use the client-side `push` API and assert no mode-navigation request occurs.
+- Permission can change after initial render. Keep the server redirect for direct visits and add a client replacement path for ownership partial reloads.
+- Changing the canonical default from Edit to Read affects browser smoke setup. Enter `/edit` explicitly for scenarios that type, toggle edit-only controls, or insert sketches.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -121,7 +121,7 @@ try {
     })
   ).json()
   const c = await browser.newPage()
-  await c.goto(`${BASE}/d/${created.slug}`)
+  await c.goto(`${BASE}/d/${created.slug}/edit`)
   await c.waitForSelector('.doc-status--live', { timeout: 15000 })
   await c.waitForTimeout(800)
   await c.click('.milkdown .ProseMirror')
@@ -148,8 +148,8 @@ try {
   ).json()
   const titleA = await browser.newPage()
   const titleB = await browser.newPage()
-  await titleA.goto(`${BASE}/d/${titleDoc.slug}`)
-  await titleB.goto(`${BASE}/d/${titleDoc.slug}`)
+  await titleA.goto(`${BASE}/d/${titleDoc.slug}/edit`)
+  await titleB.goto(`${BASE}/d/${titleDoc.slug}/edit`)
   await titleA.waitForSelector('.doc-status--live', { timeout: 15000 })
   await titleB.waitForSelector('.doc-status--live', { timeout: 15000 })
   const renamedTitle = `Renamed title ${Date.now()}`
@@ -218,8 +218,8 @@ try {
       server.send(message)
     })
   })
-  await taskA.goto(`${BASE}/d/${taskDoc.slug}`)
-  await taskB.goto(`${BASE}/d/${taskDoc.slug}`)
+  await taskA.goto(`${BASE}/d/${taskDoc.slug}/edit`)
+  await taskB.goto(`${BASE}/d/${taskDoc.slug}/edit`)
   await taskA.waitForSelector('.doc-status--live', { timeout: 15000 })
   await taskB.waitForSelector('.doc-status--live', { timeout: 15000 })
   const taskCheckboxes = taskA.locator(
@@ -287,8 +287,7 @@ try {
   // tracked as suggestions. Attr-only task transactions must bypass the
   // suggest-changes transform or the native control toggles without changing
   // ProseMirror/Yjs and silently reverts on reload.
-  await taskA.context().addCookies([{ name: 'pruf_mode', value: 'suggest', url: BASE }])
-  await taskA.reload()
+  await taskA.goto(`${BASE}/d/${taskDoc.slug}/suggest`)
   await taskA.waitForSelector('.doc-status--live', { timeout: 15000 })
   await taskA.waitForFunction(
     () => document.querySelector('.mode-control-trigger')?.textContent?.includes('Suggest'),
@@ -330,8 +329,8 @@ try {
   const sketchA = await browser.newPage({ viewport: { width: 1280, height: 900 } })
   const sketchB = await browser.newPage({ viewport: { width: 1280, height: 900 } })
   await Promise.all([
-    sketchA.goto(`${BASE}/d/${sketchDoc.slug}`),
-    sketchB.goto(`${BASE}/d/${sketchDoc.slug}`),
+    sketchA.goto(`${BASE}/d/${sketchDoc.slug}/edit`),
+    sketchB.goto(`${BASE}/d/${sketchDoc.slug}/edit`),
   ])
   await Promise.all([
     sketchA.waitForSelector('.doc-status--live', { timeout: 15000 }),
@@ -704,7 +703,7 @@ try {
     })
   ).json()
   const insertSketchPage = await browser.newPage({ viewport: { width: 1280, height: 900 } })
-  await insertSketchPage.goto(`${BASE}/d/${emptySketchDoc.slug}`)
+  await insertSketchPage.goto(`${BASE}/d/${emptySketchDoc.slug}/edit`)
   await insertSketchPage.waitForSelector('.doc-status--live', { timeout: 15000 })
   await insertSketchPage.locator('.sketch-add-inline').waitFor({ state: 'visible', timeout: 5000 })
   await insertSketchPage.locator('.sketch-add-inline').click()
@@ -775,7 +774,7 @@ try {
   await failedChunkPage.route('**/vite-dev/editor/sketch/excalidraw_canvas.tsx*', (route) =>
     route.abort(),
   )
-  await failedChunkPage.goto(`${BASE}/d/${malformedDoc.slug}`)
+  await failedChunkPage.goto(`${BASE}/d/${malformedDoc.slug}/edit`)
   await failedChunkPage.locator('.milkdown .ProseMirror').click()
   await failedChunkPage.keyboard.press('Meta+ArrowDown')
   await failedChunkPage.keyboard.press('Enter')
@@ -805,7 +804,7 @@ try {
     permissions: ['clipboard-read', 'clipboard-write'],
   })
   const clipboardPage = await clipboardContext.newPage()
-  await clipboardPage.goto(`${BASE}/d/${clipboardDoc.slug}`)
+  await clipboardPage.goto(`${BASE}/d/${clipboardDoc.slug}/edit`)
   await clipboardPage.waitForSelector('.doc-status--live', { timeout: 15000 })
   await clipboardPage.locator('.milkdown .ProseMirror').click()
   await clipboardPage.keyboard.press('Meta+A')
@@ -959,7 +958,7 @@ try {
     }
   }
   const fmPage = await browser.newPage()
-  await fmPage.goto(`${BASE}/d/${fmDoc.slug}`)
+  await fmPage.goto(`${BASE}/d/${fmDoc.slug}/edit`)
   await fmPage.waitForSelector('.doc-status--live', { timeout: 15000 })
   await assertFrontmatterRender(fmPage, 'initial render')
   // Typing at the very top of the doc displaces the frontmatter; the guard
@@ -1401,6 +1400,17 @@ try {
   const winA = await makePage('a')
   await winA.goto(`${BASE}/d/${trackDoc.slug}`)
   await winA.waitForSelector('.doc-status--live', { timeout: 15000 })
+  const modeDocumentRequests = []
+  const recordModeDocumentRequest = (request) => {
+    const path = new URL(request.url()).pathname
+    if (request.method() === 'GET' && path.startsWith(`/d/${trackDoc.slug}`)) {
+      modeDocumentRequests.push(path)
+    }
+  }
+  winA.on('request', recordModeDocumentRequest)
+  await winA.locator('.milkdown .ProseMirror').evaluate((node) => {
+    node.dataset.modeSession = 'preserved'
+  })
   if ((await winA.locator('.mode-control-trigger').count()) === 1) {
     ok('header renders one mode control')
   } else {
@@ -1411,21 +1421,67 @@ try {
   } else {
     fail('mode control is not in the left header')
   }
+  if (
+    new URL(winA.url()).pathname === `/d/${trackDoc.slug}` &&
+    (await winA.locator('.mode-control-trigger').textContent())?.includes('Read mode') &&
+    (await winA.locator('.milkdown .ProseMirror').getAttribute('contenteditable')) === 'false'
+  ) {
+    ok('canonical document URL opens in Read mode')
+  } else {
+    fail(`canonical document URL did not open in Read mode: ${winA.url()}`)
+  }
   await winA.evaluate(() => window.dispatchEvent(new KeyboardEvent('keydown', {
     key: '3', code: 'Digit3', metaKey: true, bubbles: true, cancelable: true,
   })))
+  await winA.waitForURL(`${BASE}/d/${trackDoc.slug}/comment`)
   if ((await winA.locator('.mode-control-trigger').textContent())?.includes('Comment mode')) {
-    ok('Command+3 switches to Comment mode')
+    ok('Command+3 switches to Comment mode and pushes its URL')
   } else {
     fail('Command+3 did not switch to Comment mode')
   }
+  await winA.click('.mode-control-trigger')
+  await winA.locator('.mode-control-option', { hasText: 'Suggest' }).click()
+  await winA.waitForURL(`${BASE}/d/${trackDoc.slug}/suggest`)
+  const editorSessionPreserved = await winA
+    .locator('.milkdown .ProseMirror')
+    .getAttribute('data-mode-session')
+  if (modeDocumentRequests.length === 0 && editorSessionPreserved === 'preserved') {
+    ok('mode choices update Inertia state without a document request or editor remount')
+  } else {
+    fail(
+      `mode choice disturbed the editor: requests=${JSON.stringify(modeDocumentRequests)} ` +
+      `session=${editorSessionPreserved}`,
+    )
+  }
+  await winA.goBack()
+  await winA.waitForURL(`${BASE}/d/${trackDoc.slug}/comment`)
+  await winA.waitForFunction(
+    () => document.querySelector('.mode-control-trigger')?.textContent?.includes('Comment mode'),
+  )
+  await winA.goForward()
+  await winA.waitForURL(`${BASE}/d/${trackDoc.slug}/suggest`)
+  await winA.waitForFunction(
+    () => document.querySelector('.mode-control-trigger')?.textContent?.includes('Suggest mode'),
+  )
+  if (modeDocumentRequests.length === 0) {
+    ok('Back and Forward restore mode from Inertia history without a document request')
+  } else {
+    fail(`mode history made document requests: ${JSON.stringify(modeDocumentRequests)}`)
+  }
+  winA.off('request', recordModeDocumentRequest)
+  await winA.reload()
+  await winA.waitForSelector('.doc-status--live', { timeout: 15000 })
+  if ((await winA.locator('.mode-control-trigger').textContent())?.includes('Suggest mode')) {
+    ok('reloading a mode URL restores that mode from the server')
+  } else {
+    fail('Suggest mode URL did not survive reload')
+  }
+
   const winB = await makePage('b')
-  await winB.goto(`${BASE}/d/${trackDoc.slug}`)
+  await winB.goto(`${BASE}/d/${trackDoc.slug}/edit`)
   await winB.waitForSelector('.doc-status--live', { timeout: 15000 })
   await winA.waitForTimeout(1500)
 
-  await winA.click('.mode-control-trigger')
-  await winA.locator('.mode-control-option', { hasText: 'Suggest' }).click()
   const sugSentinel = `tracked-${Date.now()}`
   await winA.click('.milkdown .ProseMirror')
   await winA.keyboard.press('Meta+ArrowDown')
@@ -1548,7 +1604,7 @@ try {
   ).json()
   const widthContext = await browser.newContext({ viewport: { width: 1440, height: 900 } })
   const widthPage = await widthContext.newPage()
-  await widthPage.goto(`${BASE}/d/${widthDoc.slug}`)
+  await widthPage.goto(`${BASE}/d/${widthDoc.slug}/edit`)
   await widthPage.waitForSelector('.doc-status--live', { timeout: 15000 })
   await widthPage.waitForSelector('.document-width-handle')
 
@@ -1685,7 +1741,7 @@ try {
     userAgent: 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
   })
   const ipadPage = await ipadContext.newPage()
-  await ipadPage.goto(`${BASE}/d/${widthDoc.slug}`)
+  await ipadPage.goto(`${BASE}/d/${widthDoc.slug}/edit`)
   await ipadPage.waitForSelector('.doc-canvas')
   const ipadGeometry = await ipadPage.evaluate(() => ({
     coarse: matchMedia('(hover: none) and (pointer: coarse)').matches,
@@ -1725,7 +1781,7 @@ try {
     })
   ).json()
   const p = await makePage('a')
-  await p.goto(`${BASE}/d/${placeDoc.slug}`)
+  await p.goto(`${BASE}/d/${placeDoc.slug}/edit`)
   await p.waitForSelector('.doc-status--live', { timeout: 15000 })
   await p.waitForTimeout(1000)
 
@@ -1857,7 +1913,7 @@ try {
   await seedSuggestion('bravo')
 
   const q = await makePage('persist')
-  await q.goto(`${BASE}/d/${persistDoc.slug}`)
+  await q.goto(`${BASE}/d/${persistDoc.slug}/edit`)
   await q.waitForSelector('.doc-status--live', { timeout: 15000 })
   await q.waitForTimeout(800) // initial Yjs bind + margin card placement settle
 
@@ -2001,7 +2057,7 @@ try {
     replaces: 'Original receipts copy.',
   })
   const bulk = await makePage('a')
-  await bulk.goto(`${BASE}/d/${bulkDoc.slug}`)
+  await bulk.goto(`${BASE}/d/${bulkDoc.slug}/edit`)
   await bulk.waitForSelector('.doc-status--live', { timeout: 15000 })
   await bulk.waitForTimeout(1000)
 

--- a/test/integration/document_create_test.rb
+++ b/test/integration/document_create_test.rb
@@ -13,6 +13,7 @@ class DocumentCreateTest < ActionDispatch::IntegrationTest
     assert_equal "human", doc.seed_author_kind
     assert_equal "Quiet Falcon", doc.seed_author_name
     assert_equal doc.owner_name, doc.seed_author_name
+    assert_redirected_to document_mode_path(doc.slug, "edit")
   end
 
   test "human-created doc without a name falls back to Anonymous" do

--- a/test/integration/document_mode_routing_test.rb
+++ b/test/integration/document_mode_routing_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class DocumentModeRoutingTest < ActionDispatch::IntegrationTest
+  setup do
+    @document = Document.create!(title: "Addressable modes", seed_markdown: "# Addressable modes")
+  end
+
+  test "canonical document URL renders Read mode even with a stale mode cookie" do
+    cookies[:pruf_mode] = "suggest"
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_response :ok
+    assert_inertia_props { |props| props.dig(:ui, :mode) == "read" }
+  end
+
+  test "explicit mode URLs render their matching mode" do
+    %w[edit suggest comment].each do |mode|
+      get document_mode_path(@document.slug, mode), headers: browser
+
+      assert_response :ok
+      assert_inertia_props { |props| props.dig(:ui, :mode) == mode }
+    end
+  end
+
+  test "unknown mode URLs do not route to the document page" do
+    get "/d/#{@document.slug}/review", headers: browser
+
+    assert_response :not_found
+  end
+
+  test "locked owner can open an explicit mode but another viewer is redirected to Read" do
+    get root_path
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+    patch document_editing_lock_path(@document.slug), params: { locked: true }
+
+    get document_mode_path(@document.slug, "suggest"), headers: browser
+    assert_response :ok
+    assert_inertia_props { |props| props.dig(:ui, :mode) == "suggest" }
+
+    other = open_session
+    other.get document_mode_path(@document.slug, "edit"), headers: browser
+    assert_equal 303, other.response.status
+    assert_equal document_page_path(@document.slug), URI(other.response.location).path
+  end
+
+  test "unavailable mode redirect does not claim a pending document seed" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      claimed_at: Time.current,
+      editing_locked: true
+    )
+
+    get document_mode_path(@document.slug, "comment"), headers: browser
+
+    assert_response :see_other
+    assert_redirected_to document_page_path(@document.slug)
+    assert_equal "pending", @document.reload.seed_state
+  end
+
+  test "demo keeps its established URL locked to Edit" do
+    demo = Document.create!(title: "Demo", slug: "demo")
+
+    get document_page_path(demo.slug), headers: browser
+    assert_response :ok
+    assert_inertia_props { |props| props.dig(:ui, :mode) == "edit" }
+
+    get document_mode_path(demo.slug, "suggest"), headers: browser
+    assert_response :see_other
+    assert_redirected_to document_page_path(demo.slug)
+  end
+
+  private
+
+  def browser
+    { "User-Agent" => "Mozilla/5.0" }
+  end
+end


### PR DESCRIPTION
## Summary

- make `/d/:slug` canonical Read and add `/edit`, `/suggest`, and `/comment` mode URLs
- switch modes through Inertia client history without a document request or editor remount
- restore modes on reload and Back/Forward, redirect locked viewers to canonical Read, and keep `/d/demo` locked to Edit
- send newly created documents directly to `/edit` and retire mode-cookie persistence

## Verification

- `bin/vite build --clear --mode=test && bin/rails test` (398 runs, 1854 assertions)
- `bin/rubocop`
- `npm run check`
- `bin/vite build`
- agent-browser: canonical Read, direct Edit/Suggest, zero-request mode switching, Back/Forward, reload persistence, locked fallback, and create-to-Edit

Closes #76