### PR TITLE
Add shared-link access levels

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -15,9 +15,18 @@ module Api
 
     rescue_from Document::EditingLockedError do
       render json: {
-        error: "This document is read-only. Only its owner can make changes.",
+        error: "This link does not allow editing.",
+        link_access: document.link_access,
         editing_locked: true,
-        next_action: "Wait for the browser owner to turn off Read only for others, then retry."
+        next_action: "Wait for the browser owner to change link access to Can edit, then retry."
+      }, status: :locked
+    end
+
+    rescue_from Document::CommentingLockedError do
+      render json: {
+        error: "This link does not allow commenting.",
+        link_access: document.link_access,
+        next_action: "Wait for the browser owner to allow comments or editing, then retry."
       }, status: :locked
     end
 
@@ -50,6 +59,10 @@ module Api
 
     def with_document_write_access(&block)
       document.with_write_access(&block)
+    end
+
+    def with_document_comment_access(&block)
+      document.with_comment_access(&block)
     end
 
     def participation_example

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     # POST /api/docs/:slug/comments — leave a comment anchored to text.
     def create
-      comment = with_document_write_access do
+      comment = with_document_comment_access do
         posted = Comment.post!(
           document:,
           author_name: current_agent,
@@ -27,7 +27,7 @@ module Api
     # The web UI resolves over a CSRF-protected Inertia request; agents get the
     # same capability here over plain HTTP, attributed via X-Agent-Name.
     def resolve
-      comment = with_document_write_access do
+      comment = with_document_comment_access do
         found = document.comments.find(params[:id])
         found.resolve!
         Activity.log!(

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < InertiaController
 
   def create
     document = Document.find_by!(slug: params[:slug])
-    with_document_write_access(document) do
+    with_document_comment_access(document) do
       Comment.post!(
         document:,
         author_name: preferred_name(params[:author_name], fallback: "Anonymous"),
@@ -28,7 +28,7 @@ class CommentsController < InertiaController
   def resolve
     comment = Comment.find(params[:id])
     document = comment.document
-    with_document_write_access(document) do
+    with_document_comment_access(document) do
       comment.resolve!
       Activity.log!(
         document:,

--- a/app/controllers/concerns/document_write_authorization.rb
+++ b/app/controllers/concerns/document_write_authorization.rb
@@ -3,6 +3,7 @@ module DocumentWriteAuthorization
 
   included do
     rescue_from Document::EditingLockedError, with: :render_document_read_only
+    rescue_from Document::CommentingLockedError, with: :render_document_commenting_disabled
   end
 
   private
@@ -10,6 +11,11 @@ module DocumentWriteAuthorization
   def with_document_write_access(document, &block)
     @write_document = document
     document.with_write_access(token: owner_token, user: current_user, &block)
+  end
+
+  def with_document_comment_access(document, &block)
+    @write_document = document
+    document.with_comment_access(token: owner_token, user: current_user, &block)
   end
 
   def render_document_read_only
@@ -20,6 +26,16 @@ module DocumentWriteAuthorization
     else
       redirect_back fallback_location: document ? document_page_path(document.slug) : root_path,
                     inertia: { errors: { document: "This document is read-only" } }
+    end
+  end
+
+  def render_document_commenting_disabled
+    document = @write_document
+    if request.format.json?
+      render json: { error: "This link does not allow commenting." }, status: :locked
+    else
+      redirect_back fallback_location: document ? document_page_path(document.slug) : root_path,
+                    inertia: { errors: { document: "Commenting is not enabled for this link" } }
     end
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -59,7 +59,7 @@ class DocumentsController < InertiaController
     # intentionally fixed-mode document: it remains Edit at its established
     # base URL, so alternate demo URLs canonicalize there too.
     if params[:mode].present? &&
-       (document.slug == "demo" || !document.writable_by?(owner_token, user: current_user))
+       (document.slug == "demo" || !document_mode_available?(document, mode))
       return redirect_to document_page_path(document.slug), status: :see_other
     end
 
@@ -199,6 +199,27 @@ class DocumentsController < InertiaController
     "1" => true, "0" => false,
     1 => true, 0 => false
   }.freeze
+
+  def update_link_access
+    document = Document.find_by!(slug: params[:slug])
+    access = params[:access].to_s
+    unless Document::LINK_ACCESS_LEVELS.include?(access)
+      return redirect_back fallback_location: document_page_path(document.slug), status: :see_other,
+                           inertia: { errors: { link_access: "Choose Can edit, Can comment, or Can view" } }
+    end
+
+    document.set_link_access!(
+      access:,
+      token: owner_token,
+      user: current_user
+    )
+    redirect_back fallback_location: document_page_path(document.slug), status: :see_other
+  rescue Document::NotOwnerError
+    redirect_back fallback_location: document_page_path(params[:slug]), status: :see_other,
+                  inertia: { errors: { link_access: "Only the owner can change link access" } }
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, status: :see_other
+  end
 
   def update_editing_lock
     document = Document.find_by!(slug: params[:slug])
@@ -416,6 +437,14 @@ class DocumentsController < InertiaController
     return "edit" if document.slug == "demo"
 
     params[:mode].presence || "read"
+  end
+
+  def document_mode_available?(document, mode)
+    if mode == "comment"
+      document.commentable_by?(owner_token, user: current_user)
+    else
+      document.writable_by?(owner_token, user: current_user)
+    end
   end
 
   def ui_prefs(mode:)

--- a/app/frontend/components/header_menu.tsx
+++ b/app/frontend/components/header_menu.tsx
@@ -3,7 +3,11 @@ import { createPortal } from 'react-dom'
 import { Link, router } from '@inertiajs/react'
 import { useMediaQuery } from '../lib/use_media_query'
 import { useDismissable } from '../lib/use_dismissable'
-import { OwnershipChip, type OwnershipPayload } from './ownership_chip'
+import {
+  OwnershipChip,
+  type LinkAccess,
+  type OwnershipPayload,
+} from './ownership_chip'
 import { FeedbackButton } from './feedback_button'
 import { ThemePicker } from './theme_picker'
 import type { AccountPayload } from '../types/viewer'
@@ -18,6 +22,16 @@ interface Props {
   claimerName: string
   account: AccountPayload | null
 }
+
+const LINK_ACCESS_OPTIONS: ReadonlyArray<{
+  value: LinkAccess
+  label: string
+  hint: string
+}> = [
+  { value: 'edit', label: 'Can edit', hint: 'Edit, suggest, and comment' },
+  { value: 'comment', label: 'Can comment', hint: 'Comment and read' },
+  { value: 'view', label: 'Can view', hint: 'Read only' },
+]
 
 /**
  * The header's `⋯` document-options dialog — content layer over the same popover
@@ -37,8 +51,8 @@ export function HeaderMenu({
   account,
 }: Props) {
   const [open, setOpen] = useState(false)
-  const [lockUpdating, setLockUpdating] = useState(false)
-  const [lockFailed, setLockFailed] = useState(false)
+  const [accessUpdating, setAccessUpdating] = useState(false)
+  const [accessFailed, setAccessFailed] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const viewLabelId = useId()
@@ -52,9 +66,7 @@ export function HeaderMenu({
   useDismissable(open, () => setOpen(false), [rootRef, popoverRef])
 
   const showOwnership = ownership.yours || ownership.claimed || ownership.claimable
-  let lockLabel = 'Read only for others'
-  if (lockUpdating) lockLabel = 'Updating access…'
-  else if (lockFailed) lockLabel = 'Could not update — retry'
+  const activeAccess = LINK_ACCESS_OPTIONS.find(({ value }) => value === ownership.link_access)!
 
   return (
     <div className="share-root header-menu-root" ref={rootRef}>
@@ -110,44 +122,64 @@ export function HeaderMenu({
               {showOwnership && (
                 <div className="header-menu-group" role="group" aria-labelledby={accessLabelId}>
                   <div className="header-menu-label" id={accessLabelId}>Access</div>
-                  {ownership.yours && (
-                    <button
-                      className="header-menu-item"
-                      aria-pressed={ownership.editing_locked}
-                      disabled={lockUpdating}
-                      onClick={() => {
-                        const locked = !ownership.editing_locked
-                        setLockUpdating(true)
-                        setLockFailed(false)
-                        router.optimistic((props: { ownership?: OwnershipPayload }) => ({
-                          ownership: {
-                            ...(props.ownership ?? ownership),
-                            editing_locked: locked,
-                            can_write: true,
-                          },
-                        })).patch(
-                          `/d/${slug}/editing_lock`,
-                          { locked },
-                          {
-                            only: ['ownership', 'activities'],
-                            preserveScroll: true,
-                            async: true,
-                            onError: () => setLockFailed(true),
-                            onFinish: () => setLockUpdating(false),
-                          },
-                        )
-                      }}
+                  {ownership.yours ? (
+                    <div
+                      className="header-menu-access"
+                      role="radiogroup"
+                      aria-label="Anyone with the link"
                     >
-                      <span className="header-menu-check" aria-hidden>
-                        {ownership.editing_locked ? '✓' : ''}
-                      </span>
-                      {lockLabel}
-                    </button>
-                  )}
-                  {ownership.editing_locked && !ownership.yours && (
+                      {LINK_ACCESS_OPTIONS.map(({ value, label, hint }) => (
+                        <button
+                          key={value}
+                          type="button"
+                          role="radio"
+                          aria-checked={ownership.link_access === value}
+                          className="header-menu-access-option"
+                          disabled={accessUpdating}
+                          onClick={() => {
+                            if (value === ownership.link_access) return
+                            setAccessUpdating(true)
+                            setAccessFailed(false)
+                            router.optimistic((props: { ownership?: OwnershipPayload }) => ({
+                              ownership: {
+                                ...(props.ownership ?? ownership),
+                                link_access: value,
+                                editing_locked: value !== 'edit',
+                                can_write: true,
+                                can_comment: true,
+                              },
+                            })).patch(
+                              `/d/${slug}/link_access`,
+                              { access: value },
+                              {
+                                only: ['ownership', 'activities'],
+                                preserveScroll: true,
+                                async: true,
+                                onError: () => setAccessFailed(true),
+                                onFinish: () => setAccessUpdating(false),
+                              },
+                            )
+                          }}
+                        >
+                          <span className="header-menu-access-check" aria-hidden>
+                            {ownership.link_access === value ? '✓' : ''}
+                          </span>
+                          <span>
+                            <span className="header-menu-access-label">{label}</span>
+                            <span className="header-menu-access-hint">{hint}</span>
+                          </span>
+                        </button>
+                      ))}
+                      {accessFailed && (
+                        <span className="header-menu-access-error" role="alert">
+                          Could not update link access — try again
+                        </span>
+                      )}
+                    </div>
+                  ) : (
                     <div className="header-menu-status" role="status">
-                      <span className="header-menu-check" aria-hidden>🔒</span>
-                      Read only — locked by owner
+                      <span className="header-menu-check" aria-hidden>↗</span>
+                      Anyone with the link {activeAccess.label.toLowerCase()}
                     </div>
                   )}
                   <OwnershipChip slug={slug} ownership={ownership} claimerName={claimerName} />

--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -36,9 +36,12 @@ export const MODE_SHORTCUTS = Object.fromEntries(
   MODE_OPTIONS.map(({ shortcut, value }) => [`Digit${shortcut}`, value]),
 ) as Record<string, EditorMode>
 
+const ALL_MODES = MODE_OPTIONS.map(({ value }) => value)
+
 interface Props {
   mode: EditorMode
   onChange: (mode: EditorMode) => void
+  availableModes?: readonly EditorMode[]
   /** Demo doc: control renders but stays locked to Edit. */
   locked?: boolean
   lockedReason?: string
@@ -49,7 +52,13 @@ interface Props {
  * current mode, opening to the four modes with hints. Per-visitor UI state
  * only — switching never affects other collaborators.
  */
-export function ModeControl({ mode, onChange, locked = false, lockedReason }: Props) {
+export function ModeControl({
+  mode,
+  onChange,
+  availableModes = ALL_MODES,
+  locked = false,
+  lockedReason,
+}: Props) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
@@ -70,6 +79,8 @@ export function ModeControl({ mode, onChange, locked = false, lockedReason }: Pr
           key={value}
           role="option"
           aria-selected={mode === value}
+          disabled={!availableModes.includes(value)}
+          title={!availableModes.includes(value) ? `This link cannot use ${label} mode` : hint}
           className={`mode-control-option ${mode === value ? 'is-active' : ''}`}
           onClick={() => {
             onChange(value)

--- a/app/frontend/components/ownership_chip.tsx
+++ b/app/frontend/components/ownership_chip.tsx
@@ -2,13 +2,17 @@ import { useRef, useState } from 'react'
 import { router } from '@inertiajs/react'
 import { useClaim } from '../lib/use_claim'
 
+export type LinkAccess = 'edit' | 'comment' | 'view'
+
 export interface OwnershipPayload {
   claimed: boolean
   claimable: boolean
   owner_name: string | null
   yours: boolean
+  link_access: LinkAccess
   editing_locked: boolean
   can_write: boolean
+  can_comment: boolean
 }
 
 interface Props {

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2307,6 +2307,69 @@ a:focus-visible {
   color: var(--ink-faint);
 }
 
+.header-menu-access {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.header-menu-access-option {
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  gap: 0.45rem;
+  width: 100%;
+  border: none;
+  border-radius: 7px;
+  padding: 0.45rem 0.55rem;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.header-menu-access-option:hover,
+.header-menu-access-option[aria-checked='true'] {
+  background: var(--accent-soft);
+}
+
+.header-menu-access-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.header-menu-access-option:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.header-menu-access-check {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2rem;
+}
+
+.header-menu-access-label,
+.header-menu-access-hint {
+  display: block;
+}
+
+.header-menu-access-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.header-menu-access-hint {
+  margin-top: 0.05rem;
+  color: var(--ink-faint);
+  font-size: 0.68rem;
+}
+
+.header-menu-access-error {
+  padding: 0.25rem 0.55rem;
+  color: #a1372c;
+  font-size: 0.68rem;
+}
+
 .header-menu-item:disabled {
   cursor: wait;
   opacity: 0.65;
@@ -2478,6 +2541,15 @@ a:focus-visible {
 
 .mode-control-option:hover {
   background: var(--accent-soft);
+}
+
+.mode-control-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.mode-control-option:disabled:hover {
+  background: transparent;
 }
 
 .mode-control-option.is-active {
@@ -3901,6 +3973,7 @@ a:focus-visible {
 @media (hover: none), (pointer: coarse) {
   .header-menu-item,
   .header-menu-status,
+  .header-menu-access-option,
   .header-menu-popover .chrome-toggle,
   .header-menu-popover .feedback-button > button,
   .header-menu-theme .theme-option,

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -142,6 +142,12 @@ interface CommentTarget {
 const documentModePath = (slug: string, mode: EditorMode) =>
   `/d/${encodeURIComponent(slug)}${mode === 'read' ? '' : `/${mode}`}`
 
+const availableDocumentModes = (ownership: OwnershipPayload): EditorMode[] => {
+  if (ownership.can_write) return ['edit', 'suggest', 'comment', 'read']
+  if (ownership.can_comment) return ['comment', 'read']
+  return ['read']
+}
+
 // Server-side anchor cap is 10 KB; a truncated anchor still matches as a
 // prefix within the block (findTextRange matches the exact search string).
 // Single encode + byte slice; a byte-boundary cut mid-codepoint decodes to
@@ -242,10 +248,15 @@ export default function DocumentShow({
   // take mode directly from the Inertia page props/history entry.
   const demoModeLocked = doc.slug === 'demo'
   const mode = demoModeLocked ? 'edit' : ui.mode
-  const effectiveMode: EditorMode = ownership.can_write ? mode : 'read'
-  const modeLocked = demoModeLocked || !ownership.can_write
+  const availableModes = useMemo(
+    () => availableDocumentModes(ownership),
+    [ownership.can_comment, ownership.can_write],
+  )
+  const modeAvailable = availableModes.includes(mode)
+  const effectiveMode: EditorMode = modeAvailable ? mode : 'read'
+  const modeLocked = demoModeLocked || availableModes.length === 1
   const changeMode = useCallback((nextMode: EditorMode) => {
-    if (modeLocked || nextMode === mode) return
+    if (modeLocked || !availableModes.includes(nextMode) || nextMode === mode) return
 
     // This is an Inertia client-side visit: it pushes URL + props into Inertia
     // history without fetching or remounting the collaborative editor. Native
@@ -259,7 +270,7 @@ export default function DocumentShow({
       preserveState: true,
       preserveScroll: true,
     })
-  }, [doc.slug, mode, modeLocked])
+  }, [availableModes, doc.slug, mode, modeLocked])
   const isReading = effectiveMode === 'read'
   const connectionIdentity = viewer.account ? `account:${viewer.account.id}` : 'guest'
   const editorSessionKey = `${doc.slug}:${ownership.can_write ? 'write' : 'read'}`
@@ -340,7 +351,7 @@ export default function DocumentShow({
   // Replace (rather than push) that now-invalid entry with canonical Read so
   // Back cannot return the viewer to an unavailable mode.
   useEffect(() => {
-    if (demoModeLocked || ownership.can_write || ui.mode === 'read') return
+    if (demoModeLocked || availableModes.includes(ui.mode)) return
 
     router.replace<DocumentProps>({
       url: documentModePath(doc.slug, 'read'),
@@ -351,7 +362,7 @@ export default function DocumentShow({
       preserveState: true,
       preserveScroll: true,
     })
-  }, [demoModeLocked, doc.slug, ownership.can_write, ui.mode])
+  }, [availableModes, demoModeLocked, doc.slug, ui.mode])
 
   // ⌘1–4 selects Edit/Suggest/Comment/Read. ⌘\ toggles the side panel,
   // and ⌘. toggles suggestion focus. Control mirrors Command for parity.
@@ -360,7 +371,7 @@ export default function DocumentShow({
       if (!(event.metaKey || event.ctrlKey)) return
       const shortcutMode = MODE_SHORTCUTS[event.code] ?? MODE_SHORTCUTS[`Digit${event.key}`]
       if (shortcutMode) {
-        if (modeLocked) return
+        if (modeLocked || !availableModes.includes(shortcutMode)) return
         event.preventDefault()
         changeMode(shortcutMode)
         return
@@ -377,7 +388,7 @@ export default function DocumentShow({
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [changeMode, modeLocked])
+  }, [availableModes, changeMode, modeLocked])
 
   // Human presence from Yjs awareness. Self is filtered out — the
   // IdentityChip represents you; a duplicate avatar next to it is noise.
@@ -1088,11 +1099,12 @@ export default function DocumentShow({
             <ModeControl
               mode={effectiveMode}
               onChange={changeMode}
+              availableModes={availableModes}
               locked={modeLocked}
               lockedReason={
-                ownership.can_write
-                  ? undefined
-                  : 'Read only — the document owner locked editing'
+                modeLocked && !demoModeLocked
+                  ? 'Can view — the owner limited this link to reading'
+                  : undefined
               }
             />
             <span

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,9 +1,11 @@
 class Document < ApplicationRecord
   class EditingLockedError < StandardError; end
+  class CommentingLockedError < StandardError; end
   class NotOwnerError < StandardError; end
   DEFAULT_SEED = "# Untitled\n\nStart writing — everything you type is attributed to you.\n"
   DEFAULT_HTML_SEED = "<h1>Untitled</h1><p>Start writing — everything you type is attributed to you.</p>"
   CONTENT_FORMATS = %w[markdown html].freeze
+  LINK_ACCESS_LEVELS = %w[edit comment view].freeze
   MAX_CONTENT_BYTES = 2.megabytes
   MAX_TAGS = 8
   MAX_TAG_LENGTH = 32
@@ -36,10 +38,12 @@ class Document < ApplicationRecord
 
   before_validation :ensure_slug, on: :create
   before_validation :normalize_tags
+  before_validation :sync_legacy_editing_lock
 
   validates :title, presence: true
   validates :slug, presence: true, uniqueness: true
   validates :content_format, inclusion: { in: CONTENT_FORMATS }
+  validates :link_access, inclusion: { in: LINK_ACCESS_LEVELS }
   validate :content_format_is_immutable, on: :update
   # owner_name is broadcast to every client and served to agents — unbounded
   # names are an amplification vector, so cap it (deliberate exception to the
@@ -120,11 +124,21 @@ class Document < ApplicationRecord
   end
 
   def writable_by?(token, user: nil)
-    !editing_locked? || owned_by?(token, user:)
+    link_access == "edit" || owned_by?(token, user:)
+  end
+
+  def commentable_by?(token, user: nil)
+    link_access != "view" || owned_by?(token, user:)
   end
 
   def assert_write_access!(token: nil, user: nil)
-    raise EditingLockedError, "This document is read-only." unless writable_by?(token, user:)
+    raise EditingLockedError, "This link does not allow editing." unless writable_by?(token, user:)
+
+    self
+  end
+
+  def assert_comment_access!(token: nil, user: nil)
+    raise CommentingLockedError, "This link does not allow commenting." unless commentable_by?(token, user:)
 
     self
   end
@@ -138,28 +152,52 @@ class Document < ApplicationRecord
     end
   end
 
+  def with_comment_access(token: nil, user: nil)
+    with_lock do
+      reload
+      assert_comment_access!(token:, user:)
+
+      yield
+    end
+  end
+
+  # Compatibility predicate for clients that still understand the previous
+  # binary field. Both Comment and View are "editing locked" in that vocabulary.
+  def editing_locked? = link_access != "edit"
+
   def set_editing_locked!(locked:, token:, user: nil)
+    set_link_access!(access: locked ? "view" : "edit", token:, user:)
+  end
+
+  def set_link_access!(access:, token:, user: nil)
+    access = access.to_s
+    unless LINK_ACCESS_LEVELS.include?(access)
+      raise ArgumentError, "link access must be edit, comment, or view"
+    end
+
     changed = false
     actor_name = user&.name || owner_name || "Anonymous"
 
     with_lock do
       reload
-      raise NotOwnerError, "Only the owner can change editing access." unless owned_by?(token, user:)
-      next if editing_locked? == locked
+      raise NotOwnerError, "Only the owner can change link access." unless owned_by?(token, user:)
+      next if link_access == access
 
-      update!(editing_locked: locked)
+      update!(link_access: access)
       activities.create!(
         actor_name:,
         actor_kind: "human",
-        action: locked ? "locked_editing" : "unlocked_editing",
-        detail: locked ? "made the document read-only for others" : "reopened the document for editing"
+        action: "changed_link_access",
+        detail: "set link access to #{access}"
       )
       changed = true
     end
 
     if changed
       DocumentMetaChannel.broadcast_event(self, :activities)
-      DocumentMetaChannel.broadcast_event(self, :editing_lock, locked:)
+      # Keep the established event name so clients mounted during a rolling
+      # deploy still reload their ownership props. New payloads include access.
+      DocumentMetaChannel.broadcast_event(self, :editing_lock, locked: editing_locked?, access: link_access)
     end
     self
   end
@@ -254,8 +292,10 @@ class Document < ApplicationRecord
       claimable: claimable?,
       owner_name: owner_name,
       yours: owned_by?(viewer_token, user: viewer_user),
+      link_access:,
       editing_locked: editing_locked?,
-      can_write: writable_by?(viewer_token, user: viewer_user)
+      can_write: writable_by?(viewer_token, user: viewer_user),
+      can_comment: commentable_by?(viewer_token, user: viewer_user)
     }
   end
 
@@ -294,6 +334,10 @@ class Document < ApplicationRecord
   end
 
   private
+
+  def sync_legacy_editing_lock
+    self.editing_locked = link_access != "edit" if link_access.present?
+  end
 
   def normalize_tags
     seen = Set.new

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -267,7 +267,7 @@ class AgentGuide
         "Tracked changes use <ins data-suggestion-id> / <del data-suggestion-id> in the source snapshot. They are human-typed suggestions pending review, not your proposals, and are not resolvable through this API.",
         "Review is human-gated by design: accepting/rejecting suggestions and advancing review states happen in the editor, by humans. Your job is to propose well.",
         "Ownership: a human can claim a document in the browser; claimed docs show an owner in this payload (claimable: false means nobody can ever claim it, e.g. the demo). Claiming is browser-only (cookie-based) — agents cannot claim, so don't POST to any claim path. When a human claims, a claimed_document activity appears in the event feed with their name.",
-        "Editing access: editing_locked=true means the owner made this document read-only for everyone else. You can keep reading state, presence, and events, but suggestions and comments return 423 until the browser owner unlocks it. Agents cannot change this setting.",
+        "Link access: link_access is edit, comment, or view. can_write permits document updates and suggestions; can_comment permits comments. Comment links allow comments but not suggestions or document writes, and View links allow reads/presence/events only. editing_locked remains a compatibility field and is true for both comment and view. Disallowed writes return 423. Agents cannot change this setting.",
         "A claimed document can be deleted by its owner, after which every endpoint here returns 404. Treat a 404 on a previously-working slug as deletion, not an outage to retry.",
         "Document creation, suggestion, and comment writes are rate-limited per source IP. A 429 response means retry later; inspect each endpoint's rate_limits field for the current windows."
       ]
@@ -421,10 +421,11 @@ class AgentGuide
         ## Ownership
         A human can claim a document in their browser; the claimed owner shows
         in the state payload. Claiming is browser-only (cookie-based) — agents
-        cannot claim. When editing_locked is true, everyone except the owner is
-        read-only: keep reading state and events, but wait for the browser owner
-        to unlock before proposing suggestions or comments. Agents cannot change
-        this setting. An owner can delete their document, after which every
+        cannot claim. link_access is edit, comment, or view: edit allows suggestions
+        and comments, comment allows comments but not suggestions or document
+        writes, and view is read-only. Inspect can_write and can_comment for the
+        effective capability; editing_locked remains a compatibility field. Agents
+        cannot change this setting. An owner can delete their document, after which every
         endpoint returns 404: treat a 404 on a previously-working slug as deletion,
         not an outage to retry.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "d/:slug", to: "documents#show", as: :document_page
   post "d/:slug/claim", to: "documents#claim", as: :claim_document
   patch "d/:slug/tags", to: "documents#update_tags", as: :document_tags
+  patch "d/:slug/link_access", to: "documents#update_link_access", as: :document_link_access
   patch "d/:slug/editing_lock", to: "documents#update_editing_lock", as: :document_editing_lock
   delete "d/:slug", to: "documents#destroy", as: :destroy_document
   post "d/:slug/snapshot", to: "documents#snapshot", as: :document_snapshot

--- a/db/migrate/20260626120000_add_link_access_to_documents.rb
+++ b/db/migrate/20260626120000_add_link_access_to_documents.rb
@@ -1,0 +1,18 @@
+class AddLinkAccessToDocuments < ActiveRecord::Migration[8.1]
+  def up
+    add_column :documents, :link_access, :string, default: "edit", null: false
+    execute <<~SQL.squish
+      UPDATE documents
+      SET link_access = 'view'
+      WHERE editing_locked = 1
+    SQL
+    add_check_constraint :documents,
+                         "link_access IN ('edit', 'comment', 'view')",
+                         name: "documents_link_access_check"
+  end
+
+  def down
+    remove_check_constraint :documents, name: "documents_link_access_check"
+    remove_column :documents, :link_access
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_120000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -93,6 +93,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_110000) do
     t.text "content_markdown"
     t.datetime "created_at", null: false
     t.boolean "editing_locked", default: false, null: false
+    t.string "link_access", default: "edit", null: false
     t.string "owner_name", limit: 255
     t.string "owner_token"
     t.json "provenance_spans", default: []
@@ -111,6 +112,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_110000) do
     t.index ["slug"], name: "index_documents_on_slug", unique: true
     t.index ["user_id"], name: "index_documents_on_user_id"
     t.check_constraint "content_format IN ('markdown', 'html')", name: "documents_content_format"
+    t.check_constraint "link_access IN ('edit', 'comment', 'view')", name: "documents_link_access_check"
     t.check_constraint "user_id IS NULL OR owner_token IS NULL", name: "documents_single_owner"
   end
 

--- a/docs/plans/2026-06-26-011-feat-link-access-levels-plan.md
+++ b/docs/plans/2026-06-26-011-feat-link-access-levels-plan.md
@@ -1,0 +1,87 @@
+---
+title: "feat: Expand shared-link access to view, comment, or edit"
+type: feat
+date: 2026-06-26
+issue: 77
+---
+
+# feat: Expand shared-link access to view, comment, or edit
+
+## Summary
+
+Replace the owner’s binary “Read only for others” switch with one document-wide shared-link role: Can edit, Can comment, or Can view. Owners keep full control; everyone else receives the capability attached to the link, with matching mode URLs, UI affordances, browser writes, and Agent API enforcement.
+
+## Requirements
+
+- R1. Every document has one shared-link access level: `edit`, `comment`, or `view`; new documents default to `edit` to preserve today’s collaboration behavior.
+- R2. The owner can change link access from the document options dialog using an explicit three-choice control with clear labels and selected state.
+- R3. Owners always retain Edit, Suggest, Comment, and Read access regardless of the selected link role.
+- R4. A link editor can use every mode and all existing document/comment/suggestion actions.
+- R5. A link commenter can open Comment and Read modes, create and resolve comments, but cannot enter Edit or Suggest, mutate Yjs content, toggle tasks, submit suggestions, or write snapshots/sync updates.
+- R6. A link viewer can only use Read mode and cannot create or resolve comments or perform document writes.
+- R7. Direct `/edit`, `/suggest`, and `/comment` URLs enforce the same capability matrix. Unavailable mode URLs redirect to canonical `/d/:slug`; a live access downgrade replaces an unavailable URL with canonical Read.
+- R8. The mode dropdown leaves permitted modes enabled and visibly disables unavailable modes. It remains fully disabled only for view-only visitors and the fixed Edit demo.
+- R9. Browser comments and Agent API comments use comment-level authorization; all document/suggestion writes continue to require edit-level authorization.
+- R10. The Agent API state and guide expose `link_access`, `can_write`, and `can_comment`, while retaining `editing_locked` as a compatibility field during the transition.
+- R11. Existing documents migrate from `editing_locked=false` to `edit` and `editing_locked=true` to `view`. Existing owners, links, document state, and access endpoints remain safe across a rolling deploy.
+- R12. Access remains per-document/per-link only. Inviting named users, separate URLs/tokens, email ACLs, and account-specific sharing are out of scope.
+
+## Key Decisions
+
+- KTD1. Add a constrained `link_access` string instead of composing more booleans. The enum is the authoritative, extensible policy; the existing `editing_locked` column/field remains temporarily synchronized for old clients and rolling-deploy compatibility.
+- KTD2. Model the access lattice explicitly: `edit` implies write + comment + read; `comment` implies comment + read; `view` implies read only. Owner checks sit above the lattice and always grant full access.
+- KTD3. “Can comment” does not enable Suggest mode. Suggest edits are Yjs document mutations; allowing them would require accepting content-write authority and would let a forged collaborator bypass tracked-change UI. This iteration grants the capability named by the role: comments only.
+- KTD4. Split comment authorization from document-write authorization on both browser and Agent API paths. Presence, state, and event reads remain available at every level.
+- KTD5. Use a native radiogroup-style control in the Access section. The three choices are mutually exclusive policy values, not a binary toggle, and should be understandable without opening a second modal.
+- KTD6. Reuse the mode-specific URLs shipped in issue #76. Server routing and client `changeMode` share the same capability predicate so disabled UI and direct-link behavior cannot drift.
+- KTD7. Keep `PATCH /d/:slug/editing_lock` as a compatibility adapter (`false` → edit, `true` → view) while adding the explicit owner-only `PATCH /d/:slug/link_access` endpoint.
+- KTD8. Broadcast the existing access-change event after any role transition so both old and new mounted clients reload ownership permissions during the rolling transition.
+
+## Implementation Units
+
+### U1. Link-access domain model and migration
+
+- **Files:** new migration, `db/schema.rb`, `app/models/document.rb`, model tests
+- **Approach:** Add `link_access` with an `edit|comment|view` constraint/default and backfill from `editing_locked`. Add `writable_by?`, `commentable_by?`, assertion/lock helpers, a single owner-only `set_link_access!`, compatibility mapping for `set_editing_locked!`, and ownership props for access/capabilities. Persist the compatibility boolean alongside the enum.
+- **Verification:** Tests cover defaults, backfill semantics, all owner/guest capability combinations, invalid values, atomic owner authorization, activity logging, compatibility mapping, and token non-disclosure.
+
+### U2. Owner access controls and live reconciliation
+
+- **Files:** `config/routes.rb`, `app/controllers/documents_controller.rb`, `app/frontend/components/header_menu.tsx`, `app/frontend/components/ownership_chip.tsx`, CSS, ownership integration tests
+- **Approach:** Add the explicit owner-only update action and replace the binary menu row with a labelled three-choice link-access group. Optimistically update the owner’s props, keep failures recoverable, show non-owners the active link role, and broadcast/reload the access state.
+- **Verification:** Owner can select all three roles; non-owner cannot update them; only real changes log/broadcast; selected state, keyboard focus, touch targets, and failure recovery are correct.
+
+### U3. Capability-aware mode URLs and editor UI
+
+- **Files:** `app/controllers/documents_controller.rb`, `app/frontend/pages/documents/show.tsx`, `app/frontend/components/mode_control.tsx`, routing tests
+- **Approach:** Permit explicit modes through a shared access matrix. Pass available modes to ModeControl, disable unavailable choices, keep Comment accessible to commenters, mount commenters through the read-only sync provider, and canonicalize any current mode that becomes unavailable after an access change.
+- **Verification:** Editors get four modes; commenters get Comment/Read; viewers get Read only; direct routes and live downgrades match; Comment mode remains non-editable and task controls stay inert.
+
+### U4. Browser and Agent API comment authorization
+
+- **Files:** `app/controllers/concerns/document_write_authorization.rb`, `app/controllers/comments_controller.rb`, `app/controllers/api/base_controller.rb`, `app/controllers/api/comments_controller.rb`, API/browser integration tests
+- **Approach:** Add comment-level guarded blocks and a distinct helpful access error. Route comment create/resolve through them while leaving suggestions, snapshots, sync, and source updates on write-level guards.
+- **Verification:** Commenters can create/resolve comments from browser and API; viewers receive 423; commenters receive 423 for suggestions/document writes; editors retain all behavior.
+
+### U5. Discovery and end-to-end regression coverage
+
+- **Files:** `app/services/agent_guide.rb`, `script/browser_check.mjs`, discovery tests
+- **Approach:** Teach agents the three roles and capability fields. Add a two-browser flow that changes owner access, verifies route/UI enforcement, posts a commenter comment live, downgrades to View, and restores Edit before cleanup.
+- **Verification:** Focused browser checks pass at desktop and mobile; full Rails/TypeScript/lint/build gates pass; production verification uses a temporary owner document and deletes it.
+
+## Acceptance Examples
+
+- AE1. Given an owned document, when the owner chooses Can comment, then Access shows that choice selected and another browser can open `/comment` but `/edit` and `/suggest` redirect to the Read URL.
+- AE2. Given that commenter in Comment mode, when they select text and post a comment, then it appears live for the owner while the document remains non-editable.
+- AE3. Given the same commenter, when they call the suggestion API or submit a snapshot, then the server returns 423 with the current `link_access` and a useful next action.
+- AE4. When the owner changes the role to Can view, then the commenter’s open `/comment` page moves to canonical Read, the mode control locks, and comment creation returns 423.
+- AE5. When the owner changes the role to Can edit, then another link visitor can open `/edit`, type, suggest, comment, and use tasks as before.
+- AE6. Given an older document whose binary lock was enabled, after migration it has `link_access=view`; an unlocked older document has `link_access=edit`.
+
+## Risks
+
+- Comment authorization currently reuses the write lock. Missing either browser or API comments would make the role look enabled while requests fail; cover create and resolve on both surfaces.
+- Comment mode needs selection/comment UI but must use the read-only Yjs provider. Keep `canWrite=false` while allowing HTTP comments, and test that task/content mutations remain blocked.
+- Access events can arrive while a visitor is on a now-invalid mode URL. Reconcile both server partial reloads and client props, replacing rather than pushing the canonical Read entry.
+- Removing `editing_locked` immediately would break the old container during deployment. Keep and synchronize it until a later cleanup after all clients and servers understand `link_access`.
+- Optimistic owner controls can drift on a rejected update. Scope the reload to ownership/activities and reset updating/error state on completion.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -66,6 +66,7 @@ try {
 
   await landing.getByRole('button', { name: 'New document' }).click()
   await landing.waitForURL(/\/d\//)
+  const accessSlug = new URL(landing.url()).pathname.split('/')[2]
   await landing.goto(BASE)
   await landing.getByRole('button', { name: /Add tag/ }).first().click()
   await landing
@@ -92,6 +93,87 @@ try {
   } else {
     fail('saved tags did not update the document row')
   }
+
+  // Shared-link access: the owner chooses Edit, Comment, or View. A commenter
+  // gets Comment/Read modes and HTTP comments without Yjs write authority;
+  // downgrading to View canonicalizes their open Comment URL immediately.
+  await landing.goto(`${BASE}/d/${accessSlug}/edit`)
+  await landing.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await landing.getByRole('button', { name: 'More options' }).click()
+  const accessOptions = landing.locator('.header-menu-access-option')
+  if (
+    (await accessOptions.count()) === 3 &&
+    (await accessOptions.nth(0).getAttribute('aria-checked')) === 'true'
+  ) {
+    ok('owner Access menu offers Edit, Comment, and View roles')
+  } else {
+    fail('owner Access menu did not expose the three link roles')
+  }
+  await accessOptions.nth(1).click()
+  await landing.waitForFunction(
+    () => document.querySelectorAll('.header-menu-access-option')[1]?.getAttribute('aria-checked') === 'true',
+  )
+
+  const accessGuest = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+  await accessGuest.goto(`${BASE}/d/${accessSlug}/comment`)
+  await accessGuest.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await accessGuest.click('.mode-control-trigger')
+  const guestModes = await accessGuest.locator('.mode-control-option').evaluateAll((options) =>
+    options.map((option) => ({
+      label: option.querySelector('.mode-control-option-label')?.textContent,
+      disabled: option.disabled,
+    })),
+  )
+  if (
+    guestModes[0]?.disabled && guestModes[1]?.disabled &&
+    !guestModes[2]?.disabled && !guestModes[3]?.disabled &&
+    (await accessGuest.locator('.milkdown .ProseMirror').getAttribute('contenteditable')) === 'false'
+  ) {
+    ok('comment link enables Comment/Read while keeping document writes disabled')
+  } else {
+    fail(`comment link mode matrix diverged: ${JSON.stringify(guestModes)}`)
+  }
+  await accessGuest.keyboard.press('Escape')
+  await accessGuest.locator('.milkdown .ProseMirror p').first().dblclick()
+  await accessGuest.locator('.selection-toolbar button', { hasText: 'Comment' }).click()
+  const accessComment = `Comment-role check ${Date.now()}`
+  await accessGuest.getByPlaceholder('Say something about this…').fill(accessComment)
+  await accessGuest.locator('.comment-composer--anchored .btn-accept').click()
+  await landing.locator('.comment-card', { hasText: accessComment }).waitFor({ timeout: 10000 })
+  ok('comment-role contribution appears live for the owner')
+
+  await accessOptions.nth(2).click()
+  await accessGuest.waitForURL(`${BASE}/d/${accessSlug}`, { timeout: 10000 })
+  if (
+    (await accessGuest.locator('.mode-control-trigger').isDisabled()) &&
+    (await accessGuest.locator('.mode-control-trigger').textContent())?.includes('Read mode')
+  ) {
+    ok('View downgrade canonicalizes the commenter to locked Read mode')
+  } else {
+    fail('View downgrade left an unavailable mode active')
+  }
+  await accessGuest.close()
+
+  await landing.setViewportSize({ width: 390, height: 844 })
+  const accessGeometry = await landing.evaluate(() => ({
+    sheet: document.querySelector('.header-menu-popover')?.getBoundingClientRect().width,
+    rows: Array.from(document.querySelectorAll('.header-menu-access-option')).map(
+      (option) => option.getBoundingClientRect().height,
+    ),
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }))
+  if (
+    accessGeometry.sheet === 390 &&
+    accessGeometry.rows.every((height) => height >= 44) &&
+    accessGeometry.overflow === 0
+  ) {
+    ok('mobile link-access sheet is full-width with touch-sized choices')
+  } else {
+    fail(`mobile link-access geometry diverged: ${JSON.stringify(accessGeometry)}`)
+  }
+  await landing.getByRole('button', { name: 'Yours — delete…' }).click()
+  await landing.getByRole('button', { name: 'Delete?' }).click()
+  await landing.waitForURL(`${BASE}/`)
   await landing.close()
 
   const a = await makePage('a')

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -146,7 +146,7 @@ class SyncChannelTest < ActionCable::Channel::TestCase
       title: "Locked",
       owner_token: "owner-token",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
     subscribe slug: doc.slug
     update = build_update_b64("forbidden")
@@ -164,7 +164,7 @@ class SyncChannelTest < ActionCable::Channel::TestCase
       title: "Locked",
       owner_token: "owner-token",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
     stub_connection(owner_token: "owner-token", current_user: nil)
     subscribe slug: doc.slug
@@ -184,7 +184,7 @@ class SyncChannelTest < ActionCable::Channel::TestCase
       title: "Locked",
       owner_token: "owner-token",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
     subscribe slug: doc.slug
 

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -225,7 +225,8 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     body = response.parsed_body
     assert_equal(
       { "claimed" => false, "claimable" => true, "owner_name" => nil,
-        "editing_locked" => false, "can_write" => true },
+        "link_access" => "edit", "editing_locked" => false,
+        "can_write" => true, "can_comment" => true },
       body["ownership"]
     )
 
@@ -235,7 +236,8 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     body = response.parsed_body
     assert_equal(
       { "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon",
-        "editing_locked" => false, "can_write" => true },
+        "link_access" => "edit", "editing_locked" => false,
+        "can_write" => true, "can_comment" => true },
       body["ownership"]
     )
     refute_includes response.body, "tok-owner"
@@ -354,7 +356,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     @document.update!(
       owner_token: "owner-token",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
     comment = @document.comments.create!(
       author_name: "A", author_kind: "human", body: "Existing"
@@ -383,6 +385,27 @@ class AgentApiTest < ActionDispatch::IntegrationTest
          headers: AGENT, as: :json
     assert_response :locked
     assert_not comment.reload.resolved_at
+  end
+
+  test "comment link permits agent comments but rejects suggestions" do
+    @document.update!(
+      owner_token: "owner-token",
+      owner_name: "Owner",
+      link_access: "comment"
+    )
+
+    assert_difference -> { @document.comments.count }, 1 do
+      post "/api/docs/#{@document.slug}/comments",
+           params: { body: "Allowed comment" }, headers: AGENT, as: :json
+    end
+    assert_response :created
+
+    assert_no_difference -> { @document.suggestions.count } do
+      post "/api/docs/#{@document.slug}/suggestions",
+           params: { body: "Forbidden suggestion" }, headers: AGENT, as: :json
+    end
+    assert_response :locked
+    assert_equal "comment", response.parsed_body["link_access"]
   end
 
   test "agent comment is agent-attributed and logged" do

--- a/test/integration/agent_discovery_test.rb
+++ b/test/integration/agent_discovery_test.rb
@@ -137,26 +137,27 @@ class AgentDiscoveryTest < ActionDispatch::IntegrationTest
     body = response.parsed_body
     assert_equal(
       { "claimed" => true, "claimable" => false, "owner_name" => "Quiet Falcon",
-        "editing_locked" => false, "can_write" => true },
+        "link_access" => "edit", "editing_locked" => false,
+        "can_write" => true, "can_comment" => true },
       body["ownership"]
     )
     assert body["notes"].any? { |n| n.include?("cannot claim") }
     refute_includes response.body, "tok-owner"
   end
 
-  test "text guide explains owner-controlled read-only mode" do
+  test "text guide explains owner-controlled link access" do
     @document.update!(
       owner_token: "tok-owner",
       owner_name: "Quiet Falcon",
-      editing_locked: true
+      link_access: "view"
     )
 
     get "/d/#{@document.slug}", headers: { "User-Agent" => "curl/8.6.0" }
 
     assert_response :success
     assert_includes response.body, "editing_locked"
-    assert_includes response.body, "read-only"
-    assert_match(/Agents cannot change\s+this setting/, response.body)
+    assert_includes response.body, "link_access"
+    assert_match(/Agents\s+cannot change this setting/, response.body)
   end
 
   test "HTML text guide uses readable native HTML in its suggestion example" do

--- a/test/integration/comment_flow_test.rb
+++ b/test/integration/comment_flow_test.rb
@@ -37,11 +37,11 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "locked non-owner cannot create or resolve comments" do
+  test "view-only non-owner cannot create or resolve comments" do
     @document.update!(
       owner_token: "someone-else",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
     comment = @document.comments.create!(
       author_name: "A", author_kind: "human", body: "Existing"
@@ -57,6 +57,26 @@ class CommentFlowTest < ActionDispatch::IntegrationTest
     patch resolve_comment_path(comment), params: { by: "Reader" }, as: :json
     assert_response :locked
     assert_not comment.reload.resolved_at
+  end
+
+  test "comment link can create and resolve comments without document write access" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      link_access: "comment"
+    )
+
+    assert_not @document.writable_by?(nil)
+    assert_difference -> { @document.comments.count }, 1 do
+      post document_comments_path(@document.slug), params: {
+        body: "Allowed comment", author_name: "Commenter"
+      }
+    end
+    comment = @document.comments.last
+
+    patch resolve_comment_path(comment), params: { by: "Commenter" }
+    assert_response :see_other
+    assert comment.reload.resolved_at.present?
   end
 
   test "resolving a comment timestamps it and keeps it out of open scope" do

--- a/test/integration/document_mode_routing_test.rb
+++ b/test/integration/document_mode_routing_test.rb
@@ -49,7 +49,7 @@ class DocumentModeRoutingTest < ActionDispatch::IntegrationTest
       owner_token: "someone-else",
       owner_name: "Owner",
       claimed_at: Time.current,
-      editing_locked: true
+      link_access: "view"
     )
 
     get document_mode_path(@document.slug, "comment"), headers: browser
@@ -57,6 +57,28 @@ class DocumentModeRoutingTest < ActionDispatch::IntegrationTest
     assert_response :see_other
     assert_redirected_to document_page_path(@document.slug)
     assert_equal "pending", @document.reload.seed_state
+  end
+
+  test "comment link permits Comment mode but redirects Edit and Suggest" do
+    @document.update!(
+      owner_token: "someone-else",
+      owner_name: "Owner",
+      claimed_at: Time.current,
+      link_access: "comment"
+    )
+
+    get document_mode_path(@document.slug, "comment"), headers: browser
+    assert_response :ok
+    assert_inertia_props do |props|
+      props.dig(:ui, :mode) == "comment" &&
+        props.dig(:ownership, :can_comment) == true &&
+        props.dig(:ownership, :can_write) == false
+    end
+
+    %w[edit suggest].each do |mode|
+      get document_mode_path(@document.slug, mode), headers: browser
+      assert_redirected_to document_page_path(@document.slug)
+    end
   end
 
   test "demo keeps its established URL locked to Edit" do

--- a/test/integration/ownership_flow_test.rb
+++ b/test/integration/ownership_flow_test.rb
@@ -271,6 +271,30 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
     assert_not @document.reload.editing_locked?
   end
 
+  test "owner can set explicit link access and non-owner cannot" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+
+    patch document_link_access_path(@document.slug), params: { access: "comment" }
+    assert_response :see_other
+    assert_equal "comment", @document.reload.link_access
+
+    reset!
+    patch document_link_access_path(@document.slug), params: { access: "view" }
+    assert_response :see_other
+    assert_equal "comment", @document.reload.link_access
+  end
+
+  test "link access rejects unknown values" do
+    establish_identity
+    post claim_document_path(@document.slug), params: { name: "Owner" }
+
+    patch document_link_access_path(@document.slug), params: { access: "suggest" }
+
+    assert_response :see_other
+    assert_equal "edit", @document.reload.link_access
+  end
+
   test "show exposes viewer-specific write access for a locked document" do
     establish_identity
     post claim_document_path(@document.slug), params: { name: "Owner" }

--- a/test/integration/snapshot_test.rb
+++ b/test/integration/snapshot_test.rb
@@ -15,7 +15,7 @@ class SnapshotTest < ActionDispatch::IntegrationTest
     @document.update!(
       owner_token: "someone-else",
       owner_name: "Owner",
-      editing_locked: true,
+      link_access: "view",
       content_snapshot: "original"
     )
     ydoc = Y::Doc.new
@@ -38,7 +38,7 @@ class SnapshotTest < ActionDispatch::IntegrationTest
     @document.update!(
       owner_token: "someone-else",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
 
     post document_snapshot_path(@document.slug), params: {

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -65,7 +65,7 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     @document.update!(
       owner_token: "someone-else",
       owner_name: "Owner",
-      editing_locked: true
+      link_access: "view"
     )
 
     assert_no_difference -> { @document.suggestions.count } do

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -14,7 +14,7 @@ class DocumentTest < ActiveSupport::TestCase
     assert_not document.owned_by?("stale-token")
     assert_equal(
       { claimed: true, claimable: false, owner_name: "Kieran", yours: true,
-        editing_locked: false, can_write: true },
+        link_access: "edit", editing_locked: false, can_write: true, can_comment: true },
       document.ownership_props("stale-token", viewer_user: user)
     )
   end
@@ -343,12 +343,44 @@ class DocumentTest < ActiveSupport::TestCase
         doc.set_editing_locked!(locked: true, token: "tok-a")
       end
     end
-    assert_equal "locked_editing", doc.activities.last.action
+    assert_equal "changed_link_access", doc.activities.last.action
+    assert_equal "view", doc.reload.link_access
+    assert doc[:editing_locked], "legacy column should stay synchronized during rollout"
 
     assert_no_difference -> { doc.activities.count } do
       assert_no_broadcasts(DocumentMetaChannel.broadcasting_for(doc)) do
         doc.set_editing_locked!(locked: true, token: "tok-a")
       end
+    end
+  end
+
+  test "link access grants edit, comment, and view capabilities while owners retain all access" do
+    doc = Document.create!(title: "Mine", owner_token: "tok-a", owner_name: "Owner")
+
+    doc.set_link_access!(access: "comment", token: "tok-a")
+    assert doc.reload[:editing_locked], "comment access is editing-locked for legacy clients"
+    assert_not doc.writable_by?("tok-b")
+    assert doc.commentable_by?("tok-b")
+    assert doc.writable_by?("tok-a")
+    assert doc.commentable_by?("tok-a")
+    assert_raises(Document::EditingLockedError) { doc.assert_write_access!(token: "tok-b") }
+    assert doc.assert_comment_access!(token: "tok-b")
+
+    doc.set_link_access!(access: "view", token: "tok-a")
+    assert doc.reload[:editing_locked], "view access is editing-locked for legacy clients"
+    assert_not doc.commentable_by?("tok-b")
+    assert_raises(Document::CommentingLockedError) { doc.assert_comment_access!(token: "tok-b") }
+    assert doc.commentable_by?("tok-a")
+  end
+
+  test "link access rejects values outside the access lattice" do
+    doc = Document.new(title: "Mine", link_access: "suggest")
+    assert_not doc.valid?
+    assert_includes doc.errors[:link_access], "is not included in the list"
+
+    owner = Document.create!(title: "Owned", owner_token: "tok-a", owner_name: "Owner")
+    assert_raises(ArgumentError) do
+      owner.set_link_access!(access: "suggest", token: "tok-a")
     end
   end
 
@@ -405,19 +437,19 @@ class DocumentTest < ActiveSupport::TestCase
     props = doc.ownership_props(nil)
     assert_equal(
       { claimed: false, claimable: true, owner_name: nil, yours: false,
-        editing_locked: false, can_write: true },
+        link_access: "edit", editing_locked: false, can_write: true, can_comment: true },
       props
     )
 
     doc.claim!(token: "tok-a", name: "Owner")
     assert_equal(
       { claimed: true, claimable: false, owner_name: "Owner", yours: true,
-        editing_locked: false, can_write: true },
+        link_access: "edit", editing_locked: false, can_write: true, can_comment: true },
       doc.ownership_props("tok-a")
     )
     assert_equal(
       { claimed: true, claimable: false, owner_name: "Owner", yours: false,
-        editing_locked: false, can_write: true },
+        link_access: "edit", editing_locked: false, can_write: true, can_comment: true },
       doc.ownership_props("tok-b")
     )
     doc.set_editing_locked!(locked: true, token: "tok-a")


### PR DESCRIPTION
## Summary
- replace the binary read-only toggle with Can edit, Can comment, and Can view shared-link roles
- enforce the capability lattice across document modes, Yjs writes, suggestions, browser comments, and the agent API
- preserve the legacy editing lock contract during rollout and add responsive owner controls plus realtime downgrade handling

## Verification
- `bin/vite build --clear --mode=test && bin/rails test` (405 tests, 1,896 assertions)
- focused authorization suite (181 tests, 836 assertions)
- `npm run check`
- `bin/rubocop`
- `bin/vite build`
- two-browser desktop/mobile access-role walkthrough

Closes #77