### PR TITLE
Redesign document social previews

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -461,13 +461,14 @@ class DocumentsController < InertiaController
     preview = DocumentSocialPreview.new(document)
     {
       title: preview.title,
+      page_title: preview.page_title,
       description: preview.description,
       url: document_page_url(document.slug),
       image_url: document_og_image_url(
         document.slug,
         v: DocumentOgImage.url_version(document)
       ),
-      image_alt: "Document preview: #{preview.title}"
+      image_alt: "Thinkroom shared document preview for “#{preview.title}” with an Open document button."
     }
   end
 

--- a/app/services/document_og_image.rb
+++ b/app/services/document_og_image.rb
@@ -1,11 +1,11 @@
 class DocumentOgImage
   WIDTH = 1200
   HEIGHT = 630
-  VERSION = "1"
-  TITLE_LINE_WIDTH = 15.5
+  VERSION = "2"
+  TITLE_LINE_WIDTH = 16.5
   TITLE_MAX_LINES = 3
-  DESCRIPTION_LINE_WIDTH = 33.0
-  DESCRIPTION_MAX_LINES = 3
+  DESCRIPTION_LINE_WIDTH = 39.0
+  DESCRIPTION_MAX_LINES = 2
 
   class << self
     def call(document)
@@ -29,24 +29,50 @@ class DocumentOgImage
     def svg(document)
       preview = DocumentSocialPreview.new(document)
       title_lines = wrap(preview.title, width: TITLE_LINE_WIDTH, maximum: TITLE_MAX_LINES)
+      description_maximum = title_lines.length >= TITLE_MAX_LINES ? 1 : DESCRIPTION_MAX_LINES
       description_lines = wrap(
         preview.description,
         width: DESCRIPTION_LINE_WIDTH,
-        maximum: DESCRIPTION_MAX_LINES
+        maximum: description_maximum
       )
-      description_y = 154 + (title_lines.length * 76) + 36
+      description_y = 222 + (title_lines.length * 68)
 
       <<~SVG
         <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
-          <rect width="#{WIDTH}" height="#{HEIGHT}" fill="#fbfaf8"/>
-          <line x1="96" y1="88" x2="1104" y2="88" stroke="#d8d5cf" stroke-width="2"/>
-          <line x1="96" y1="542" x2="1104" y2="542" stroke="#d8d5cf" stroke-width="2"/>
-          <text x="96" y="154" fill="#252525" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="64" font-weight="600" letter-spacing="-1.2">
-            #{tspans(title_lines, x: 96, line_height: 76)}
+          <defs>
+            <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0" stop-color="#f4effa"/>
+              <stop offset="1" stop-color="#ece5f6"/>
+            </linearGradient>
+            <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#a755db"/>
+              <stop offset="1" stop-color="#7240c7"/>
+            </linearGradient>
+          </defs>
+          <rect width="#{WIDTH}" height="#{HEIGHT}" fill="url(#background)"/>
+          <circle cx="1090" cy="8" r="260" fill="#9d4edd" opacity="0.08"/>
+          <circle cx="1138" cy="72" r="126" fill="none" stroke="#9d4edd" stroke-width="2" opacity="0.16"/>
+          <rect x="48" y="48" width="1104" height="534" rx="28" fill="#fffdf9" stroke="#dcd2e8" stroke-width="2"/>
+          <path d="M76 48H62C54.268 48 48 54.268 48 62V568C48 575.732 54.268 582 62 582H76Z" fill="url(#accent)"/>
+
+          <circle cx="105" cy="112" r="6" fill="#9d4edd"/>
+          <text x="123" y="120" fill="#674e78" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" letter-spacing="2.6">THINKROOM · SHARED DOCUMENT</text>
+          <g opacity="0.72">
+            <circle cx="1040" cy="111" r="17" fill="#eadcf5" stroke="#fffdf9" stroke-width="4"/>
+            <circle cx="1072" cy="111" r="17" fill="#d6c2ec" stroke="#fffdf9" stroke-width="4"/>
+            <circle cx="1104" cy="111" r="17" fill="#9d4edd" stroke="#fffdf9" stroke-width="4"/>
+          </g>
+
+          <text x="100" y="198" fill="#252128" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="62" font-weight="650" letter-spacing="-1.5">
+            #{tspans(title_lines, x: 100, line_height: 68)}
           </text>
-          <text x="96" y="#{description_y}" fill="#666666" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="30" font-weight="400">
-            #{tspans(description_lines, x: 96, line_height: 42)}
+          <text x="100" y="#{description_y}" fill="#685f6c" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="400">
+            #{tspans(description_lines, x: 100, line_height: 40)}
           </text>
+
+          <rect x="100" y="504" width="232" height="50" rx="25" fill="#8f46cf"/>
+          <text x="126" y="536" fill="#ffffff" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="19" font-weight="700">Open document →</text>
+          <text x="1100" y="535" text-anchor="end" fill="#827787" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18">A place for deeper thinking</text>
         </svg>
       SVG
     end

--- a/app/services/document_social_preview.rb
+++ b/app/services/document_social_preview.rb
@@ -1,13 +1,22 @@
 class DocumentSocialPreview
-  TITLE_MAX_GRAPHEMES = 160
-  DESCRIPTION_MAX_GRAPHEMES = 240
+  TITLE_MAX_GRAPHEMES = 96
+  DESCRIPTION_MAX_GRAPHEMES = 125
+  PAGE_TITLE_MAX_GRAPHEMES = 60
+  PAGE_TITLE_SUFFIXES = [
+    " — A collaborative document shared with you on Thinkroom",
+    " — A collaborative document shared on Thinkroom",
+    " — Open this shared document on Thinkroom",
+    " — Read and collaborate on Thinkroom"
+  ].freeze
+  PAGE_TITLE_FALLBACK_SUFFIX = " · Thinkroom"
 
-  attr_reader :title, :description
+  attr_reader :title, :description, :page_title
 
   def initialize(document)
     raw_title = document.display_title.to_s.squish.presence || "Untitled"
     @title = bound(raw_title, TITLE_MAX_GRAPHEMES)
     @description = description_for(document, raw_title)
+    @page_title = page_title_for(raw_title)
   end
 
   private
@@ -20,6 +29,16 @@ class DocumentSocialPreview
       plain_text
     end
     bound(excerpt.presence || title, DESCRIPTION_MAX_GRAPHEMES)
+  end
+
+  def page_title_for(raw_title)
+    PAGE_TITLE_SUFFIXES.each do |suffix|
+      descriptive = "#{raw_title}#{suffix}"
+      return descriptive if descriptive.scan(/\X/).length <= PAGE_TITLE_MAX_GRAPHEMES
+    end
+
+    title_budget = PAGE_TITLE_MAX_GRAPHEMES - PAGE_TITLE_FALLBACK_SUFFIX.scan(/\X/).length
+    "#{bound(raw_title, title_budget)}#{PAGE_TITLE_FALLBACK_SUFFIX}"
   end
 
   def bound(text, maximum)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
 <html data-theme="<%= cookies[:proof_theme].to_s.presence_in(%w[proof whitey]) || "proof" %>">
   <head>
-    <title data-inertia><%= content_for(:title) || "Thinkroom" %></title>
+    <title data-inertia><%= @open_graph&.dig(:page_title) || content_for(:title) || "Thinkroom" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <% if @open_graph.present? %>
+      <%= tag.meta name: "description", content: @open_graph[:description] %>
       <%= tag.link rel: "canonical", href: @open_graph[:url] %>
       <%= tag.meta property: "og:type", content: "article" %>
+      <%= tag.meta property: "og:site_name", content: "Thinkroom" %>
+      <%= tag.meta property: "og:locale", content: "en_US" %>
       <%= tag.meta property: "og:title", content: @open_graph[:title] %>
       <%= tag.meta property: "og:description", content: @open_graph[:description] %>
       <%= tag.meta property: "og:url", content: @open_graph[:url] %>

--- a/docs/plans/2026-06-26-012-feat-social-preview-redesign-plan.md
+++ b/docs/plans/2026-06-26-012-feat-social-preview-redesign-plan.md
@@ -1,0 +1,45 @@
+---
+title: "feat: Redesign document social previews"
+type: feat
+date: 2026-06-26
+issue: 79
+---
+
+# Redesign document social previews
+
+## Outcome
+
+Make a shared Thinkroom document recognizable and inviting in link previews without turning the card into an advertisement. The preview should feel like an editorial document cover, explain where the link goes, and pass the metadata checks reported in issue #79.
+
+## Design direction
+
+- Keep the document title as the dominant element.
+- Replace the empty ruled page with a warm paper card, violet edge/accent field, and restrained collaboration marks.
+- Add a small `THINKROOM · SHARED DOCUMENT` label for source context.
+- Add one honest conversion action: `Open document →`.
+- Preserve generous whitespace and avoid owner names, tags, permissions, or application chrome.
+
+## Requirements
+
+1. The first server-rendered `<title>` is a bounded, descriptive document title with Thinkroom context.
+2. Document pages include an explicit meta description, `og:site_name`, and concise matching Open Graph/X descriptions of at most 125 graphemes.
+3. The 1200×630 PNG includes the document title, bounded excerpt, source label, and CTA with no overflow for long or Unicode content.
+4. The image alt text describes both the document preview and the invitation to open it.
+5. The image renderer version changes so already-cached previews are invalidated.
+6. Existing canonical URLs, crawler behavior, image caching, and agent/plain-text responses remain unchanged.
+
+## Implementation
+
+- Extend `DocumentSocialPreview` with a bounded SEO page title and reduce the social description budget.
+- Emit the page title and missing metadata from the Rails layout before Inertia's SSR head.
+- Redesign `DocumentOgImage` as a deterministic SVG-to-PNG editorial card and adjust excerpt lines based on title height.
+- Expand service/integration tests for metadata completeness, length limits, cache versioning, escaping, dimensions, and long-title layout.
+
+## Verification
+
+- Service and integration tests.
+- TypeScript/Ruby lint and full Rails suite.
+- Production Vite build.
+- Visual inspection of representative short-, long-, and Unicode-title PNGs.
+- Raw HTML inspection with browser and social-crawler user agents.
+- Production image and metadata smoke test after deploy.

--- a/test/integration/document_open_graph_test.rb
+++ b/test/integration/document_open_graph_test.rb
@@ -18,17 +18,25 @@ class DocumentOpenGraphTest < ActionDispatch::IntegrationTest
     image_url = property(page, "og:image")
 
     assert_equal "article", property(page, "og:type")
+    assert_equal "Thinkroom", property(page, "og:site_name")
+    assert_equal "en_US", property(page, "og:locale")
     assert_equal "Product & market", property(page, "og:title")
     assert_equal "A focused explanation with source text.", property(page, "og:description")
+    assert_equal property(page, "og:description"), named(page, "description")
     assert_equal "https://thinkroom.kieranklaassen.com/d/#{@document.slug}", property(page, "og:url")
     assert_equal "1200", property(page, "og:image:width")
     assert_equal "630", property(page, "og:image:height")
     assert_equal "summary_large_image", named(page, "twitter:card")
     assert_equal property(page, "og:title"), named(page, "twitter:title")
+    assert_equal property(page, "og:description"), named(page, "twitter:description")
     assert_equal image_url, named(page, "twitter:image")
     assert_equal URI(image_url).path, document_og_image_path(@document.slug)
     assert URI(image_url).query.include?("v=")
-    refute_includes property(page, "og:image:alt"), "Thinkroom"
+    assert_includes property(page, "og:image:alt"), "Thinkroom shared document"
+    assert_includes property(page, "og:image:alt"), "Open document"
+    assert_equal "Product & market — Open this shared document on Thinkroom", page.at_css("title").text
+    assert_includes 50..60, page.at_css("title").text.scan(/\X/).length
+    assert_operator named(page, "description").scan(/\X/).length, :<=, 125
     assert_equal property(page, "og:url"), page.at_css('link[rel="canonical"]')["href"]
   end
 

--- a/test/services/document_og_image_test.rb
+++ b/test/services/document_og_image_test.rb
@@ -56,4 +56,14 @@ class DocumentOgImageServiceTest < ActiveSupport::TestCase
       DocumentOgImage.send(:visual_width, line) <= DocumentOgImage::TITLE_LINE_WIDTH
     end
   end
+
+  test "renders source context and an honest call to action" do
+    document = Document.new(title: "Plan", seed_content: "# Plan\n\nA useful summary")
+    svg = DocumentOgImage.send(:svg, document)
+
+    assert_includes svg, "THINKROOM · SHARED DOCUMENT"
+    assert_includes svg, "Open document →"
+    assert_includes svg, "A place for deeper thinking"
+    refute_includes svg, "owner_token"
+  end
 end

--- a/test/services/document_social_preview_test.rb
+++ b/test/services/document_social_preview_test.rb
@@ -11,6 +11,7 @@ class DocumentSocialPreviewTest < ActiveSupport::TestCase
 
     assert_equal "Product & market", preview.title
     assert_equal "A focused explanation of the opportunity.", preview.description
+    assert_equal "Product & market — Open this shared document on Thinkroom", preview.page_title
   end
 
   test "projects HTML and sketch-aware content to plain text" do
@@ -40,6 +41,22 @@ class DocumentSocialPreviewTest < ActiveSupport::TestCase
                     DocumentSocialPreview::TITLE_MAX_GRAPHEMES
     assert_equal grapheme, preview.title.scan(/\X/).last(2).first
     assert_equal "…", preview.title.scan(/\X/).last
+    assert_operator preview.page_title.scan(/\X/).length, :<=,
+                    DocumentSocialPreview::PAGE_TITLE_MAX_GRAPHEMES
+    assert preview.page_title.end_with?(" · Thinkroom")
+  end
+
+  test "bounds social descriptions to mobile-friendly copy" do
+    document = Document.create!(
+      title: "A concise title",
+      seed_content: "# A concise title\n\n#{'word ' * 80}"
+    )
+
+    preview = DocumentSocialPreview.new(document)
+
+    assert_operator preview.description.scan(/\X/).length, :<=,
+                    DocumentSocialPreview::DESCRIPTION_MAX_GRAPHEMES
+    assert preview.description.end_with?("…")
   end
 
   test "falls back to the title for a title-only document" do


### PR DESCRIPTION
## Summary
- redesign document OG images as a restrained editorial card with Thinkroom context and an Open document CTA
- add complete server-first SEO/Open Graph metadata, including site name, explicit meta description, locale, and a useful first title
- cap social descriptions at 125 graphemes and adapt image layout for long and Unicode titles

## Verification
- `bin/vite build --clear --mode=test && bin/rails test` (407 tests, 1,925 assertions)
- `npm run check`
- `bin/rubocop`
- `bin/vite build`
- visual inspection of short, long, and Unicode preview images
- browser and Twitterbot first-response metadata checks

Closes #79