### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,10 @@
 
 - `docs/solutions/` — documented solutions to past problems (bugs, best practices, architecture patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in a documented area.
 - `docs/plans/` — implementation plans (`ce-plan` output); `CONCEPTS.md`, when present, holds shared domain vocabulary.
+
+## Cursor Cloud specific instructions
+
+- Ruby 3.4.2 is provided via `rbenv` (installed in `~/.rbenv`, initialized from `~/.bashrc`). Login/interactive shells get `ruby`/`bundle` on `PATH` automatically. If a non-login shell can't find `ruby`, run commands through `bash -lc '...'` or `eval "$(rbenv init - bash)"` first. Node 22 and `libvips` (image uploads) are already present.
+- Dependencies refresh automatically on startup (the configured update script runs `bundle install` + `npm install`). The database is not reset by the update script — for a fresh checkout or to (re)create + seed the dev DB (`storage/development.sqlite3`, demo doc at `/d/demo`), run `bin/setup`.
+- Run the app with `bin/dev` (see "Local development and review" above): Rails on `:3000`, Vite on `:3036`. Dev has no Redis/Postgres — Action Cable uses the in-process `async` adapter and storage is SQLite + local-disk Active Storage.
+- Verify with `npm run check` (TypeScript), `bin/rubocop`, and `bin/rails test` (Minitest, ~405 tests). Google OAuth is optional (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`); anonymous and password flows work without it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Thinkroom development environment for Cursor Cloud agents and documents non-obvious startup caveats. The only repo change is adding a `## Cursor Cloud specific instructions` section to `AGENTS.md`; the rest is environment provisioning (update script + VM dependencies).

## Environment setup

- Installed Ruby **3.4.2** via `rbenv` (per `.ruby-version`), plus build deps and `libvips` (image uploads). Node 22 was already present.
- Ran `bin/setup` (`bundle install`, `npm install`, `bin/rails db:prepare`, seed → demo doc at `/d/demo`).
- Configured the startup **update script** to refresh dependencies only:
  ```
  export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
  eval "$(rbenv init - bash)"
  bundle install
  npm install
  ```

## Verification

- `npm run check` (TypeScript) — passed
- `bin/rubocop` — 121 files, no offenses
- `bin/rails test` — 405 runs, 1899 assertions, 0 failures
- `bin/dev` boots Rails (:3000) + Vite (:3036); `GET /d/demo` returns HTTP 200
- Hello-world: opened the demo doc in the browser editor and typed text successfully

[thinkroom_editor_hello_world.mp4](https://cursor.com/agents/bc-2af6ef04-3a69-4087-bfd2-f5a6d61f9dae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthinkroom_editor_hello_world.mp4)

[Text typed into Thinkroom editor](https://cursor.com/agents/bc-2af6ef04-3a69-4087-bfd2-f5a6d61f9dae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthinkroom_editor_typed_text.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2af6ef04-3a69-4087-bfd2-f5a6d61f9dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2af6ef04-3a69-4087-bfd2-f5a6d61f9dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

