### PR TITLE
Follow collaborators through a document

### DIFF
--- a/app/frontend/components/presence_bar.tsx
+++ b/app/frontend/components/presence_bar.tsx
@@ -8,11 +8,17 @@ export interface AgentPresencePayload {
   last_seen_at: string
 }
 
+export interface HumanPresence extends UserIdentity {
+  clientId: number
+}
+
 interface Props {
-  humans: UserIdentity[]
+  humans: HumanPresence[]
   agents: AgentPresencePayload[]
   /** Mobile header: 24px avatars, max 3 visible. */
   compact?: boolean
+  followingClientId?: number | null
+  onFollow?: (clientId: number) => void
 }
 
 const MAX_VISIBLE = 5
@@ -27,11 +33,18 @@ const initials = (name: string): string =>
     .map((word) => word[0]!.toUpperCase())
     .join('')
 
-export function PresenceBar({ humans, agents, compact = false }: Props) {
+export function PresenceBar({
+  humans,
+  agents,
+  compact = false,
+  followingClientId = null,
+  onFollow,
+}: Props) {
   const total = humans.length + agents.length
 
   const visibleHumans = humans.slice(0, compact ? MAX_VISIBLE_COMPACT : MAX_VISIBLE)
   const overflow = humans.length - visibleHumans.length
+  const following = humans.find((human) => human.clientId === followingClientId)
 
   // Always render the container — even with 0 collaborators — so its reserved
   // lane (a min-width in render-blocking CSS, scoped to .presence-bar) holds
@@ -58,15 +71,19 @@ export function PresenceBar({ humans, agents, compact = false }: Props) {
         </span>
       ))}
       <span className="presence-stack">
-        {visibleHumans.map((human, index) => (
-          <span
-            key={`human-${index}`}
-            className="presence-avatar"
+        {visibleHumans.map((human) => (
+          <button
+            type="button"
+            key={human.clientId}
+            className={`presence-avatar presence-avatar--human ${followingClientId === human.clientId ? 'is-following' : ''}`}
             style={{ background: human.color }}
-            title={human.name}
+            title={followingClientId === human.clientId ? `Stop following ${human.name}` : `Follow ${human.name}`}
+            aria-label={followingClientId === human.clientId ? `Stop following ${human.name}` : `Follow ${human.name}`}
+            aria-pressed={followingClientId === human.clientId}
+            onClick={() => onFollow?.(human.clientId)}
           >
             {initials(human.name)}
-          </span>
+          </button>
         ))}
         {overflow > 0 && (
           <span className="presence-avatar presence-overflow" title={`${overflow} more`}>
@@ -74,6 +91,11 @@ export function PresenceBar({ humans, agents, compact = false }: Props) {
           </span>
         )}
       </span>
+      {following && (
+        <span className="presence-following" aria-live="polite">
+          Following {following.name}
+        </span>
+      )}
       {total > 1 && <span className="presence-count">{total} here</span>}
     </span>
   )

--- a/app/frontend/editor/collab_positions.ts
+++ b/app/frontend/editor/collab_positions.ts
@@ -1,0 +1,56 @@
+import type { EditorState } from '@milkdown/kit/prose/state'
+import * as Y from 'yjs'
+import {
+  absolutePositionToRelativePosition,
+  relativePositionToAbsolutePosition,
+} from 'y-prosemirror'
+
+export interface CollabSyncState {
+  doc: Y.Doc
+  type: Y.XmlFragment
+  binding: {
+    mapping: Parameters<typeof absolutePositionToRelativePosition>[2]
+  }
+}
+
+// @milkdown/plugin-collab is prebundled by Vite, so importing its
+// ySyncPluginKey through the app can create a second key object. Locate the
+// installed y-sync plugin by its stable ProseMirror key instead.
+export const collabSyncState = (state: EditorState): CollabSyncState | undefined => {
+  const syncKey = state.plugins.map((plugin) => plugin.spec.key).find((pluginKey) => {
+    const runtimeKey = pluginKey as unknown as { key?: string } | undefined
+    return runtimeKey?.key === 'y-sync$'
+  })
+  return syncKey?.getState(state) as CollabSyncState | undefined
+}
+
+export const toRelativePosition = (
+  state: EditorState,
+  position: number,
+): Y.RelativePosition | null => {
+  const syncState = collabSyncState(state)
+  if (!syncState || syncState.binding.mapping.size === 0) return null
+  return absolutePositionToRelativePosition(
+    position,
+    syncState.type,
+    syncState.binding.mapping,
+  )
+}
+
+export const fromRelativePosition = (
+  state: EditorState,
+  anchorJson: unknown,
+  syncState = collabSyncState(state),
+): number | null => {
+  if (!syncState || syncState.binding.mapping.size === 0) return null
+  try {
+    return relativePositionToAbsolutePosition(
+      syncState.doc,
+      syncState.type,
+      Y.createRelativePositionFromJSON(anchorJson),
+      syncState.binding.mapping,
+    )
+  } catch {
+    return null
+  }
+}

--- a/app/frontend/editor/read_pointers.ts
+++ b/app/frontend/editor/read_pointers.ts
@@ -3,12 +3,13 @@ import { $ctx, $prose } from '@milkdown/kit/utils'
 import { Plugin, PluginKey, type EditorState } from '@milkdown/kit/prose/state'
 import { Decoration, DecorationSet, type EditorView } from '@milkdown/kit/prose/view'
 import type { Awareness } from 'y-protocols/awareness'
-import * as Y from 'yjs'
-import {
-  absolutePositionToRelativePosition,
-  relativePositionToAbsolutePosition,
-} from 'y-prosemirror'
 import type { UserIdentity } from './identity'
+import {
+  collabSyncState,
+  fromRelativePosition,
+  toRelativePosition,
+  type CollabSyncState,
+} from './collab_positions'
 
 interface ReadPointerState {
   anchor?: unknown
@@ -19,14 +20,6 @@ interface AwarenessState {
   readPointer?: ReadPointerState | null
 }
 
-interface SyncState {
-  doc: Y.Doc
-  type: Y.XmlFragment
-  binding: {
-    mapping: Parameters<typeof absolutePositionToRelativePosition>[2]
-  }
-}
-
 export const readPointerAwarenessCtx = $ctx<Awareness | null, 'readPointerAwareness'>(
   null,
   'readPointerAwareness',
@@ -34,17 +27,6 @@ export const readPointerAwarenessCtx = $ctx<Awareness | null, 'readPointerAwaren
 
 const readPointerKey = new PluginKey('READ_POINTERS')
 const SAFE_COLOR = /^#[0-9a-f]{6}$/i
-
-// @milkdown/plugin-collab is prebundled by Vite, so importing its
-// ySyncPluginKey through the app can create a second key object. Locate the
-// installed y-sync plugin by its stable ProseMirror key instead.
-const syncStateFor = (state: EditorState): SyncState | undefined => {
-  const syncKey = state.plugins.map((plugin) => plugin.spec.key).find((pluginKey) => {
-    const runtimeKey = pluginKey as unknown as { key?: string } | undefined
-    return runtimeKey?.key === 'y-sync$'
-  })
-  return syncKey?.getState(state) as SyncState | undefined
-}
 
 const buildPointer = (user: UserIdentity | undefined): HTMLElement => {
   const color = user?.color && SAFE_COLOR.test(user.color) ? user.color : '#9d4edd'
@@ -62,7 +44,7 @@ const buildPointer = (user: UserIdentity | undefined): HTMLElement => {
 const decorationsFor = (
   state: EditorState,
   awareness: Awareness | null,
-  syncState: SyncState | undefined,
+  syncState: CollabSyncState | undefined,
 ): DecorationSet => {
   if (!awareness || !syncState || syncState.binding.mapping.size === 0) {
     return DecorationSet.empty
@@ -75,12 +57,7 @@ const decorationsFor = (
     const anchorJson = awarenessState.readPointer?.anchor
     if (!anchorJson) return
 
-    const position = relativePositionToAbsolutePosition(
-      syncState.doc,
-      syncState.type,
-      Y.createRelativePositionFromJSON(anchorJson),
-      syncState.binding.mapping,
-    )
+    const position = fromRelativePosition(state, anchorJson, syncState)
     if (position === null) return
 
     const boundedPosition = Math.min(position, state.doc.content.size)
@@ -106,7 +83,7 @@ const readPointerProse = $prose((ctx) => new Plugin({
         return decorationsFor(
           newState,
           ctx.get(readPointerAwarenessCtx.key),
-          syncStateFor(oldState),
+          collabSyncState(oldState),
         )
       }
       return previous.map(transaction.mapping, transaction.doc)
@@ -182,13 +159,8 @@ export function bindReadPointerBroadcast(
     const found = editorView.posAtCoords(latestPoint)
     if (!found || found.pos === lastPosition) return
 
-    const syncState = syncStateFor(editorView.state)
-    if (!syncState || syncState.binding.mapping.size === 0) return
-    const anchor = absolutePositionToRelativePosition(
-      found.pos,
-      syncState.type,
-      syncState.binding.mapping,
-    )
+    const anchor = toRelativePosition(editorView.state, found.pos)
+    if (!anchor) return
     lastPosition = found.pos
     awareness.setLocalStateField('readPointer', { anchor })
   }

--- a/app/frontend/editor/viewport_follow.ts
+++ b/app/frontend/editor/viewport_follow.ts
@@ -1,0 +1,156 @@
+import { editorViewCtx, type Editor } from '@milkdown/kit/core'
+import type { EditorView } from '@milkdown/kit/prose/view'
+import type { Awareness } from 'y-protocols/awareness'
+import { fromRelativePosition, toRelativePosition } from './collab_positions'
+
+interface ViewportAwarenessState {
+  viewport?: {
+    anchor?: unknown
+    line?: number
+    offset?: number
+  } | null
+}
+
+const VIEWPORT_LINE = 0.42
+const MIN_VISIBLE_LINE = 0.08
+const MAX_VISIBLE_LINE = 0.92
+const MAX_OFFSET_SCREENS = 2
+
+const editorViewFor = (editor: Editor): EditorView | null => {
+  let view: EditorView | null = null
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx)
+  })
+  return view
+}
+
+const viewportPoint = (view: EditorView): { left: number; top: number; line: number } | null => {
+  const rect = view.dom.getBoundingClientRect()
+  const visibleTop = Math.max(0, rect.top)
+  const visibleBottom = Math.min(window.innerHeight, rect.bottom)
+  if (visibleBottom <= visibleTop) return null
+
+  const desiredTop = window.innerHeight * VIEWPORT_LINE
+  const top = Math.min(Math.max(desiredTop, visibleTop + 1), visibleBottom - 1)
+  return {
+    left: rect.left + rect.width / 2,
+    top,
+    line: top / window.innerHeight,
+  }
+}
+
+/** Publishes the document position currently crossing a comfortable viewport line. */
+export function bindViewportBroadcast(editor: Editor, awareness: Awareness): () => void {
+  const view = editorViewFor(editor)
+  if (!view) return () => undefined
+
+  let frame: number | null = null
+  let lastPosition: number | null = null
+  let lastLine: number | null = null
+  let lastOffset: number | null = null
+
+  const publish = () => {
+    frame = null
+    const point = viewportPoint(view)
+    if (!point) return
+    const found = view.posAtCoords(point)
+    if (!found) return
+
+    const roundedLine = Math.round(point.line * 1000) / 1000
+    let offset = 0
+    try {
+      offset = Math.round(point.top - view.coordsAtPos(found.pos).top)
+    } catch {
+      // A remap between the coordinate lookups is harmless; zero is still a
+      // usable anchor and the next scroll frame will refine it.
+    }
+    if (
+      found.pos === lastPosition &&
+      roundedLine === lastLine &&
+      offset === lastOffset
+    ) return
+    const anchor = toRelativePosition(view.state, found.pos)
+    if (!anchor) return
+
+    lastPosition = found.pos
+    lastLine = roundedLine
+    lastOffset = offset
+    awareness.setLocalStateField('viewport', { anchor, line: roundedLine, offset })
+  }
+  const schedule = () => {
+    if (frame === null) frame = requestAnimationFrame(publish)
+  }
+  const clear = () => {
+    if (frame !== null) cancelAnimationFrame(frame)
+    frame = null
+    awareness.setLocalStateField('viewport', null)
+  }
+
+  window.addEventListener('scroll', schedule, { passive: true })
+  window.addEventListener('resize', schedule, { passive: true })
+  queueMicrotask(schedule)
+
+  return () => {
+    window.removeEventListener('scroll', schedule)
+    window.removeEventListener('resize', schedule)
+    clear()
+  }
+}
+
+/** Keeps this window aligned to one remote awareness client's viewport anchor. */
+export function bindViewportFollow(
+  editor: Editor,
+  awareness: Awareness,
+  clientId: number,
+  onUnavailable: () => void,
+): () => void {
+  const view = editorViewFor(editor)
+  if (!view) return () => undefined
+
+  let frame: number | null = null
+  const follow = () => {
+    frame = null
+    const remoteState = awareness.getStates().get(clientId) as ViewportAwarenessState | undefined
+    if (!remoteState) {
+      onUnavailable()
+      return
+    }
+    const anchorJson = remoteState.viewport?.anchor
+    if (!anchorJson) return
+
+    const position = fromRelativePosition(view.state, anchorJson)
+    if (position === null) return
+    const boundedPosition = Math.min(position, view.state.doc.content.size)
+    const line = Math.min(
+      MAX_VISIBLE_LINE,
+      Math.max(MIN_VISIBLE_LINE, remoteState.viewport?.line ?? VIEWPORT_LINE),
+    )
+    const maxOffset = window.innerHeight * MAX_OFFSET_SCREENS
+    const offset = Math.min(
+      maxOffset,
+      Math.max(-maxOffset, remoteState.viewport?.offset ?? 0),
+    )
+
+    try {
+      const coordinates = view.coordsAtPos(boundedPosition)
+      const delta = coordinates.top + offset - window.innerHeight * line
+      if (Math.abs(delta) > 1) window.scrollBy({ top: delta, behavior: 'auto' })
+    } catch {
+      // The document can remap between awareness receipt and this animation
+      // frame. The next viewport update will resolve against the new mapping.
+    }
+  }
+  const schedule = () => {
+    if (frame === null) frame = requestAnimationFrame(follow)
+  }
+
+  awareness.on('change', schedule)
+  window.addEventListener('resize', schedule, { passive: true })
+  queueMicrotask(schedule)
+
+  return () => {
+    awareness.off('change', schedule)
+    window.removeEventListener('resize', schedule)
+    if (frame !== null) cancelAnimationFrame(frame)
+  }
+}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2139,6 +2139,24 @@ a:focus-visible {
   user-select: none;
 }
 
+.presence-avatar--human {
+  padding: 0;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.presence-avatar--human:hover {
+  transform: translateY(-1px);
+}
+
+.presence-avatar--human:focus-visible,
+.presence-avatar--human.is-following {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--surface-raised), 0 0 0 4px var(--accent);
+  z-index: 2;
+}
+
 .presence-stack .presence-avatar + .presence-avatar {
   margin-left: -8px;
 }
@@ -2175,6 +2193,19 @@ a:focus-visible {
   font-size: 0.68rem;
   color: var(--ink-faint);
   white-space: nowrap;
+}
+
+.presence-following {
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--ink-soft);
+  padding: 0.12rem 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 600;
 }
 
 /* Compact (mobile header) variant: 24px avatars. */
@@ -3272,7 +3303,8 @@ a:focus-visible {
   /* Glanceable chrome only: counts live on the dock, labels in titles. */
   .prov-summary,
   .presence-count,
-  .presence-agent-name {
+  .presence-agent-name,
+  .presence-following {
     display: none;
   }
 

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../editor/suggestions'
 import { refreshAgentCursors } from '../../editor/agent_cursors'
 import { bindReadPointerBroadcast } from '../../editor/read_pointers'
+import { bindViewportBroadcast, bindViewportFollow } from '../../editor/viewport_follow'
 import { editorViewCtx, parserCtx, schemaCtx } from '@milkdown/kit/core'
 import { sourceParser } from '../../editor/document_format'
 import {
@@ -53,7 +54,11 @@ import { MarginSuggestions } from '../../components/margin_suggestions'
 import { CommentsPanel, type CommentPayload } from '../../components/comments_panel'
 import { AnchoredComposer } from '../../components/anchored_composer'
 import { SelectionToolbar } from '../../components/selection_toolbar'
-import { PresenceBar, type AgentPresencePayload } from '../../components/presence_bar'
+import {
+  PresenceBar,
+  type AgentPresencePayload,
+  type HumanPresence,
+} from '../../components/presence_bar'
 import { ActivityPanel } from '../../components/activity_panel'
 import { IdentityChip } from '../../components/identity_chip'
 import { type OwnershipPayload } from '../../components/ownership_chip'
@@ -233,7 +238,8 @@ export default function DocumentShow({
   } | null>(null)
   const [swappedEditorKey, setSwappedEditorKey] = useState<string | null>(null)
   const [spans, setSpans] = useState<ProvenanceSpan[]>([])
-  const [peers, setPeers] = useState<UserIdentity[]>([])
+  const [peers, setPeers] = useState<HumanPresence[]>([])
+  const [followingClientId, setFollowingClientId] = useState<number | null>(null)
   const [reviewTarget, setReviewTarget] = useState<ReviewTarget | null>(null)
   const [selectionTarget, setSelectionTarget] = useState<SelectionTarget | null>(null)
   const [commentTarget, setCommentTarget] = useState<CommentTarget | null>(null)
@@ -338,6 +344,50 @@ export default function DocumentShow({
     return bindReadPointerBroadcast(handle.editor, handle.provider.awareness)
   }, [handle, isReading])
 
+  useEffect(() => {
+    if (!handle) return
+
+    return bindViewportBroadcast(handle.editor, handle.provider.awareness)
+  }, [handle])
+
+  useEffect(() => {
+    if (!handle || followingClientId === null) return
+    const targetId = followingClientId
+
+    return bindViewportFollow(
+      handle.editor,
+      handle.provider.awareness,
+      targetId,
+      () => setFollowingClientId((current) => current === targetId ? null : current),
+    )
+  }, [followingClientId, handle])
+
+  useEffect(() => {
+    if (followingClientId === null) return
+    const release = () => setFollowingClientId(null)
+    const releaseOutsidePresence = (event: PointerEvent | TouchEvent) => {
+      const target = event.target as Element | null
+      if (target?.closest('.presence-avatar--human')) return
+      release()
+    }
+    const releaseOnNavigationKey = (event: KeyboardEvent) => {
+      if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'].includes(event.key)) {
+        release()
+      }
+    }
+
+    window.addEventListener('wheel', release, { passive: true })
+    window.addEventListener('touchstart', releaseOutsidePresence, { passive: true })
+    window.addEventListener('pointerdown', releaseOutsidePresence, { passive: true })
+    window.addEventListener('keydown', releaseOnNavigationKey)
+    return () => {
+      window.removeEventListener('wheel', release)
+      window.removeEventListener('touchstart', releaseOutsidePresence)
+      window.removeEventListener('pointerdown', releaseOutsidePresence)
+      window.removeEventListener('keydown', releaseOnNavigationKey)
+    }
+  }, [followingClientId])
+
   // The comment composer lives in the comments panel — on mobile that means
   // opening its sheet when a selection chooses "Comment".
   useEffect(() => {
@@ -405,17 +455,38 @@ export default function DocumentShow({
     const selfId = handle.provider.doc.clientID
     const update = () => {
       const states = Array.from(awareness.getStates().entries())
-      setPeers(
-        states
-          .filter(([clientId]) => clientId !== selfId)
-          .map(([, state]) => (state as { user?: UserIdentity }).user)
-          .filter((user): user is UserIdentity => Boolean(user)),
+      const nextPeers = states
+        .filter(([clientId]) => clientId !== selfId)
+        .map(([clientId, state]) => {
+          const user = (state as { user?: UserIdentity }).user
+          return user ? { ...user, clientId } : null
+        })
+        .filter((user): user is HumanPresence => Boolean(user))
+      setPeers((current) =>
+        current.length === nextPeers.length && current.every((peer, index) => {
+          const next = nextPeers[index]
+          return next &&
+            peer.clientId === next.clientId &&
+            peer.name === next.name &&
+            peer.color === next.color
+        })
+          ? current
+          : nextPeers,
       )
     }
     update()
     awareness.on('change', update)
     return () => awareness.off('change', update)
   }, [handle])
+
+  useEffect(() => {
+    if (
+      followingClientId !== null &&
+      !peers.some((peer) => peer.clientId === followingClientId)
+    ) {
+      setFollowingClientId(null)
+    }
+  }, [followingClientId, peers])
 
   // Rename applies here AFTER the server confirms the session write (the
   // chip's POST onSuccess). The handler only moves React state — the live
@@ -1138,7 +1209,15 @@ export default function DocumentShow({
                 onRenamed={handleRenamed}
               />
               {!isReading && <ProvenanceSummaryChip spans={spans} />}
-              <PresenceBar humans={peers} agents={presences} compact={isMobile} />
+              <PresenceBar
+                humans={peers}
+                agents={presences}
+                compact={isMobile}
+                followingClientId={followingClientId}
+                onFollow={(clientId) => {
+                  setFollowingClientId((current) => current === clientId ? null : clientId)
+                }}
+              />
             </div>
             {!isReading && pendingSuggestionCount > 1 && (
               <button

--- a/docs/plans/2026-06-26-014-feat-follow-collaborator-plan.md
+++ b/docs/plans/2026-06-26-014-feat-follow-collaborator-plan.md
@@ -1,0 +1,36 @@
+---
+title: "feat: Follow a collaborator's viewport"
+type: feat
+date: 2026-06-26
+issue: 83
+---
+
+# Follow a collaborator's viewport
+
+## Outcome
+
+Clicking a present collaborator's avatar follows their reading position live, like Figma's follow mode, until the follower navigates independently or toggles follow off.
+
+## Requirements
+
+1. Every connected human publishes an ephemeral viewport anchor through the existing Yjs awareness channel.
+2. Human presence avatars are real buttons with a clear follow/unfollow label and active state.
+3. Following keeps the selected collaborator's document position at the same comfortable viewport line across different window sizes.
+4. Wheel, touch, pointer, or navigation-key input immediately releases follow; programmatic follow scrolling does not.
+5. Switching targets, clicking the active target again, disconnecting, or unmounting cleans up follow state.
+6. Viewport anchors use Yjs relative positions so edits do not invalidate them and never write or persist document content.
+7. Agents remain presence-only because API presence exposes a semantic location, not a live viewport.
+
+## Implementation
+
+- Add a collaboration viewport module that publishes a throttled, deduplicated relative position and follows a selected awareness client.
+- Preserve awareness client IDs in the page's human peer state and pass follow state/actions into `PresenceBar`.
+- Render human avatars as accessible buttons with a selected ring and a compact `Following …` status.
+- Bind viewport publication for every live editor and bind remote scrolling only while a peer is selected.
+- Add browser coverage for starting follow, remote scrolling, manual release, disconnect cleanup, and content immutability.
+
+## Verification
+
+- TypeScript, RuboCop, full Rails suite, and production Vite build.
+- Two-browser local test at different viewport sizes: click peer, follow both directions, release by manual input, and handle disconnect.
+- Production two-session smoke test followed by temporary-document cleanup.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -254,11 +254,22 @@ try {
     await fetch(`${BASE}/api/docs`, {
       method: 'POST',
       headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Original title', content: '# Original title\n\nBody.\n' }),
+      body: JSON.stringify({
+        title: 'Original title',
+        content: [
+          '# Original title',
+          ...Array.from(
+            { length: 50 },
+            (_, index) => `## Follow section ${index + 1}\n\n${'Viewport follow text. '.repeat(8)}`,
+          ),
+        ].join('\n\n'),
+      }),
     })
   ).json()
   const titleA = await browser.newPage()
   const titleB = await browser.newPage()
+  await titleA.setViewportSize({ width: 1280, height: 700 })
+  await titleB.setViewportSize({ width: 1440, height: 900 })
   await titleA.goto(`${BASE}/d/${titleDoc.slug}/edit`)
   await titleB.goto(`${BASE}/d/${titleDoc.slug}/edit`)
   await titleA.waitForSelector('.doc-status--live', { timeout: 15000 })
@@ -297,6 +308,48 @@ try {
     ok('H1 title survives reload')
   } else {
     fail('H1 title was lost on reload')
+  }
+
+  const titleContentBeforeFollow = await titleA.locator('.milkdown .ProseMirror').innerText()
+  await titleA.getByRole('button', { name: /^Follow / }).click()
+  await titleA.locator('.presence-following').waitFor()
+  await titleB.evaluate(() => window.scrollTo(0, 5000))
+  await titleA.waitForFunction(() => window.scrollY > 4500, { timeout: 5000 })
+  const followedPosition = await titleA.evaluate(() => window.scrollY)
+  const followedSection = await titleA.evaluate(() =>
+    document.elementFromPoint(window.innerWidth / 2, window.innerHeight * 0.42)
+      ?.closest('h2, p')?.textContent,
+  )
+  const leaderSection = await titleB.evaluate(() =>
+    document.elementFromPoint(window.innerWidth / 2, window.innerHeight * 0.42)
+      ?.closest('h2, p')?.textContent,
+  )
+  if (
+    (await titleA.getByRole('button', { name: /^Stop following / }).getAttribute('aria-pressed')) === 'true' &&
+    followedPosition > 4500 &&
+    followedSection === leaderSection &&
+    (await titleA.locator('.milkdown .ProseMirror').innerText()) === titleContentBeforeFollow
+  ) {
+    ok('clicking a collaborator follows their live viewport without changing content')
+  } else {
+    fail(`collaborator follow did not track the remote viewport: ${followedPosition}`)
+  }
+  await titleA.getByRole('button', { name: /^Stop following / }).click()
+  await titleA.locator('.presence-following').waitFor({ state: 'detached' })
+  ok('clicking the active collaborator toggles follow off')
+
+  await titleA.getByRole('button', { name: /^Follow / }).click()
+  await titleA.locator('.presence-following').waitFor()
+  await titleA.mouse.wheel(0, -300)
+  await titleA.locator('.presence-following').waitFor({ state: 'detached' })
+  await titleA.waitForTimeout(100)
+  const releasedPosition = await titleA.evaluate(() => window.scrollY)
+  await titleB.evaluate(() => window.scrollTo(0, 1000))
+  await titleA.waitForTimeout(500)
+  if (Math.abs((await titleA.evaluate(() => window.scrollY)) - releasedPosition) < 5) {
+    ok('manual navigation releases collaborator follow')
+  } else {
+    fail('manual navigation did not release collaborator follow')
   }
   await titleA.close()
   await titleB.close()


### PR DESCRIPTION
## Summary
- publish each collaborator’s viewport as an ephemeral Yjs-relative awareness anchor
- make human presence avatars accessible follow controls with a clear active state
- track the same visible section across viewport sizes and release on manual navigation or disconnect
- share defensive relative-position helpers with Read-mode pointers

## Verification
- `npm run check`
- `bin/rubocop`
- `bin/vite build --clear --mode=test && bin/rails test` (408 tests, 1,927 assertions)
- `bin/vite build`
- two-session browser verification across desktop/mobile viewport sizes, toggle, manual release, disconnect expiry, and Read-pointer regression

Closes #83