### PR TITLE
Show live pointers in Read mode

### DIFF
--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -83,6 +83,7 @@ import {
   type DocumentFormat,
 } from './document_format'
 import { configureSlashMenu, slashMenu } from './slash_menu'
+import { readPointerAwarenessCtx, readPointers } from './read_pointers'
 
 export interface EditorHandle {
   editor: Editor
@@ -473,6 +474,7 @@ function CollabEditor({
         .use(suggestGuard)
         .use(selectionWatcher)
         .use(agentCursors)
+        .use(readPointers)
         .use(collab),
     [],
   )
@@ -531,6 +533,7 @@ function CollabEditor({
       started = true
       editor.action((ctx) => {
         const service = ctx.get(collabServiceCtx)
+        ctx.set(readPointerAwarenessCtx.key, provider.awareness)
         service.bindDoc(ydoc).setAwareness(provider.awareness)
         ctx.set(taskPersistenceCtx.key, {
           persist: () =>

--- a/app/frontend/editor/read_pointers.ts
+++ b/app/frontend/editor/read_pointers.ts
@@ -1,0 +1,213 @@
+import { editorViewCtx, type Editor } from '@milkdown/kit/core'
+import { $ctx, $prose } from '@milkdown/kit/utils'
+import { Plugin, PluginKey, type EditorState } from '@milkdown/kit/prose/state'
+import { Decoration, DecorationSet, type EditorView } from '@milkdown/kit/prose/view'
+import type { Awareness } from 'y-protocols/awareness'
+import * as Y from 'yjs'
+import {
+  absolutePositionToRelativePosition,
+  relativePositionToAbsolutePosition,
+} from 'y-prosemirror'
+import type { UserIdentity } from './identity'
+
+interface ReadPointerState {
+  anchor?: unknown
+}
+
+interface AwarenessState {
+  user?: UserIdentity
+  readPointer?: ReadPointerState | null
+}
+
+interface SyncState {
+  doc: Y.Doc
+  type: Y.XmlFragment
+  binding: {
+    mapping: Parameters<typeof absolutePositionToRelativePosition>[2]
+  }
+}
+
+export const readPointerAwarenessCtx = $ctx<Awareness | null, 'readPointerAwareness'>(
+  null,
+  'readPointerAwareness',
+)
+
+const readPointerKey = new PluginKey('READ_POINTERS')
+const SAFE_COLOR = /^#[0-9a-f]{6}$/i
+
+// @milkdown/plugin-collab is prebundled by Vite, so importing its
+// ySyncPluginKey through the app can create a second key object. Locate the
+// installed y-sync plugin by its stable ProseMirror key instead.
+const syncStateFor = (state: EditorState): SyncState | undefined => {
+  const syncKey = state.plugins.map((plugin) => plugin.spec.key).find((pluginKey) => {
+    const runtimeKey = pluginKey as unknown as { key?: string } | undefined
+    return runtimeKey?.key === 'y-sync$'
+  })
+  return syncKey?.getState(state) as SyncState | undefined
+}
+
+const buildPointer = (user: UserIdentity | undefined): HTMLElement => {
+  const color = user?.color && SAFE_COLOR.test(user.color) ? user.color : '#9d4edd'
+  const cursor = document.createElement('span')
+  cursor.className = 'ProseMirror-yjs-cursor read-pointer-cursor'
+  cursor.style.borderColor = color
+
+  const label = document.createElement('div')
+  label.style.backgroundColor = color
+  label.textContent = `↗ ${user?.name || 'Reader'}`
+  cursor.append('\u2060', label, '\u2060')
+  return cursor
+}
+
+const decorationsFor = (
+  state: EditorState,
+  awareness: Awareness | null,
+  syncState: SyncState | undefined,
+): DecorationSet => {
+  if (!awareness || !syncState || syncState.binding.mapping.size === 0) {
+    return DecorationSet.empty
+  }
+
+  const decorations: Decoration[] = []
+  awareness.getStates().forEach((rawState, clientId) => {
+    if (clientId === awareness.clientID) return
+    const awarenessState = rawState as AwarenessState
+    const anchorJson = awarenessState.readPointer?.anchor
+    if (!anchorJson) return
+
+    const position = relativePositionToAbsolutePosition(
+      syncState.doc,
+      syncState.type,
+      Y.createRelativePositionFromJSON(anchorJson),
+      syncState.binding.mapping,
+    )
+    if (position === null) return
+
+    const boundedPosition = Math.min(position, state.doc.content.size)
+    decorations.push(
+      Decoration.widget(boundedPosition, () => buildPointer(awarenessState.user), {
+        key: `read-pointer-${clientId}`,
+        side: 10,
+      }),
+    )
+  })
+  return DecorationSet.create(state.doc, decorations)
+}
+
+const readPointerProse = $prose((ctx) => new Plugin({
+  key: readPointerKey,
+  state: {
+    init: () => DecorationSet.empty,
+    apply(transaction, previous, oldState, newState) {
+      // This plugin is installed before Milkdown dynamically adds y-sync, so
+      // ProseMirror has not applied y-sync's state field yet while building
+      // `newState`. The complete old state has the live binding and mapping.
+      if (transaction.getMeta(readPointerKey)) {
+        return decorationsFor(
+          newState,
+          ctx.get(readPointerAwarenessCtx.key),
+          syncStateFor(oldState),
+        )
+      }
+      return previous.map(transaction.mapping, transaction.doc)
+    },
+  },
+  props: {
+    decorations: (state) => readPointerKey.getState(state),
+  },
+  view(view) {
+    let awareness: Awareness | null = null
+    let destroyed = false
+
+    const refresh = () => {
+      if (destroyed) return
+      view.dispatch(view.state.tr.setMeta(readPointerKey, true))
+    }
+    const bindAwareness = () => {
+      const nextAwareness = ctx.get(readPointerAwarenessCtx.key)
+      if (nextAwareness === awareness) return
+      awareness?.off('change', refresh)
+      awareness = nextAwareness
+      awareness?.on('change', refresh)
+      queueMicrotask(refresh)
+    }
+
+    bindAwareness()
+    return {
+      update: bindAwareness,
+      destroy: () => {
+        destroyed = true
+        awareness?.off('change', refresh)
+      },
+    }
+  },
+}))
+
+export const readPointers = [readPointerAwarenessCtx, readPointerProse].flat()
+
+/**
+ * Publishes a reader's hover position without focusing or selecting inside
+ * ProseMirror. The custom field stays independent from y-prosemirror's normal
+ * editing cursor, whose plugin intentionally clears itself when unfocused.
+ */
+export function bindReadPointerBroadcast(
+  editor: Editor,
+  awareness: Awareness,
+): () => void {
+  let view: EditorView | null = null
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx)
+  })
+  if (!view) return () => undefined
+
+  const editorView = view as EditorView
+  let frame: number | null = null
+  let latestPoint: { left: number; top: number } | null = null
+  let lastPosition: number | null = null
+
+  // Read mode should never leave the ordinary editing caret visible remotely.
+  editorView.dom.blur()
+  awareness.setLocalStateField('cursor', null)
+
+  const clear = () => {
+    if (frame !== null) cancelAnimationFrame(frame)
+    frame = null
+    latestPoint = null
+    if (lastPosition !== null) awareness.setLocalStateField('readPointer', null)
+    lastPosition = null
+  }
+  const publish = () => {
+    frame = null
+    if (!latestPoint) return
+    const found = editorView.posAtCoords(latestPoint)
+    if (!found || found.pos === lastPosition) return
+
+    const syncState = syncStateFor(editorView.state)
+    if (!syncState || syncState.binding.mapping.size === 0) return
+    const anchor = absolutePositionToRelativePosition(
+      found.pos,
+      syncState.type,
+      syncState.binding.mapping,
+    )
+    lastPosition = found.pos
+    awareness.setLocalStateField('readPointer', { anchor })
+  }
+  const onPointerMove = (event: PointerEvent) => {
+    if (event.pointerType === 'touch') return
+    latestPoint = { left: event.clientX, top: event.clientY }
+    if (frame === null) frame = requestAnimationFrame(publish)
+  }
+
+  editorView.dom.addEventListener('pointermove', onPointerMove, { passive: true })
+  editorView.dom.addEventListener('pointerleave', clear)
+  editorView.dom.addEventListener('pointercancel', clear)
+  window.addEventListener('blur', clear)
+
+  return () => {
+    editorView.dom.removeEventListener('pointermove', onPointerMove)
+    editorView.dom.removeEventListener('pointerleave', clear)
+    editorView.dom.removeEventListener('pointercancel', clear)
+    window.removeEventListener('blur', clear)
+    clear()
+  }
+}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2854,6 +2854,14 @@ a:focus-visible {
   background: color-mix(in srgb, var(--user-color, var(--accent)) 18%, transparent);
 }
 
+.read-pointer-cursor {
+  border-left-style: dashed;
+}
+
+.read-pointer-cursor > div {
+  border-radius: 999px;
+}
+
 /* ----------------------------- Share popover ----------------------------- */
 
 .share-root {

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -34,6 +34,7 @@ import {
   type SuggestionPayload,
 } from '../../editor/suggestions'
 import { refreshAgentCursors } from '../../editor/agent_cursors'
+import { bindReadPointerBroadcast } from '../../editor/read_pointers'
 import { editorViewCtx, parserCtx, schemaCtx } from '@milkdown/kit/core'
 import { sourceParser } from '../../editor/document_format'
 import {
@@ -330,6 +331,12 @@ export default function DocumentShow({
     setSuggestionNotice(null)
     setActiveSheet(null)
   }, [isReading])
+
+  useEffect(() => {
+    if (!handle || !isReading) return
+
+    return bindReadPointerBroadcast(handle.editor, handle.provider.awareness)
+  }, [handle, isReading])
 
   // The comment composer lives in the comments panel — on mobile that means
   // opening its sheet when a selection chooses "Comment".

--- a/docs/plans/2026-06-26-013-feat-read-mode-pointers-plan.md
+++ b/docs/plans/2026-06-26-013-feat-read-mode-pointers-plan.md
@@ -1,0 +1,35 @@
+---
+title: "feat: Show live pointers from Read mode"
+type: feat
+date: 2026-06-26
+issue: 80
+---
+
+# Show live pointers from Read mode
+
+## Outcome
+
+People reading a document can point at its prose by hovering, and collaborators see that movement live as a labeled cursor.
+
+## Requirements
+
+1. Mouse and pen hover in Read mode publish the nearest document position through the existing Yjs awareness channel.
+2. Remote peers render the reader's position live with their name/color and a visual distinction from an editing caret.
+3. Read hover never focuses the editor, changes the ProseMirror selection, writes document content, or persists state.
+4. Leaving the editor, switching modes, blurring the window, or unmounting clears the pointer.
+5. Touch movement is ignored because it has no hover state.
+6. Positions use Yjs relative positions so concurrent edits do not strand the pointer.
+
+## Implementation
+
+- Add a Milkdown ProseMirror decoration plugin for a dedicated `readPointer` awareness field.
+- Bind pointer movement only while the page's effective mode is Read, throttled to one update per animation frame and deduplicated by ProseMirror position.
+- Clear the ordinary cursor when entering Read mode so peers never see an editing caret and read pointer simultaneously.
+- Add restrained dashed-caret styling and browser coverage with two live sessions.
+
+## Verification
+
+- TypeScript and full Rails suite (the existing locked-reader channel test proves awareness relay remains authorized).
+- Two-browser local test: reader hover appears/moves for editor, pointer leave clears it, content remains unchanged.
+- Desktop and locked-link Read mode checks; touch viewport confirms no overflow or accidental editor interaction.
+- Production smoke test and temporary-document cleanup.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -152,6 +152,35 @@ try {
   } else {
     fail('View downgrade left an unavailable mode active')
   }
+
+  const ownerContentBeforePointer = await landing.locator('.milkdown .ProseMirror').evaluate((editor) => {
+    const clone = editor.cloneNode(true)
+    clone.querySelectorAll('.read-pointer-cursor').forEach((cursor) => cursor.remove())
+    return clone.textContent
+  })
+  const readParagraph = await accessGuest.locator('.milkdown .ProseMirror p').first().boundingBox()
+  if (!readParagraph) throw new Error('Read-mode paragraph did not render')
+  await accessGuest.mouse.move(
+    readParagraph.x + Math.min(80, readParagraph.width / 2),
+    readParagraph.y + readParagraph.height / 2,
+  )
+  await landing.locator('.read-pointer-cursor').waitFor({ timeout: 5000 })
+  const ownerContentWithPointer = await landing.locator('.milkdown .ProseMirror').evaluate((editor) => {
+    const clone = editor.cloneNode(true)
+    clone.querySelectorAll('.read-pointer-cursor').forEach((cursor) => cursor.remove())
+    return clone.textContent
+  })
+  if (
+    ownerContentWithPointer === ownerContentBeforePointer &&
+    (await accessGuest.locator('.milkdown .ProseMirror').getAttribute('contenteditable')) === 'false'
+  ) {
+    ok('locked Read mode broadcasts a live pointer without editing content')
+  } else {
+    fail('Read-mode pointer changed document content or enabled editing')
+  }
+  await accessGuest.mouse.move(0, 0)
+  await landing.locator('.read-pointer-cursor').waitFor({ state: 'detached', timeout: 5000 })
+  ok('Read-mode pointer clears when the reader leaves the document')
   await accessGuest.close()
 
   await landing.setViewportSize({ width: 390, height: 844 })


### PR DESCRIPTION
## Summary
- publish reader hover positions through Yjs awareness without focusing or editing the document
- render labeled, visually distinct read pointers for collaborators and clear them on leave, blur, or mode changes
- cover locked View-link behavior in the collaboration browser check

## Verification
- `npm run check`
- `bin/rubocop`
- `bin/vite build --clear --mode=test && bin/rails test` (408 tests, 1,927 assertions)
- `bin/vite build`
- two-session browser verification for movement, cleanup, touch exclusion, and unchanged content

Closes #80