### PR TITLE
Render Mermaid Markdown diagrams

### DIFF
--- a/app/frontend/editor/mermaid.ts
+++ b/app/frontend/editor/mermaid.ts
@@ -1,0 +1,150 @@
+import DOMPurify from 'dompurify'
+import type { Node } from '@milkdown/kit/prose/model'
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state'
+import { Decoration, DecorationSet } from '@milkdown/kit/prose/view'
+import { $prose } from '@milkdown/kit/utils'
+
+type MermaidApi = (typeof import('mermaid'))['default']
+
+const RENDER_DELAY_MS = 120
+const mermaidDecorationsKey = new PluginKey<DecorationSet>('thinkroomMermaid')
+
+let mermaidPromise: Promise<MermaidApi> | null = null
+let renderSequence = 0
+
+const loadMermaid = (): Promise<MermaidApi> => {
+  mermaidPromise ??= import('mermaid').then(({ default: mermaid }) => {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      suppressErrorRendering: true,
+      theme: 'neutral',
+      // SVG <text> survives the strict SVG sanitizer; HTML labels rely on
+      // foreignObject and would be removed along with that broader attack
+      // surface, leaving correctly rendered shapes with invisible labels.
+      htmlLabels: false,
+      fontFamily: 'Assistant, ui-sans-serif, system-ui, sans-serif',
+    })
+    return mermaid
+  })
+  return mermaidPromise
+}
+
+const sourceHash = (source: string): string => {
+  let hash = 2_166_136_261
+  for (let index = 0; index < source.length; index += 1) {
+    hash = Math.imul(hash ^ source.charCodeAt(index), 16_777_619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+const statusElement = (message: string): HTMLElement => {
+  const status = document.createElement('span')
+  status.className = 'mermaid-diagram-status'
+  status.setAttribute('role', 'status')
+  status.textContent = message
+  return status
+}
+
+const sanitizedSvg = (source: string): SVGSVGElement | null => {
+  const template = document.createElement('template')
+  template.innerHTML = String(DOMPurify.sanitize(source, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+  }))
+  return template.content.querySelector('svg')
+}
+
+const renderDiagram = async (figure: HTMLElement, source: string): Promise<void> => {
+  if (!source.trim()) throw new Error('Empty Mermaid source')
+
+  const mermaid = await loadMermaid()
+  const parsed = await mermaid.parse(source, { suppressErrors: true })
+  if (!parsed) throw new Error('Invalid Mermaid source')
+
+  const id = `thinkroom-mermaid-${++renderSequence}`
+  const { svg } = await mermaid.render(id, source)
+  const rendered = sanitizedSvg(svg)
+  if (!rendered) throw new Error('Mermaid returned no SVG')
+  if (!rendered.hasAttribute('aria-label') && !rendered.hasAttribute('aria-labelledby')) {
+    rendered.setAttribute('aria-label', 'Mermaid diagram')
+  }
+  rendered.setAttribute('role', 'img')
+  rendered.classList.add('mermaid-diagram-svg')
+
+  if (!figure.isConnected) return
+  figure.dataset.state = 'ready'
+  figure.replaceChildren(rendered)
+}
+
+const diagramWidget = (position: number, source: string): Decoration => {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let destroyed = false
+
+  return Decoration.widget(
+    position,
+    () => {
+      const figure = document.createElement('figure')
+      figure.className = 'mermaid-diagram'
+      figure.contentEditable = 'false'
+      figure.dataset.state = 'loading'
+      figure.setAttribute('aria-label', 'Mermaid diagram')
+      figure.replaceChildren(statusElement('Rendering diagram…'))
+
+      timer = setTimeout(() => {
+        timer = null
+        if (destroyed || !figure.isConnected) return
+        void renderDiagram(figure, source).catch(() => {
+          if (destroyed || !figure.isConnected) return
+          figure.dataset.state = 'error'
+          figure.replaceChildren(statusElement('Couldn’t render this Mermaid diagram.'))
+        })
+      }, RENDER_DELAY_MS)
+
+      return figure
+    },
+    {
+      side: -1,
+      key: `mermaid-${position}-${sourceHash(source)}`,
+      ignoreSelection: true,
+      destroy: () => {
+        destroyed = true
+        if (timer) clearTimeout(timer)
+      },
+    },
+  )
+}
+
+const decorationsFor = (doc: Node): DecorationSet => {
+  const decorations: Decoration[] = []
+  doc.descendants((node, position) => {
+    const language = typeof node.attrs.language === 'string'
+      ? node.attrs.language.trim().toLowerCase()
+      : ''
+    if (node.type.name === 'code_block' && language === 'mermaid') {
+      decorations.push(diagramWidget(position, node.textContent))
+    }
+  })
+  return DecorationSet.create(doc, decorations)
+}
+
+/**
+ * Render fenced Mermaid code blocks without replacing their document nodes.
+ * The native code block remains the collaborative, serializable source; this
+ * plugin only adds a derived browser preview immediately before it.
+ */
+export const mermaidDiagrams = $prose(
+  () => new Plugin<DecorationSet>({
+    key: mermaidDecorationsKey,
+    state: {
+      init: (_, state) => decorationsFor(state.doc),
+      apply: (transaction, decorations) => (
+        transaction.docChanged
+          ? decorationsFor(transaction.doc)
+          : decorations.map(transaction.mapping, transaction.doc)
+      ),
+    },
+    props: {
+      decorations: (state) => mermaidDecorationsKey.getState(state) ?? null,
+    },
+  }),
+)

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -84,6 +84,7 @@ import {
 } from './document_format'
 import { configureSlashMenu, slashMenu } from './slash_menu'
 import { readPointerAwarenessCtx, readPointers } from './read_pointers'
+import { mermaidDiagrams } from './mermaid'
 
 export interface EditorHandle {
   editor: Editor
@@ -460,6 +461,7 @@ function CollabEditor({
         .use(indent)
         .use(trailing)
         .use(highlight)
+        .use(mermaidDiagrams)
         .use(upload)
         .use(provenance)
         .use(frontmatter)

--- a/app/frontend/editor/slash_menu.ts
+++ b/app/frontend/editor/slash_menu.ts
@@ -101,6 +101,10 @@ const buildItems = (ctx: Ctx): SlashItem[] => [
     run: setBlock('code_block'), available: nodeAvailable('code_block'),
   },
   {
+    label: 'Mermaid diagram', detail: 'Diagram from Mermaid source', icon: '◇', keywords: 'mermaid diagram flowchart graph sequence',
+    run: setBlock('code_block', { language: 'mermaid' }), available: nodeAvailable('code_block'),
+  },
+  {
     label: 'Divider', detail: 'Separate ideas', icon: '—', keywords: 'divider rule separator hr',
     run: insertDivider, available: nodeAvailable('hr'),
   },

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -1186,10 +1186,15 @@ a:focus-visible {
 
 /* Neutral box standing in for a sketch canvas until Excalidraw mounts, so a
    sketch doc reserves the right height instead of reflowing on swap. */
-.doc-sketch-skeleton {
+.doc-sketch-skeleton,
+.doc-mermaid-skeleton {
   margin: 1.5rem 0;
   border-radius: 12px;
   background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.doc-mermaid-skeleton {
+  min-height: 240px;
 }
 
 .milkdown .ProseMirror {
@@ -1405,6 +1410,67 @@ a:focus-visible {
   background: none;
   padding: 0;
   font-size: inherit;
+}
+
+/* Mermaid remains a native code block in the document; the figure before it
+   is a derived, disposable preview. That keeps Markdown, collaboration, undo,
+   and exports faithful while making diagrams readable in place. */
+.milkdown .ProseMirror .mermaid-diagram {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  margin: 1.5em 0 0.75em;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow: auto;
+  background: color-mix(in srgb, var(--paper) 94%, var(--ink) 6%);
+  padding: 1rem;
+}
+
+.milkdown .ProseMirror .mermaid-diagram-svg {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 70vh;
+}
+
+.milkdown .ProseMirror .mermaid-diagram-status {
+  color: var(--ink-soft);
+  font: 600 0.8rem/1.4 var(--font-ui);
+}
+
+.milkdown .ProseMirror .mermaid-diagram[data-state='error'] {
+  min-height: 96px;
+  border-style: dashed;
+}
+
+.milkdown .ProseMirror .mermaid-diagram + pre[data-language='mermaid'] {
+  position: relative;
+  margin-top: 0;
+}
+
+.milkdown .ProseMirror .mermaid-diagram + pre[data-language='mermaid']::before {
+  content: 'Mermaid source';
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--ink-faint);
+  font: 700 0.68rem/1 var(--font-ui);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.milkdown .ProseMirror[contenteditable='false']
+  .mermaid-diagram:not([data-state='error']) + pre[data-language='mermaid'] {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .milkdown .ProseMirror .mermaid-diagram {
+    min-height: 150px;
+    margin-inline: -0.25rem;
+    padding: 0.75rem;
+  }
 }
 
 /* A section break deserves air — owl-conformant: extra space comes from

--- a/app/services/document_preview_html.rb
+++ b/app/services/document_preview_html.rb
@@ -20,11 +20,12 @@ class DocumentPreviewHtml
         # "anchor">). The live Milkdown editor renders a bare <h1>, so without
         # this the preview's heading is structurally taller and the first
         # paragraph jumps ~30px when the editor swaps in.
-        Commonmarker.to_html(
+        rendered = Commonmarker.to_html(
           source,
           options: { extension: { header_ids: nil } },
           plugins: { table: true, strikethrough: true, tasklist: true }
         )
+        mark_mermaid_fences(rendered)
       end
 
       # Security boundary: document content is authored by humans and agents, so
@@ -33,6 +34,7 @@ class DocumentPreviewHtml
       fragment = Nokogiri::HTML5.fragment(sanitized)
       collapse_block_whitespace(fragment)
       skeletonize_sketches(fragment, format:)
+      skeletonize_mermaid(fragment) if format == "markdown"
       fragment.to_html
     end
 
@@ -43,6 +45,20 @@ class DocumentPreviewHtml
     WHITESPACE_BLOCK_PARENTS = %w[
       ul ol li blockquote table thead tbody tr figure dl
     ].freeze
+
+    # Commonmarker writes the fenced language to a `lang` attribute, which the
+    # document sanitizer intentionally drops. Translate only the Mermaid signal
+    # to the already-supported data-language attribute before sanitizing so the
+    # instant preview can reserve diagram space without trusting arbitrary HTML.
+    def mark_mermaid_fences(html)
+      fragment = Nokogiri::HTML5.fragment(html)
+      fragment.css("pre[lang]").each do |pre|
+        next unless pre["lang"].to_s.casecmp?("mermaid")
+
+        pre["data-language"] = "mermaid"
+      end
+      fragment.to_html
+    end
 
     # ProseMirror's DOM carries no whitespace text nodes between block elements,
     # but Commonmarker pretty-prints a "\n" between each one. The editor renders
@@ -73,6 +89,15 @@ class DocumentPreviewHtml
     def skeletonize_sketches(fragment, format:)
       sketch_nodes(fragment, format:).each do |node, height|
         node.replace(skeleton(node.document, height))
+      end
+    end
+
+    def skeletonize_mermaid(fragment)
+      fragment.css('pre[data-language="mermaid"]').each do |node|
+        figure = Nokogiri::XML::Node.new("figure", node.document)
+        figure["class"] = "doc-mermaid-skeleton"
+        figure["aria-hidden"] = "true"
+        node.replace(figure)
       end
     end
 

--- a/docs/plans/2026-06-26-015-feat-mermaid-diagrams-plan.md
+++ b/docs/plans/2026-06-26-015-feat-mermaid-diagrams-plan.md
@@ -1,0 +1,46 @@
+---
+title: "feat: Render Mermaid Markdown diagrams"
+type: feat
+status: active
+date: 2026-06-26
+issue: 85
+---
+
+# Render Mermaid Markdown diagrams
+
+## Goal
+
+Make fenced `mermaid` blocks useful in Thinkroom documents: render valid Mermaid source as a safe, responsive diagram while preserving the original Markdown as the collaborative source of truth.
+
+## Product decisions
+
+- A fenced `mermaid` code block remains an ordinary ProseMirror code block. This preserves Markdown round trips, live collaboration, history, provenance, and exports without introducing a second source format.
+- Edit mode shows the rendered diagram and its editable source. Read-only modes show the diagram alone when rendering succeeds.
+- Invalid or unsupported Mermaid never removes content. It shows a concise render error and leaves the source visible in every mode.
+- Diagram rendering is browser-only, lazy-loaded, and configured with Mermaid's strict security mode. The returned SVG is sanitized before insertion.
+- The server-rendered first paint uses a neutral Mermaid placeholder so raw source does not flash before the live editor mounts.
+
+## Implementation
+
+1. Add Mermaid as a direct frontend dependency and create an editor plugin that decorates `code_block` nodes whose language is `mermaid`.
+2. Render each diagram asynchronously with stable, collision-free IDs; discard stale results when source changes; sanitize SVG; and degrade to the source block on any error.
+3. Add responsive, theme-compatible diagram, loading, source, and error styling, including read-mode source hiding only after success.
+4. Preserve Markdown code-language metadata in the static preview long enough to replace Mermaid blocks with height-reserving placeholders.
+5. Add server preview tests and a focused Playwright check covering valid rendering, invalid fallback, edit/read behavior, source round-trip fidelity, responsive layout, and cleanup.
+
+## Verification
+
+- `npm run check`
+- `bin/rails test test/services/document_preview_html_test.rb`
+- `bin/rails test`
+- `bin/rubocop`
+- focused Mermaid browser check against `bin/dev`
+- production Vite build
+- code review and simplification passes
+- production deployment followed by the same valid/invalid/read/edit verification
+
+## Non-goals
+
+- A bespoke visual Mermaid editor.
+- Converting Mermaid diagrams to Excalidraw scenes.
+- Persisting rendered SVG in the document or database.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pruf",
+  "name": "thinkroom",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -21,6 +21,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "dompurify": "^3.4.11",
+        "mermaid": "^11.16.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "remark-frontmatter": "^5.0.0",
@@ -2654,12 +2655,6 @@
         "tailwindcss": "4.3.1"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
@@ -2985,12 +2980,6 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -5419,26 +5408,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -5460,12 +5449,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/mermaid/node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/mermaid/node_modules/katex": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "dompurify": "^3.4.11",
+    "mermaid": "^11.16.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "remark-frontmatter": "^5.0.0",

--- a/script/mermaid_check.mjs
+++ b/script/mermaid_check.mjs
@@ -1,0 +1,155 @@
+// Focused Mermaid browser regression.
+// Usage: BASE_URL=http://127.0.0.1:4123 node script/mermaid_check.mjs
+import { chromium, request } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://127.0.0.1:3000'
+const VALID_SOURCE = `flowchart LR
+  A[Draft] --> B{Review}
+  B -->|Approve| C[Publish]
+  B -->|Revise| A
+  click A "javascript:alert('unsafe')"`
+const INVALID_SOURCE = `flowchart definitely not valid
+  A --`
+
+const failures = []
+const check = (condition, message, detail = '') => {
+  if (condition) {
+    console.log(`✓ ${message}`)
+  } else {
+    failures.push(message)
+    console.error(`✗ ${message}${detail ? `: ${detail}` : ''}`)
+  }
+}
+
+const api = await request.newContext({
+  baseURL: BASE,
+  extraHTTPHeaders: { 'X-Agent-Name': 'Mermaid browser check' },
+})
+const browser = await chromium.launch()
+const context = await browser.newContext({ viewport: { width: 1280, height: 900 } })
+const page = await context.newPage()
+const mermaidErrors = []
+let slug
+
+page.on('pageerror', (error) => {
+  if (/parse error|unknowndiagram|mermaid.*(?:error|failed)/i.test(String(error))) {
+    mermaidErrors.push(String(error))
+  }
+})
+page.on('console', (message) => {
+  if (
+    message.type() === 'error' &&
+    /parse error|unknowndiagram|mermaid.*(?:error|failed)/i.test(message.text())
+  ) {
+    mermaidErrors.push(message.text())
+  }
+})
+
+try {
+  const created = await api.post('/api/docs', {
+    data: {
+      title: 'Mermaid browser check',
+      content: `# Mermaid browser check
+
+## Valid
+
+\`\`\`mermaid
+${VALID_SOURCE}
+\`\`\`
+
+## Invalid fallback
+
+\`\`\`mermaid
+${INVALID_SOURCE}
+\`\`\`
+`,
+    },
+  })
+  check(created.ok(), 'created a temporary Mermaid document', String(created.status()))
+  slug = (await created.json()).slug
+
+  await page.goto(`${BASE}/d/${slug}/edit`)
+  await page.locator('.doc-status--live').waitFor({ timeout: 15_000 })
+  await page.locator('.mermaid-diagram[data-state="ready"]').waitFor({ timeout: 15_000 })
+  await page.locator('.mermaid-diagram[data-state="error"]').waitFor({ timeout: 15_000 })
+
+  const sources = page.locator('pre[data-language="mermaid"]')
+  const labels = await page.locator('.mermaid-diagram[data-state="ready"] svg text').allTextContents()
+  check(labels.includes('Draft') && labels.includes('Publish'), 'valid Mermaid renders labeled SVG')
+  check(await sources.nth(0).isVisible(), 'edit mode keeps valid Mermaid source visible')
+  check(await sources.nth(1).isVisible(), 'invalid Mermaid keeps its source visible')
+  check((await sources.nth(0).textContent()) === VALID_SOURCE, 'editable source remains byte-for-byte intact')
+
+  const unsafeDom = await page.locator('.mermaid-diagram[data-state="ready"]').evaluate((diagram) => ({
+    scripts: diagram.querySelectorAll('script, foreignObject').length,
+    eventAttributes: Array.from(diagram.querySelectorAll('*')).flatMap((element) =>
+      Array.from(element.attributes).filter((attribute) => attribute.name.startsWith('on')),
+    ).length,
+    unsafeLinks: Array.from(diagram.querySelectorAll('a')).filter((anchor) =>
+      (anchor.getAttribute('href') ?? anchor.getAttribute('xlink:href') ?? '')
+        .trim().toLowerCase().startsWith('javascript:'),
+    ).length,
+  }))
+  check(
+    unsafeDom.scripts === 0 && unsafeDom.eventAttributes === 0 && unsafeDom.unsafeLinks === 0,
+    'rendered SVG removes executable markup and unsafe links',
+    JSON.stringify(unsafeDom),
+  )
+
+  await page.waitForTimeout(1_200)
+  const stateResponse = await api.get(`/api/docs/${slug}`)
+  const state = await stateResponse.json()
+  check(
+    state.content.includes(`\`\`\`mermaid\n${VALID_SOURCE}\n\`\`\``) &&
+      state.content.includes(`\`\`\`mermaid\n${INVALID_SOURCE}\n\`\`\``),
+    'durable Markdown preserves both Mermaid fences',
+  )
+
+  await page.goto(`${BASE}/d/${slug}`)
+  await page.locator('.mermaid-diagram[data-state="ready"]').waitFor({ timeout: 15_000 })
+  await page.locator('.mermaid-diagram[data-state="error"]').waitFor({ timeout: 15_000 })
+  check(!(await sources.nth(0).isVisible()), 'read mode hides source after a successful render')
+  check(await sources.nth(1).isVisible(), 'read mode exposes source when rendering fails')
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  const geometry = await page.evaluate(() => ({
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    diagramWidth: document.querySelector('.mermaid-diagram')?.getBoundingClientRect().width ?? 0,
+    viewportWidth: document.documentElement.clientWidth,
+  }))
+  check(
+    geometry.overflow === 0 && geometry.diagramWidth <= geometry.viewportWidth,
+    'Mermaid diagrams fit a mobile viewport without page overflow',
+    JSON.stringify(geometry),
+  )
+  check(mermaidErrors.length === 0, 'Mermaid rendering emits no unhandled browser errors', mermaidErrors.join(' | '))
+} finally {
+  if (slug) {
+    try {
+      await page.goto(`${BASE}/d/${slug}`)
+      const csrf = await page.locator('meta[name="csrf-token"]').getAttribute('content')
+      const headers = { 'X-CSRF-Token': csrf ?? '' }
+      const claimed = await context.request.post(`${BASE}/d/${slug}/claim`, {
+        form: { name: 'Mermaid browser check' },
+        headers,
+        maxRedirects: 0,
+      })
+      if (claimed.status() !== 303) throw new Error(`claim returned ${claimed.status()}`)
+      const removed = await context.request.delete(`${BASE}/d/${slug}`, {
+        headers,
+        maxRedirects: 0,
+      })
+      if (removed.status() !== 303) throw new Error(`delete returned ${removed.status()}`)
+      const deleted = await api.get(`/api/docs/${slug}`)
+      check(deleted.status() === 404, 'deleted the temporary Mermaid document')
+    } catch (error) {
+      failures.push('cleaned up the temporary Mermaid document')
+      console.error(`✗ cleaned up the temporary Mermaid document: ${error}`)
+    }
+  }
+  await context.close()
+  await browser.close()
+  await api.dispose()
+}
+
+if (failures.length > 0) process.exitCode = 1

--- a/test/services/document_preview_html_test.rb
+++ b/test/services/document_preview_html_test.rb
@@ -37,6 +37,28 @@ class DocumentPreviewHtmlTest < ActiveSupport::TestCase
     assert_includes html, "def x\n  1\nend"
   end
 
+  test "replaces a Mermaid fence with a first-paint skeleton" do
+    html = DocumentPreviewHtml.call(
+      format: "markdown",
+      content: "Before\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\nAfter"
+    )
+
+    assert_includes html, 'class="doc-mermaid-skeleton"'
+    refute_includes html, "flowchart LR"
+    assert_includes html, "Before"
+    assert_includes html, "After"
+  end
+
+  test "does not replace an ordinary code fence that mentions Mermaid" do
+    html = DocumentPreviewHtml.call(
+      format: "markdown",
+      content: "```text\nmermaid flowchart LR\n```"
+    )
+
+    refute_includes html, "doc-mermaid-skeleton"
+    assert_includes html, "mermaid flowchart LR"
+  end
+
   test "strips scripts and unsafe markup in markdown" do
     html = DocumentPreviewHtml.call(format: "markdown", content: "<script>alert(1)</script>\n\nsafe")
 


### PR DESCRIPTION
Closes #85

## Summary
- render fenced `mermaid` blocks as sanitized, responsive SVG while keeping native code blocks as the collaborative Markdown source
- show editable source in Edit mode, hide it after successful Read-mode rendering, and preserve source as the fallback for invalid diagrams
- add first-paint placeholders, a Mermaid slash-menu item, and a focused browser regression with CSRF-protected cleanup

## Verification
- `npm run check`
- `bin/rubocop`
- `bin/rails test` (410 runs, 1939 assertions)
- `BASE_URL=http://localhost:4123 node script/mermaid_check.mjs`
- `RAILS_ENV=test bin/vite build`
- `bin/vite build`
- manual desktop/mobile visual review in Edit and Read modes