### PR TITLE
Auto-claim fresh documents for signed-in users

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,6 +2,8 @@ class DocumentsController < InertiaController
   include DocumentWriteAuthorization
   rate_limit_document_creation
 
+  SIGNED_IN_AUTO_CLAIM_WINDOW = 10.minutes
+
   # SSR is scoped to the read-only document surfaces — #show (shell, header,
   # static content_html preview) and #index (the landing page) — so their
   # content is on screen at first byte. Both pages are SSR-safe: the live
@@ -70,6 +72,7 @@ class DocumentsController < InertiaController
       return render plain: AgentGuide.text(document, request.base_url)
     end
 
+    auto_claim_recent_document(document, link_preview_request:)
     remember_recent(document) unless link_preview_request
     @agent_guide = AgentGuide.text(document, request.base_url)
     @open_graph = document_open_graph(document)
@@ -474,6 +477,22 @@ class DocumentsController < InertiaController
 
   def link_preview_user_agent?
     request.user_agent.to_s.match?(LINK_PREVIEW_USER_AGENTS)
+  end
+
+  # A freshly agent-created handoff is overwhelmingly likely to belong to the
+  # authenticated person who opens it. Keep this GET-side convenience narrow:
+  # only a real, full browser navigation may claim, and the model's conditional
+  # update remains the authority if another owner wins concurrently.
+  def auto_claim_recent_document(document, link_preview_request:)
+    user = current_user
+    return unless user && request.get? && initial_render?
+    return if link_preview_request || prefetch_request?
+    return unless document.claimable?
+    return if document.created_at < SIGNED_IN_AUTO_CLAIM_WINDOW.ago
+
+    document.claim!(token: owner_token, user:, name: user.name)
+  rescue Document::ClaimRaceError
+    document.reload
   end
 
   # Browsers identify as Mozilla/...; curl, wget, httpx, ruby, etc. don't.

--- a/docs/plans/2026-06-26-016-feat-signed-in-auto-claim-plan.md
+++ b/docs/plans/2026-06-26-016-feat-signed-in-auto-claim-plan.md
@@ -1,0 +1,38 @@
+---
+title: "feat: Auto-claim fresh documents for signed-in users"
+type: feat
+status: active
+date: 2026-06-26
+issue: 89
+---
+
+# Auto-claim fresh documents for signed-in users
+
+## Goal
+
+When an authenticated person opens an unclaimed document created within the last 10 minutes, assign it to their account automatically so agent-created handoffs do not require a second claim click.
+
+## Safety boundaries
+
+- Only a signed-in user can trigger auto-claim.
+- Only unclaimed, claimable documents younger than 10 minutes qualify.
+- Only a real browser page navigation qualifies. Agent/text/JSON reads, link unfurlers, prefetch requests, and Inertia partial reloads remain side-effect free.
+- The model's existing conditional claim update remains the ownership authority. A concurrent winner is respected and the page still loads normally.
+- The transition records the existing claim activity and broadcasts the existing ownership/activity events, so other open clients reconcile normally.
+- Explicit claim remains available for older unclaimed documents.
+
+## Implementation
+
+1. Add a named 10-minute window and a private guarded auto-claim helper to `DocumentsController`.
+2. Invoke it only after agent/JSON/text exits and before the browser page's ownership/activity props are assembled.
+3. Add integration coverage for a qualifying signed-in navigation, guest navigation, stale documents, prefetch, partial reload, link preview, and a lost ownership race.
+4. Add a focused browser check proving the claim banner disappears, the header reports account ownership, the document appears under the account's home list, and cleanup succeeds.
+
+## Verification
+
+- `bin/rails test test/integration/ownership_flow_test.rb`
+- `bin/rails test`
+- `bin/rubocop`
+- `npm run check`
+- focused signed-in browser verification at desktop and mobile widths
+- production build, deploy, and production verification

--- a/test/integration/ownership_flow_test.rb
+++ b/test/integration/ownership_flow_test.rb
@@ -48,8 +48,83 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
     assert_not Document.find_by(slug: "demo").claimed?
   end
 
-  test "GET show never sets ownership" do
+  test "guest GET show never sets ownership" do
     get document_page_path(@document.slug), headers: browser
+    assert_response :success
+    assert_not @document.reload.claimed?
+  end
+
+  test "signed-in browser auto-claims a fresh unclaimed document" do
+    user = create_and_sign_in_user
+    @document.update!(created_at: 9.minutes.ago)
+
+    assert_broadcasts(DocumentMetaChannel.broadcasting_for(@document), 2) do
+      get document_page_path(@document.slug), headers: browser
+    end
+
+    assert_response :success
+    assert_equal user, @document.reload.user
+    assert_nil @document.owner_token
+    assert_equal user.name, @document.owner_name
+    assert_equal "claimed_document", @document.activities.last.action
+    assert_inertia_props do |props|
+      props.dig(:ownership, :yours) == true &&
+        props.dig(:ownership, :claimable) == false
+    end
+  end
+
+  test "signed-in browser leaves an older unclaimed document claimable" do
+    create_and_sign_in_user
+    @document.update!(created_at: 11.minutes.ago)
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_response :success
+    assert_not @document.reload.claimed?
+  end
+
+  test "signed-in prefetch never auto-claims a fresh document" do
+    create_and_sign_in_user
+
+    get document_page_path(@document.slug), headers: browser.merge("Sec-Purpose" => "prefetch")
+
+    assert_response :success
+    assert_not @document.reload.claimed?
+  end
+
+  test "signed-in Inertia partial reload never auto-claims a fresh document" do
+    create_and_sign_in_user
+
+    get document_page_path(@document.slug), headers: browser.merge(
+      "X-Inertia" => "true",
+      "X-Inertia-Version" => InertiaController.safe_vite_digest.to_s,
+      "X-Inertia-Partial-Component" => "documents/show",
+      "X-Inertia-Partial-Data" => "ownership"
+    )
+
+    assert_response :success
+    assert_not @document.reload.claimed?
+  end
+
+  test "signed-in link preview never auto-claims a fresh document" do
+    create_and_sign_in_user
+
+    get document_page_path(@document.slug), headers: {
+      "User-Agent" => "Slackbot-LinkExpanding 1.0"
+    }
+
+    assert_response :success
+    assert_not @document.reload.claimed?
+  end
+
+  test "signed-in agent and JSON reads never auto-claim a fresh document" do
+    create_and_sign_in_user
+
+    get document_page_path(@document.slug), headers: { "User-Agent" => "curl/8.0" }
+    assert_response :success
+    assert_not @document.reload.claimed?
+
+    get document_page_path(@document.slug, format: :json), headers: browser
     assert_response :success
     assert_not @document.reload.claimed?
   end


### PR DESCRIPTION
Closes #89

## Summary
- automatically claim unclaimed documents created within the last 10 minutes when a signed-in user opens the real browser page
- keep guests, old docs, prefetches, Inertia partial reloads, link unfurlers, agent reads, and JSON reads side-effect free
- reuse the atomic account claim transition so races, activity, and live ownership broadcasts retain existing behavior

## Verification
- `bin/rails test test/integration/ownership_flow_test.rb` (41 runs, 147 assertions)
- `bin/rails test` (416 runs, 1965 assertions)
- `bin/rubocop`
- `npm run check`
- `bin/vite build`
- local browser: signed-up account, no claim banner, Yours menu, home-list membership, desktop/mobile layout, document/account cleanup