### PR TITLE
Add an account-linked Thinkroom CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ Inspired by [Proof](https://proofeditor.ai) from Dan Shipper.
 - Local-first Yjs state synchronized through Action Cable
 - Optional password or Google sign-in so claimed documents follow you across browsers
 
+## Thinkroom CLI
+
+Install the zero-dependency CLI (Node 20 or newer), connect it to your account
+through a browser approval, and initialize the project-local agent skill:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kieranklaassen/thinkroom/main/script/install_thinkroom_cli.sh | sh
+thinkroom login
+thinkroom init
+```
+
+The login flow opens a browser and polls until you approve it—there is no token
+to copy and paste. Documents created through the connected CLI belong to that
+account while retaining the agent name as provenance:
+
+```bash
+thinkroom new draft.md --title "Decision memo" --agent "Codex"
+thinkroom show https://thinkroom.kieranklaassen.com/d/RETURNED_SLUG
+thinkroom suggest RETURNED_SLUG --replaces "Old text" --body "New text" --intent "Tighten the claim" --agent "Codex"
+```
+
+`thinkroom prime` works without a login or network connection. It points the
+agent at repository instructions, `CONCEPTS.md`, documented solutions, and
+active plans. For a self-hosted deployment, pass `--url https://your-host` to
+`thinkroom login` or set `THINKROOM_URL`; automation can use
+`THINKROOM_TOKEN` without writing a config file.
+
 ## Run locally
 
 Requires Ruby 3.4, Node 20 or newer, and SQLite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,11 @@ coordinate a fix, and credit the reporter unless anonymity is requested.
   selected mode.
 - `X-Agent-Name` records attribution; it is not authentication and must not be
   treated as proof of identity.
+- Thinkroom CLI bearer tokens authenticate an account for CLI-owned document
+  creation and account identity. They do not override a document share link's
+  edit/comment/view access. Tokens are stored as SHA-256 digests server-side;
+  protect the raw token in `~/.config/thinkroom/config.json` like a password and
+  revoke it with `thinkroom logout`.
 - Browser ownership tokens authorize destructive owner actions. They are
   stored in signed, HTTP-only cookies and are not user accounts.
 - Operators are responsible for keeping `config/master.key`, `.kamal/secrets`,

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,8 @@ module Api
   class BaseController < ActionController::API
     include WriteRateLimited
 
+    before_action :authenticate_cli_bearer
+
     rescue_from ActiveRecord::RecordNotFound do
       render json: { error: "No document with that slug." }, status: :not_found
     end
@@ -31,6 +33,36 @@ module Api
     end
 
     private
+
+    attr_reader :current_cli_token, :current_api_user
+
+    def authenticate_cli_bearer
+      authorization = request.authorization
+      return if authorization.blank?
+
+      scheme, raw_token = authorization.split(" ", 2)
+      token = CliAccessToken.authenticate(raw_token) if scheme&.casecmp?("Bearer")
+      return assign_cli_token(token) if token
+
+      render json: {
+        error: "Invalid or revoked Thinkroom access token.",
+        next_action: "Run `thinkroom login` to connect this CLI again."
+      }, status: :unauthorized
+    end
+
+    def assign_cli_token(token)
+      @current_cli_token = token
+      @current_api_user = token.user
+    end
+
+    def require_cli_user!
+      return if current_api_user
+
+      render json: {
+        error: "A Thinkroom access token is required.",
+        next_action: "Run `thinkroom login` first."
+      }, status: :unauthorized
+    end
 
     def render_write_rate_limit
       render json: { error: "Write rate limit exceeded; retry later." }, status: :too_many_requests

--- a/app/controllers/api/cli/device_authorizations_controller.rb
+++ b/app/controllers/api/cli/device_authorizations_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module Cli
+    class DeviceAuthorizationsController < BaseController
+      rate_limit_cli_device_authorization
+      rate_limit_cli_token_polling
+
+      def create
+        authorization, raw_device_code = CliDeviceAuthorization.start!
+        render json: {
+          device_code: raw_device_code,
+          user_code: authorization.user_code,
+          verification_url: cli_authorize_url(code: authorization.user_code),
+          expires_in: CliDeviceAuthorization::LIFETIME.to_i,
+          interval: CliDeviceAuthorization::POLL_INTERVAL.to_i
+        }, status: :created
+      end
+
+      def token
+        token_record, raw_token = CliDeviceAuthorization.exchange!(params[:device_code])
+        render json: {
+          access_token: raw_token,
+          token_type: "Bearer",
+          account: token_record.user.slice(:id, :name, :email)
+        }
+      rescue CliDeviceAuthorization::InvalidDeviceCode
+        render_device_error("invalid_device_code", "That device authorization does not exist.", :not_found)
+      rescue CliDeviceAuthorization::AuthorizationPending
+        render_device_error("authorization_pending", "Waiting for browser approval.", :too_early)
+      rescue CliDeviceAuthorization::PollingTooQuickly
+        render_device_error("slow_down", "Wait before polling again.", :too_many_requests)
+      rescue CliDeviceAuthorization::Expired
+        render_device_error("expired_token", "That device authorization expired.", :gone)
+      rescue CliDeviceAuthorization::AlreadyConsumed
+        render_device_error("access_denied", "That device authorization was already used.", :gone)
+      end
+
+      private
+
+      def render_device_error(code, message, status)
+        render json: { error: code, error_description: message }, status:
+      end
+    end
+  end
+end

--- a/app/controllers/api/cli/sessions_controller.rb
+++ b/app/controllers/api/cli/sessions_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module Cli
+    class SessionsController < BaseController
+      before_action :require_cli_user!
+
+      def show
+        render json: {
+          account: current_api_user.slice(:id, :name, :email),
+          token: { name: current_cli_token.name, created_at: current_cli_token.created_at }
+        }
+      end
+
+      def destroy
+        current_cli_token.revoke!
+        head :no_content
+      end
+    end
+  end
+end

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -25,7 +25,9 @@ module Api
         content_format: format,
         seed_content: source,
         seed_author_kind: kind,
-        seed_author_name: name
+        seed_author_name: name,
+        user: current_api_user,
+        owner_name: current_api_user&.name
       )
       DocumentAsset.claim_from_html!(document: doc, source:) if doc.html?
 
@@ -178,12 +180,20 @@ module Api
         plain_text: doc.plain_text,
         normalized: normalized,
         warning: warning,
-        note: "This document is unclaimed. The first person to open the share URL in a browser can claim it — claiming grants them ownership (including delete).",
+        note: ownership_note(doc),
         content_contract: AgentGuide.content_contract(doc.content_format, request.base_url),
         api: AgentGuide.endpoints(doc, request.base_url)
       }
       response[:markdown] = doc.current_content if doc.content_format == "markdown"
       response
+    end
+
+    def ownership_note(doc)
+      if doc.user_id?
+        "This document belongs to your Thinkroom account and appears in your document list."
+      else
+        "This document is unclaimed. The first person to open the share URL in a browser can claim it — claiming grants them ownership (including delete)."
+      end
     end
   end
 end

--- a/app/controllers/cli_authorizations_controller.rb
+++ b/app/controllers/cli_authorizations_controller.rb
@@ -1,0 +1,54 @@
+class CliAuthorizationsController < InertiaController
+  before_action :require_account
+
+  def show
+    authorization = find_authorization
+    render inertia: "cli/authorize", props: authorization_props(authorization)
+  end
+
+  def create
+    authorization = find_authorization
+    authorization&.approve!(current_user)
+    redirect_to cli_authorize_path(code: normalized_code), status: :see_other
+  rescue CliDeviceAuthorization::Expired, CliDeviceAuthorization::AlreadyConsumed,
+         CliDeviceAuthorization::AlreadyApproved
+    redirect_to cli_authorize_path(code: normalized_code), status: :see_other
+  end
+
+  private
+
+  def require_account
+    return if current_user
+
+    redirect_to login_path(return_to: request.fullpath), status: :see_other
+  end
+
+  def find_authorization
+    CliDeviceAuthorization.includes(:user).find_by(user_code: normalized_code)
+  end
+
+  def normalized_code
+    CliDeviceAuthorization.normalize_user_code(params[:code])
+  end
+
+  def authorization_props(authorization)
+    status =
+      if authorization.nil?
+        "invalid"
+      elsif authorization.expired?
+        "expired"
+      elsif authorization.consumed_at?
+        "consumed"
+      elsif authorization.approved_at?
+        authorization.user_id == current_user.id ? "approved" : "unavailable"
+      else
+        "ready"
+      end
+
+    {
+      status:,
+      user_code: authorization&.user_code || normalized_code,
+      account: current_user.slice(:name, :email)
+    }
+  end
+end

--- a/app/controllers/concerns/write_rate_limited.rb
+++ b/app/controllers/concerns/write_rate_limited.rb
@@ -7,6 +7,8 @@ module WriteRateLimited
   CONTRIBUTION_BURST_LIMIT = 60
   CONTRIBUTION_DAILY_LIMIT = 500
   AUTHENTICATION_BURST_LIMIT = 10
+  CLI_DEVICE_BURST_LIMIT = 10
+  CLI_POLL_BURST_LIMIT = 1_200
 
   class_methods do
     def rate_limit_document_creation
@@ -43,6 +45,18 @@ module WriteRateLimited
       rate_limit to: AUTHENTICATION_BURST_LIMIT, within: 10.minutes, by: -> { request.remote_ip },
                  with: :render_write_rate_limit, store: STORE, name: "authentication-burst",
                  only: :create
+    end
+
+    def rate_limit_cli_device_authorization
+      rate_limit to: CLI_DEVICE_BURST_LIMIT, within: 10.minutes, by: -> { request.remote_ip },
+                 with: :render_write_rate_limit, store: STORE, name: "cli-device-authorization",
+                 only: :create
+    end
+
+    def rate_limit_cli_token_polling
+      rate_limit to: CLI_POLL_BURST_LIMIT, within: 10.minutes, by: -> { request.remote_ip },
+                 with: :render_write_rate_limit, store: STORE, name: "cli-token-polling",
+                 only: :token
     end
   end
 end

--- a/app/frontend/pages/cli/authorize.css
+++ b/app/frontend/pages/cli/authorize.css
@@ -1,0 +1,67 @@
+.cli-auth-card {
+  width: min(100%, 25rem);
+}
+
+.cli-auth-eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.cli-auth-code {
+  display: grid;
+  gap: 0.3rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-raised);
+  padding: 0.9rem 1rem;
+}
+
+.cli-auth-code span,
+.cli-auth-account span {
+  color: var(--ink-faint);
+  font-size: 0.7rem;
+}
+
+.cli-auth-code strong {
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1.25rem;
+  letter-spacing: 0.12em;
+}
+
+.cli-auth-account {
+  display: grid;
+  margin-bottom: 1rem;
+}
+
+.cli-auth-account strong {
+  margin-top: 0.2rem;
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.cli-auth-account small {
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+}
+
+.cli-auth-submit {
+  display: flex;
+  width: 100%;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+.cli-auth-safety {
+  margin-top: 0.9rem;
+  color: var(--ink-faint);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}

--- a/app/frontend/pages/cli/authorize.tsx
+++ b/app/frontend/pages/cli/authorize.tsx
@@ -1,0 +1,98 @@
+import { Form, Head, Link } from '@inertiajs/react'
+import '../auth/show.css'
+import './authorize.css'
+
+type Status = 'ready' | 'approved' | 'consumed' | 'expired' | 'invalid' | 'unavailable'
+
+interface Props {
+  status: Status
+  user_code: string
+  account: {
+    name: string
+    email: string
+  }
+}
+
+const statusCopy: Record<Exclude<Status, 'ready'>, { title: string; body: string }> = {
+  approved: {
+    title: 'CLI connected',
+    body: 'Approval is complete. You can return to your terminal.',
+  },
+  consumed: {
+    title: 'CLI connected',
+    body: 'This authorization has already been completed. You can close this page.',
+  },
+  expired: {
+    title: 'Code expired',
+    body: 'Run thinkroom login again to start a fresh connection.',
+  },
+  invalid: {
+    title: 'Code not found',
+    body: 'Check the link from your terminal or run thinkroom login again.',
+  },
+  unavailable: {
+    title: 'Code unavailable',
+    body: 'This connection was approved from another account. Start again from your terminal if needed.',
+  },
+}
+
+export default function CliAuthorize({ status, user_code, account }: Props) {
+  const ready = status === 'ready'
+  const copy = ready
+    ? {
+        title: 'Connect Thinkroom CLI',
+        body: `Approve access to ${account.name}’s Thinkroom account.`,
+      }
+    : statusCopy[status]
+
+  return (
+    <>
+      <Head title={`${copy.title} · Thinkroom`} />
+      <main className="auth-page">
+        <section className="auth-card cli-auth-card" aria-labelledby="cli-auth-heading">
+          <Link href="/" className="auth-wordmark" aria-label="Thinkroom home">
+            T.
+          </Link>
+
+          <div className="auth-heading">
+            <p className="cli-auth-eyebrow">Thinkroom CLI</p>
+            <h1 id="cli-auth-heading">{copy.title}</h1>
+            <p>{copy.body}</p>
+          </div>
+
+          <div className="cli-auth-code" aria-label={`Connection code ${user_code}`}>
+            <span>Connection code</span>
+            <strong>{user_code}</strong>
+          </div>
+
+          {ready ? (
+            <>
+              <div className="cli-auth-account">
+                <span>Signed in as</span>
+                <strong>{account.name}</strong>
+                <small>{account.email}</small>
+              </div>
+              <Form method="post" action="/cli/authorize" disableWhileProcessing>
+                {({ processing }) => (
+                  <>
+                    <input type="hidden" name="code" value={user_code} />
+                    <button className="btn btn-primary cli-auth-submit" type="submit" disabled={processing}>
+                      {processing ? 'Connecting…' : 'Approve connection'}
+                    </button>
+                  </>
+                )}
+              </Form>
+              <p className="cli-auth-safety">
+                This lets the CLI create documents in your account. It never receives your password or browser session.
+              </p>
+            </>
+          ) : (
+            <Link href="/" className="btn cli-auth-submit">
+              Back to Thinkroom
+            </Link>
+          )}
+        </section>
+      </main>
+    </>
+  )
+}

--- a/app/models/cli_access_token.rb
+++ b/app/models/cli_access_token.rb
@@ -1,0 +1,35 @@
+class CliAccessToken < ApplicationRecord
+  TOKEN_PREFIX = "trm_"
+  LAST_USED_TOUCH_INTERVAL = 5.minutes
+
+  belongs_to :user
+
+  validates :token_digest, presence: true, uniqueness: true, length: { is: 64 }
+  validates :name, presence: true, length: { maximum: 255 }
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  def self.issue!(user:, name: "Thinkroom CLI")
+    raw_token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(32)}"
+    record = create!(user:, name:, token_digest: digest(raw_token))
+    [ record, raw_token ]
+  end
+
+  def self.authenticate(raw_token)
+    return if raw_token.blank? || !raw_token.start_with?(TOKEN_PREFIX)
+
+    token = active.includes(:user).find_by(token_digest: digest(raw_token))
+    return unless token
+
+    token.touch(:last_used_at) if token.last_used_at.nil? || token.last_used_at < LAST_USED_TOUCH_INTERVAL.ago
+    token
+  end
+
+  def self.digest(value)
+    Digest::SHA256.hexdigest(value.to_s)
+  end
+
+  def revoke!
+    update!(revoked_at: Time.current) unless revoked_at?
+  end
+end

--- a/app/models/cli_device_authorization.rb
+++ b/app/models/cli_device_authorization.rb
@@ -1,0 +1,92 @@
+class CliDeviceAuthorization < ApplicationRecord
+  class InvalidDeviceCode < StandardError; end
+  class AuthorizationPending < StandardError; end
+  class PollingTooQuickly < StandardError; end
+  class Expired < StandardError; end
+  class AlreadyConsumed < StandardError; end
+  class AlreadyApproved < StandardError; end
+
+  LIFETIME = 10.minutes
+  POLL_INTERVAL = 2.seconds
+  USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+  belongs_to :user, optional: true
+
+  scope :stale, -> { where(expires_at: ...1.day.ago) }
+
+  validates :device_code_digest, presence: true, uniqueness: true, length: { is: 64 }
+  validates :user_code, presence: true, uniqueness: true, format: { with: /\A[A-Z2-9]{4}-[A-Z2-9]{4}\z/ }
+  validates :expires_at, presence: true
+
+  def self.start!
+    stale.delete_all
+    raw_code = SecureRandom.urlsafe_base64(32)
+    record = create!(
+      device_code_digest: CliAccessToken.digest(raw_code),
+      user_code: unique_user_code,
+      expires_at: LIFETIME.from_now
+    )
+    [ record, raw_code ]
+  end
+
+  def self.exchange!(raw_device_code, now: Time.current)
+    record = find_by(device_code_digest: CliAccessToken.digest(raw_device_code))
+    raise InvalidDeviceCode unless record
+
+    outcome = record.with_lock do
+      record.reload
+      raise Expired if record.expires_at <= now
+      raise AlreadyConsumed if record.consumed_at?
+      if record.last_polled_at && record.last_polled_at > now - POLL_INTERVAL
+        next :polling_too_quickly
+      end
+
+      record.update!(last_polled_at: now)
+      next :authorization_pending unless record.approved_at? && record.user
+
+      token, raw_token = CliAccessToken.issue!(user: record.user)
+      record.update!(consumed_at: now)
+      [ token, raw_token ]
+    end
+
+    raise PollingTooQuickly if outcome == :polling_too_quickly
+    raise AuthorizationPending if outcome == :authorization_pending
+
+    outcome
+  end
+
+  def approve!(approving_user, now: Time.current)
+    with_lock do
+      reload
+      raise Expired if expires_at <= now
+      raise AlreadyConsumed if consumed_at?
+      if approved_at?
+        raise AlreadyApproved unless user_id == approving_user.id
+
+        return self
+      end
+
+      update!(user: approving_user, approved_at: now)
+    end
+    self
+  end
+
+  def expired? = expires_at <= Time.current
+
+  def self.normalize_user_code(value)
+    compact = value.to_s.upcase.gsub(/[^A-Z2-9]/, "")
+    return value.to_s.strip.upcase unless compact.length == 8
+
+    "#{compact.first(4)}-#{compact.last(4)}"
+  end
+
+  def self.unique_user_code
+    loop do
+      characters = Array.new(8) { USER_CODE_ALPHABET[SecureRandom.random_number(USER_CODE_ALPHABET.length)] }
+      code = "#{characters.first(4).join}-#{characters.last(4).join}"
+      return code unless exists?(user_code: code)
+    end
+  end
+
+  private_class_method :unique_user_code
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_secure_password validations: false
 
   has_many :documents, dependent: :restrict_with_exception
+  has_many :cli_access_tokens, dependent: :destroy
+  has_many :cli_device_authorizations, dependent: :destroy
 
   before_validation :normalize_identity
 

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kieran Klaassen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,13 @@
+# Thinkroom CLI
+
+Connect agents and terminals to [Thinkroom](https://thinkroom.kieranklaassen.com).
+
+```bash
+npm install --global thinkroom
+thinkroom login
+thinkroom init
+thinkroom new draft.md --title "Decision memo" --agent "Codex"
+```
+
+Use `thinkroom help` for commands. Set `THINKROOM_URL` for a self-hosted server
+and `THINKROOM_TOKEN` for non-interactive automation.

--- a/cli/bin/thinkroom.js
+++ b/cli/bin/thinkroom.js
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { constants as fsConstants } from 'node:fs'
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  open as openFile,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { homedir, platform } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const VERSION = '0.1.0'
+const DEFAULT_URL = 'https://thinkroom.kieranklaassen.com'
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+
+class CliError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message)
+    this.exitCode = exitCode
+  }
+}
+
+class ApiError extends CliError {
+  constructor(status, payload) {
+    const detail = payload?.error_description || payload?.error || `Thinkroom returned HTTP ${status}.`
+    const next = payload?.next_action || payload?.how_to_revise
+    super(next ? `${detail}\n${next}` : detail)
+    this.status = status
+    this.payload = payload
+  }
+}
+
+function parseArgs(argv) {
+  const options = {}
+  const positionals = []
+  const booleans = new Set(['json', 'help', 'version', 'no-open'])
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (!argument.startsWith('--')) {
+      positionals.push(argument)
+      continue
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split(/=(.*)/s, 2)
+    if (booleans.has(rawKey)) {
+      options[rawKey] = true
+      continue
+    }
+
+    const value = inlineValue ?? argv[index + 1]
+    if (value === undefined || value.startsWith('--')) throw new CliError(`Missing value for --${rawKey}.`)
+    options[rawKey] = value
+    if (inlineValue === undefined) index += 1
+  }
+
+  return { command: positionals.shift(), positionals, options }
+}
+
+function configDirectory() {
+  return process.env.XDG_CONFIG_HOME
+    ? path.join(process.env.XDG_CONFIG_HOME, 'thinkroom')
+    : path.join(homedir(), '.config', 'thinkroom')
+}
+
+function configPath() {
+  return path.join(configDirectory(), 'config.json')
+}
+
+async function loadConfig() {
+  try {
+    return JSON.parse(await readFile(configPath(), 'utf8'))
+  } catch (error) {
+    if (error.code === 'ENOENT') return {}
+    if (error instanceof SyntaxError) throw new CliError(`Could not parse ${configPath()}.`)
+    throw error
+  }
+}
+
+async function saveConfig(config) {
+  const directory = configDirectory()
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  await chmod(directory, 0o700)
+  const temporary = `${configPath()}.${process.pid}.tmp`
+  const handle = await openFile(temporary, fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_TRUNC, 0o600)
+  try {
+    await handle.writeFile(`${JSON.stringify(config, null, 2)}\n`)
+  } finally {
+    await handle.close()
+  }
+  await rename(temporary, configPath())
+  await chmod(configPath(), 0o600)
+}
+
+function normalizeBaseUrl(value) {
+  const candidate = value || DEFAULT_URL
+  let url
+  try {
+    url = new URL(candidate)
+  } catch {
+    throw new CliError(`Invalid Thinkroom URL: ${candidate}`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) throw new CliError('Thinkroom URL must use http or https.')
+  return url.toString().replace(/\/$/, '')
+}
+
+async function connection(options, { requireToken = false } = {}) {
+  const config = await loadConfig()
+  const baseUrl = normalizeBaseUrl(options.url || options.host || process.env.THINKROOM_URL || config.url)
+  const token = process.env.THINKROOM_TOKEN || config.token
+  if (requireToken && !token) throw new CliError('Not connected to a Thinkroom account. Run `thinkroom login` first.')
+  return { config, baseUrl, token }
+}
+
+async function request(endpoint, options, requestOptions = {}) {
+  const { requireToken = false, useToken = true, agent, method = 'GET', body } = requestOptions
+  const { config, baseUrl, token } = await connection(options, { requireToken })
+  const headers = { Accept: 'application/json' }
+  if (useToken && token) headers.Authorization = `Bearer ${token}`
+  if (agent) headers['X-Agent-Name'] = agent
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+
+  let response
+  try {
+    response = await fetch(`${baseUrl}${endpoint}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+  } catch (error) {
+    throw new CliError(`Could not reach ${baseUrl}: ${error.message}`)
+  }
+
+  const text = await response.text()
+  let payload = null
+  if (text) {
+    try {
+      payload = JSON.parse(text)
+    } catch {
+      payload = { error: text }
+    }
+  }
+  if (!response.ok) throw new ApiError(response.status, payload)
+  return { payload, config, baseUrl, response }
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)
+}
+
+function agentName(options) {
+  return options.agent || process.env.THINKROOM_AGENT || 'Thinkroom CLI'
+}
+
+function slugFrom(value) {
+  if (!value) throw new CliError('A Thinkroom slug or share URL is required.')
+  try {
+    const url = new URL(value)
+    const match = url.pathname.match(/\/(?:d|api\/docs)\/([^/]+)/)
+    if (match) return decodeURIComponent(match[1])
+  } catch {
+    // A bare slug is expected to fail URL parsing.
+  }
+  const slug = value.trim()
+  if (/^[A-Za-z0-9_-]+$/.test(slug)) return slug
+  throw new CliError(`Could not find a Thinkroom document slug in: ${value}`)
+}
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) chunks.push(chunk)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function readContent(file) {
+  if (file && file !== '-') return readFile(path.resolve(file), 'utf8')
+  if (file === '-' || !process.stdin.isTTY) return readStdin()
+  return undefined
+}
+
+function openBrowser(url) {
+  const command = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'cmd' : 'xdg-open'
+  const args = platform() === 'win32' ? ['/c', 'start', '', url] : [url]
+  try {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+    child.unref()
+    return true
+  } catch {
+    return false
+  }
+}
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+async function login(options) {
+  if (process.env.THINKROOM_TOKEN) {
+    throw new CliError('THINKROOM_TOKEN is set. Unset it before connecting a different account with `thinkroom login`.')
+  }
+  const config = await loadConfig()
+  const baseUrl = normalizeBaseUrl(options.url || options.host || process.env.THINKROOM_URL || config.url)
+  const started = await request(
+    '/api/cli/device_authorizations',
+    { ...options, url: baseUrl },
+    { method: 'POST', body: {}, useToken: false },
+  )
+  const grant = started.payload
+
+  process.stderr.write(`Connection code: ${grant.user_code}\n`)
+  process.stderr.write(`Approve in your browser: ${grant.verification_url}\n`)
+  if (!options['no-open'] && openBrowser(grant.verification_url)) process.stderr.write('Opened your browser.\n')
+
+  const deadline = Date.now() + grant.expires_in * 1000
+  let interval = Math.max(Number(grant.interval) || 2, 1)
+  while (Date.now() < deadline) {
+    await delay(interval * 1000)
+    try {
+      const exchanged = await request(
+        '/api/cli/device_authorizations/token',
+        { ...options, url: baseUrl },
+        { method: 'POST', body: { device_code: grant.device_code }, useToken: false },
+      )
+      const nextConfig = {
+        ...config,
+        url: baseUrl,
+        token: exchanged.payload.access_token,
+        account: exchanged.payload.account,
+      }
+      await saveConfig(nextConfig)
+      if (options.json) printJson({ url: baseUrl, account: exchanged.payload.account })
+      else process.stdout.write(`Connected as ${exchanged.payload.account.name} (${exchanged.payload.account.email}).\n`)
+      return
+    } catch (error) {
+      if (error instanceof ApiError && error.payload?.error === 'authorization_pending') continue
+      if (error instanceof ApiError && error.payload?.error === 'slow_down') {
+        interval += 1
+        continue
+      }
+      throw error
+    }
+  }
+  throw new CliError('The browser approval expired. Run `thinkroom login` to try again.')
+}
+
+async function whoami(options) {
+  const result = await request('/api/cli/session', options, { requireToken: true })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`${result.payload.account.name} <${result.payload.account.email}>\n${result.baseUrl}\n`)
+}
+
+async function logout(options) {
+  const { config, token } = await connection(options)
+  if (token) {
+    try {
+      await request('/api/cli/session', options, { method: 'DELETE' })
+    } catch (error) {
+      if (!(error instanceof ApiError && error.status === 401)) throw error
+    }
+  }
+  await saveConfig({ ...config, token: undefined, account: undefined })
+  process.stdout.write(process.env.THINKROOM_TOKEN
+    ? 'Revoked the token, but THINKROOM_TOKEN remains set in this environment. Unset it to disconnect fully.\n'
+    : 'Disconnected from Thinkroom.\n')
+}
+
+async function createDocument(positionals, options) {
+  const content = await readContent(positionals[0])
+  const body = {}
+  if (options.title) body.title = options.title
+  if (content !== undefined) body.content = content
+  if (options.format) body.format = options.format
+  const result = await request('/api/docs', options, {
+    method: 'POST',
+    body,
+    requireToken: true,
+    agent: agentName(options),
+  })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`${result.payload.share_url}\n`)
+}
+
+async function showDocument(positionals, options) {
+  const slug = slugFrom(positionals[0])
+  const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, { agent: agentName(options) })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`${result.payload.content ?? result.payload.markdown ?? ''}\n`)
+}
+
+async function updateDocument(positionals, options) {
+  const slug = slugFrom(positionals[0])
+  const content = await readContent(positionals[1])
+  const body = {}
+  if (options.title) body.title = options.title
+  if (content !== undefined) body.content = content
+  if (options.format) body.format = options.format
+  if (Object.keys(body).length === 0) throw new CliError('Provide a file/stdin and/or --title to update the document.')
+  const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, {
+    method: 'PATCH',
+    body,
+    agent: agentName(options),
+  })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`${result.payload.share_url}\n`)
+}
+
+async function suggest(positionals, options) {
+  const slug = slugFrom(positionals[0])
+  const bodyText = options.body ?? (await readContent(positionals[1]))
+  if (!bodyText) throw new CliError('Suggestion body is required via --body, a file, or stdin.')
+  const result = await request(`/api/docs/${encodeURIComponent(slug)}/suggestions`, options, {
+    method: 'POST',
+    agent: agentName(options),
+    body: {
+      body: bodyText,
+      intent: options.intent,
+      replaces: options.replaces,
+      anchor_text: options.anchor,
+    },
+  })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`Suggestion ${result.payload.suggestion.id} is pending human review.\n`)
+}
+
+async function comment(positionals, options) {
+  const slug = slugFrom(positionals[0])
+  const bodyText = options.body ?? (await readContent(positionals[1]))
+  if (!bodyText) throw new CliError('Comment body is required via --body, a file, or stdin.')
+  const result = await request(`/api/docs/${encodeURIComponent(slug)}/comments`, options, {
+    method: 'POST',
+    agent: agentName(options),
+    body: { body: bodyText, anchor_text: options.anchor },
+  })
+  if (options.json) printJson(result.payload)
+  else process.stdout.write(`Comment ${result.payload.comment.id} posted.\n`)
+}
+
+async function openDocument(positionals, options) {
+  const slug = slugFrom(positionals[0])
+  const { baseUrl } = await connection(options)
+  const url = `${baseUrl}/d/${encodeURIComponent(slug)}`
+  if (!openBrowser(url)) throw new CliError(`Could not open a browser. Visit ${url}`)
+  process.stdout.write(`${url}\n`)
+}
+
+async function exists(candidate) {
+  try {
+    await access(candidate)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function projectRoot(start = process.cwd()) {
+  let current = path.resolve(start)
+  while (true) {
+    if (await exists(path.join(current, '.git'))) return current
+    const parent = path.dirname(current)
+    if (parent === current) return path.resolve(start)
+    current = parent
+  }
+}
+
+async function markdownFiles(directory) {
+  if (!(await exists(directory))) return []
+  const results = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const candidate = path.join(directory, entry.name)
+    if (entry.isDirectory()) results.push(...(await markdownFiles(candidate)))
+    else if (entry.isFile() && entry.name.endsWith('.md')) results.push(candidate)
+  }
+  return results.sort()
+}
+
+async function prime(options) {
+  const root = await projectRoot()
+  const config = await loadConfig()
+  const durable = []
+  for (const filename of ['AGENTS.md', 'CLAUDE.md', 'CONCEPTS.md']) {
+    const candidate = path.join(root, filename)
+    if (await exists(candidate)) durable.push(candidate)
+  }
+  durable.push(...(await markdownFiles(path.join(root, 'docs', 'solutions'))))
+
+  const activePlans = []
+  for (const candidate of await markdownFiles(path.join(root, 'docs', 'plans'))) {
+    const source = await readFile(candidate, 'utf8')
+    if (/^status:\s*active\s*$/m.test(source.slice(0, 1000))) activePlans.push(candidate)
+  }
+
+  const relative = (candidate) => path.relative(root, candidate) || '.'
+  const payload = {
+    project_root: root,
+    thinkroom_url: normalizeBaseUrl(options.url || options.host || process.env.THINKROOM_URL || config.url),
+    account: config.account || null,
+    durable_context: durable.map(relative),
+    active_plans: activePlans.map(relative),
+  }
+  if (options.json) return printJson(payload)
+
+  process.stdout.write(`# Thinkroom prime\n\nProject: ${root}\n`)
+  process.stdout.write(`Account: ${payload.account ? `${payload.account.name} <${payload.account.email}>` : 'not connected (run thinkroom login when publishing)'}\n`)
+  process.stdout.write(`Host: ${payload.thinkroom_url}\n\n`)
+  process.stdout.write('Read the relevant durable context before substantial work:\n')
+  if (payload.durable_context.length === 0) process.stdout.write('- No AGENTS/CLAUDE/CONCEPTS or docs/solutions files found.\n')
+  else payload.durable_context.forEach((candidate) => process.stdout.write(`- ${candidate}\n`))
+  if (payload.active_plans.length > 0) {
+    process.stdout.write('\nActive plans:\n')
+    payload.active_plans.forEach((candidate) => process.stdout.write(`- ${candidate}\n`))
+  }
+  process.stdout.write('\nUse Thinkroom for human judgment handoffs: new → share URL; show before update; suggest after human editing.\n')
+}
+
+async function skillSource() {
+  const candidates = [
+    process.env.THINKROOM_SKILL_SOURCE,
+    path.resolve(scriptDirectory, '..', 'skill', 'thinkroom'),
+    path.resolve(scriptDirectory, '..', 'share', 'thinkroom', 'skill', 'thinkroom'),
+  ].filter(Boolean)
+  for (const candidate of candidates) {
+    if (await exists(path.join(candidate, 'SKILL.md'))) return candidate
+  }
+  throw new CliError('The bundled Thinkroom skill is missing. Reinstall the CLI.')
+}
+
+async function skillTargets(root, requested) {
+  const mapping = {
+    agents: path.join(root, '.agents', 'skills', 'thinkroom'),
+    claude: path.join(root, '.claude', 'skills', 'thinkroom'),
+    codex: path.join(root, '.codex', 'skills', 'thinkroom'),
+  }
+  if (requested && requested !== 'all') {
+    if (!mapping[requested]) throw new CliError('--agent must be agents, claude, codex, or all.')
+    return [mapping[requested]]
+  }
+  if (requested === 'all') return Object.values(mapping)
+
+  const detected = []
+  for (const [agent, target] of Object.entries(mapping)) {
+    if (await exists(path.join(root, `.${agent}`))) detected.push(target)
+  }
+  return detected.length > 0 ? detected : [mapping.agents]
+}
+
+async function installSkill(options) {
+  const root = await projectRoot()
+  const source = await skillSource()
+  const targets = await skillTargets(root, options.agent)
+  for (const target of targets) {
+    await mkdir(path.join(target, 'agents'), { recursive: true })
+    await copyFile(path.join(source, 'SKILL.md'), path.join(target, 'SKILL.md'))
+    await copyFile(path.join(source, 'agents', 'openai.yaml'), path.join(target, 'agents', 'openai.yaml'))
+    process.stdout.write(`Installed Thinkroom skill: ${path.relative(root, target)}\n`)
+  }
+}
+
+async function init(options) {
+  await installSkill(options)
+  process.stdout.write('\n')
+  await prime(options)
+}
+
+function help() {
+  process.stdout.write(`Thinkroom CLI ${VERSION}\n\n`)
+  process.stdout.write('Usage: thinkroom <command> [arguments] [options]\n\n')
+  process.stdout.write('Account\n  login [--url URL] [--no-open]\n  whoami [--json]\n  logout\n\n')
+  process.stdout.write('Documents\n  new [FILE|-] [--title TITLE] [--format markdown|html] [--agent NAME] [--json]\n  show SLUG|URL [--json]\n  update SLUG|URL [FILE|-] [--title TITLE] [--agent NAME] [--json]\n  suggest SLUG|URL [FILE|-] --body TEXT --replaces TEXT --intent TEXT [--agent NAME]\n  comment SLUG|URL [FILE|-] --body TEXT [--anchor TEXT] [--agent NAME]\n  open SLUG|URL\n\n')
+  process.stdout.write('Agent setup\n  init [--agent agents|claude|codex|all]\n  skill install [--agent agents|claude|codex|all]\n  prime [--json]\n\n')
+  process.stdout.write('Environment: THINKROOM_URL, THINKROOM_TOKEN, THINKROOM_AGENT, XDG_CONFIG_HOME\n')
+}
+
+async function main(argv) {
+  const { command, positionals, options } = parseArgs(argv)
+  if (options.version || command === 'version') return process.stdout.write(`${VERSION}\n`)
+  if (options.help || !command || command === 'help') return help()
+
+  switch (command) {
+    case 'login': return login(options)
+    case 'logout': return logout(options)
+    case 'whoami': return whoami(options)
+    case 'new': return createDocument(positionals, options)
+    case 'show': return showDocument(positionals, options)
+    case 'update': return updateDocument(positionals, options)
+    case 'suggest': return suggest(positionals, options)
+    case 'comment': return comment(positionals, options)
+    case 'open': return openDocument(positionals, options)
+    case 'prime': return prime(options)
+    case 'init': return init(options)
+    case 'skill':
+      if (positionals[0] !== 'install') throw new CliError('Usage: thinkroom skill install [--agent agents|claude|codex|all]')
+      return installSkill(options)
+    default: throw new CliError(`Unknown command: ${command}\nRun \`thinkroom help\` for usage.`)
+  }
+}
+
+main(process.argv.slice(2)).catch((error) => {
+  process.stderr.write(`Error: ${error.message}\n`)
+  process.exitCode = error.exitCode || 1
+})

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "thinkroom",
+  "version": "0.1.0",
+  "description": "Account-linked CLI and agent skill for Thinkroom",
+  "type": "module",
+  "bin": {
+    "thinkroom": "bin/thinkroom.js"
+  },
+  "files": [
+    "bin/thinkroom.js",
+    "skill/thinkroom"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kieranklaassen/thinkroom.git"
+  },
+  "homepage": "https://thinkroom.kieranklaassen.com",
+  "bugs": {
+    "url": "https://github.com/kieranklaassen/thinkroom/issues"
+  }
+}

--- a/cli/skill/thinkroom/SKILL.md
+++ b/cli/skill/thinkroom/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: thinkroom
+description: Collaborate with people through Thinkroom documents using the Thinkroom CLI. Use when an agent needs to start or share a document, hand substantial thinking to a human, inspect or revise an existing Thinkroom share link, propose a targeted suggestion, leave a comment, or load a repository's durable agent context with thinkroom prime.
+---
+
+# Thinkroom
+
+Use Thinkroom as the durable handoff surface for substantial work that benefits from human reading, judgment, suggestions, or endorsement. Keep local files authoritative while drafting; publish or revise the Thinkroom document at clear handoff points.
+
+## Prime the repository
+
+Run this before substantial work in a repository:
+
+```bash
+thinkroom prime
+```
+
+Read the relevant paths it reports, especially `AGENTS.md`, `CONCEPTS.md`, and matching entries under `docs/solutions/`. Priming is offline and must not block work when the CLI is not logged in.
+
+## Start a document
+
+Write the complete draft to a file or pipe it on standard input. Identify the actual agent name so provenance is useful:
+
+```bash
+thinkroom new draft.md --title "Decision memo" --agent "Codex"
+```
+
+Use `--format html` only when semantic HTML is genuinely needed. Return the printed share URL to the user.
+
+If the CLI asks for authentication, run `thinkroom login` and let the person approve the browser prompt. Never ask them to paste a token into chat.
+
+## Work with an existing document
+
+Read live state before changing anything:
+
+```bash
+thinkroom show SHARE_URL --json
+```
+
+For a document that is still an untouched agent seed, revise it in place:
+
+```bash
+thinkroom update SHARE_URL revision.md --title "Updated title" --agent "Codex"
+```
+
+Once a person has claimed or edited the document, do not overwrite the seed. Propose the smallest exact replacement and include intent:
+
+```bash
+thinkroom suggest SHARE_URL \
+  --replaces "Exact current text" \
+  --body "Proposed replacement" \
+  --intent "Why this improves the document" \
+  --agent "Codex"
+```
+
+Use comments for questions or review notes that should not directly replace prose:
+
+```bash
+thinkroom comment SHARE_URL --body "Could we verify this assumption?" --agent "Codex"
+```
+
+When an API conflict provides a next action, follow that guidance instead of retrying the same write.
+
+## Handoff
+
+Finish by giving the person the share URL and one sentence describing what judgment or action is needed. Do not expose CLI config files, bearer tokens, browser cookies, or raw API responses containing credentials.

--- a/cli/skill/thinkroom/agents/openai.yaml
+++ b/cli/skill/thinkroom/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Thinkroom"
+  short_description: "Collaborate with humans in Thinkroom"
+  default_prompt: "Use $thinkroom to start, share, or revise a Thinkroom document."

--- a/cli/test/thinkroom.test.js
+++ b/cli/test/thinkroom.test.js
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import { mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const cli = path.join(repositoryRoot, 'cli', 'bin', 'thinkroom.js')
+
+async function temporaryDirectory(name) {
+  return mkdtemp(path.join(tmpdir(), `thinkroom-${name}-`))
+}
+
+function runCli(args, { cwd, configHome, input = '', env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cli, ...args], {
+      cwd: cwd || repositoryRoot,
+      env: {
+        ...process.env,
+        XDG_CONFIG_HOME: configHome || path.join(tmpdir(), 'thinkroom-unused-config'),
+        THINKROOM_SKILL_SOURCE: path.join(repositoryRoot, 'cli', 'skill', 'thinkroom'),
+        ...env,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', reject)
+    child.on('close', (code) => resolve({ code, stdout, stderr }))
+    child.stdin.end(input)
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  }
+}
+
+async function jsonRequest(request) {
+  const chunks = []
+  for await (const chunk of request) chunks.push(chunk)
+  return chunks.length ? JSON.parse(Buffer.concat(chunks).toString('utf8')) : {}
+}
+
+function sendJson(response, status, payload) {
+  response.writeHead(status, { 'Content-Type': 'application/json' })
+  response.end(JSON.stringify(payload))
+}
+
+test('help, version, and prime work without a network or login', async () => {
+  const root = await temporaryDirectory('prime')
+  const configHome = path.join(root, 'config')
+  await mkdir(path.join(root, '.git'))
+  await mkdir(path.join(root, 'docs', 'solutions', 'architecture'), { recursive: true })
+  await mkdir(path.join(root, 'docs', 'plans'), { recursive: true })
+  await writeFile(path.join(root, 'AGENTS.md'), '# Instructions\n')
+  await writeFile(path.join(root, 'CONCEPTS.md'), '# Concepts\n')
+  await writeFile(path.join(root, 'docs', 'solutions', 'architecture', 'durable.md'), '# Durable\n')
+  await writeFile(path.join(root, 'docs', 'plans', 'active.md'), '---\nstatus: active\n---\n')
+
+  const version = await runCli(['--version'], { cwd: root, configHome })
+  assert.equal(version.code, 0)
+  assert.match(version.stdout, /^0\.1\.0/)
+
+  const primed = await runCli(['prime'], { cwd: path.join(root, 'docs'), configHome })
+  assert.equal(primed.code, 0, primed.stderr)
+  assert.match(primed.stdout, /AGENTS\.md/)
+  assert.match(primed.stdout, /CONCEPTS\.md/)
+  assert.match(primed.stdout, /docs\/solutions\/architecture\/durable\.md/)
+  assert.match(primed.stdout, /docs\/plans\/active\.md/)
+  assert.match(primed.stdout, /not connected/)
+})
+
+test('init installs the bundled skill into detected agent roots', async () => {
+  const root = await temporaryDirectory('skill')
+  const configHome = path.join(root, 'config')
+  await mkdir(path.join(root, '.git'))
+  await mkdir(path.join(root, '.claude'))
+
+  const initialized = await runCli(['init'], { cwd: root, configHome })
+  assert.equal(initialized.code, 0, initialized.stderr)
+  assert.match(initialized.stdout, /\.claude\/skills\/thinkroom/)
+
+  const installed = await readFile(path.join(root, '.claude', 'skills', 'thinkroom', 'SKILL.md'), 'utf8')
+  const source = await readFile(path.join(repositoryRoot, 'cli', 'skill', 'thinkroom', 'SKILL.md'), 'utf8')
+  assert.equal(installed, source)
+  assert.equal(await readFile(path.join(root, '.claude', 'skills', 'thinkroom', 'agents', 'openai.yaml'), 'utf8'),
+    await readFile(path.join(repositoryRoot, 'cli', 'skill', 'thinkroom', 'agents', 'openai.yaml'), 'utf8'))
+})
+
+test('login ignores stale credentials, saves a protected token, and links document creation', async (t) => {
+  const root = await temporaryDirectory('login')
+  const configHome = path.join(root, 'config')
+  await mkdir(path.join(configHome, 'thinkroom'), { recursive: true })
+  await writeFile(path.join(configHome, 'thinkroom', 'config.json'), JSON.stringify({ token: 'trm_stale' }))
+  const seen = { polls: 0 }
+
+  const server = await startServer(async (request, response) => {
+    if (request.url === '/api/cli/device_authorizations' && request.method === 'POST') {
+      assert.equal(request.headers.authorization, undefined)
+      return sendJson(response, 201, {
+        device_code: 'device-secret',
+        user_code: 'ABCD-EFGH',
+        verification_url: `${server.url}/cli/authorize?code=ABCD-EFGH`,
+        expires_in: 20,
+        interval: 1,
+      })
+    }
+    if (request.url === '/api/cli/device_authorizations/token' && request.method === 'POST') {
+      seen.polls += 1
+      assert.equal(request.headers.authorization, undefined)
+      assert.deepEqual(await jsonRequest(request), { device_code: 'device-secret' })
+      return sendJson(response, 200, {
+        access_token: 'trm_fresh',
+        token_type: 'Bearer',
+        account: { id: 7, name: 'Kieran', email: 'kieran@example.com' },
+      })
+    }
+    if (request.url === '/api/cli/session' && request.method === 'GET') {
+      assert.equal(request.headers.authorization, 'Bearer trm_fresh')
+      return sendJson(response, 200, {
+        account: { id: 7, name: 'Kieran', email: 'kieran@example.com' },
+        token: { name: 'Thinkroom CLI' },
+      })
+    }
+    if (request.url === '/api/docs' && request.method === 'POST') {
+      assert.equal(request.headers.authorization, 'Bearer trm_fresh')
+      assert.equal(request.headers['x-agent-name'], 'Codex')
+      seen.created = await jsonRequest(request)
+      return sendJson(response, 201, { slug: 'abc123', share_url: `${server.url}/d/abc123` })
+    }
+    return sendJson(response, 404, { error: `Unexpected ${request.method} ${request.url}` })
+  })
+  t.after(() => server.close())
+
+  const loggedIn = await runCli(['login', '--url', server.url, '--no-open'], { cwd: root, configHome })
+  assert.equal(loggedIn.code, 0, loggedIn.stderr)
+  assert.match(loggedIn.stdout, /Connected as Kieran/)
+  assert.equal(seen.polls, 1)
+
+  const configFile = path.join(configHome, 'thinkroom', 'config.json')
+  const stored = JSON.parse(await readFile(configFile, 'utf8'))
+  assert.equal(stored.token, 'trm_fresh')
+  assert.equal(stored.url, server.url)
+  if (process.platform !== 'win32') assert.equal((await stat(configFile)).mode & 0o777, 0o600)
+
+  const identity = await runCli(['whoami'], { cwd: root, configHome })
+  assert.equal(identity.code, 0, identity.stderr)
+  assert.match(identity.stdout, /Kieran <kieran@example\.com>/)
+
+  const created = await runCli(
+    ['new', '-', '--title', 'CLI draft', '--agent', 'Codex'],
+    { cwd: root, configHome, input: '# Draft\n' },
+  )
+  assert.equal(created.code, 0, created.stderr)
+  assert.equal(created.stdout.trim(), `${server.url}/d/abc123`)
+  assert.deepEqual(seen.created, { title: 'CLI draft', content: '# Draft\n' })
+})
+
+test('document commands normalize share URLs and surface API failures', async (t) => {
+  const root = await temporaryDirectory('documents')
+  const configHome = path.join(root, 'config')
+  const seen = []
+  const server = await startServer(async (request, response) => {
+    const body = ['POST', 'PATCH'].includes(request.method) ? await jsonRequest(request) : null
+    seen.push({ method: request.method, url: request.url, body, agent: request.headers['x-agent-name'] })
+    if (request.method === 'GET' && request.url === '/api/docs/slug123') {
+      return sendJson(response, 200, { slug: 'slug123', content: '# Current' })
+    }
+    if (request.method === 'PATCH' && request.url === '/api/docs/slug123') {
+      return sendJson(response, 409, { error: 'Live state is authoritative.', how_to_revise: 'Propose a suggestion.' })
+    }
+    if (request.method === 'POST' && request.url === '/api/docs/slug123/suggestions') {
+      return sendJson(response, 201, { suggestion: { id: 12 } })
+    }
+    if (request.method === 'POST' && request.url === '/api/docs/slug123/comments') {
+      return sendJson(response, 201, { comment: { id: 13 } })
+    }
+    return sendJson(response, 404, { error: 'Unexpected request' })
+  })
+  t.after(() => server.close())
+  const env = { THINKROOM_URL: server.url }
+
+  const shown = await runCli(['show', `${server.url}/d/slug123`], { cwd: root, configHome, env })
+  assert.equal(shown.code, 0, shown.stderr)
+  assert.equal(shown.stdout.trim(), '# Current')
+
+  const updated = await runCli(['update', 'slug123', '-', '--agent', 'Codex'], {
+    cwd: root, configHome, env, input: '# Revision',
+  })
+  assert.equal(updated.code, 1)
+  assert.match(updated.stderr, /Propose a suggestion/)
+
+  const suggested = await runCli([
+    'suggest', `${server.url}/d/slug123`, '--body', 'New', '--replaces', 'Old', '--intent', 'Tighten', '--agent', 'Codex',
+  ], { cwd: root, configHome, env })
+  assert.equal(suggested.code, 0, suggested.stderr)
+  assert.match(suggested.stdout, /Suggestion 12/)
+
+  const commented = await runCli(['comment', 'slug123', '--body', 'Check this', '--anchor', 'Current', '--agent', 'Scout'], {
+    cwd: root, configHome, env,
+  })
+  assert.equal(commented.code, 0, commented.stderr)
+  assert.match(commented.stdout, /Comment 13/)
+
+  assert.deepEqual(seen[2].body, { body: 'New', intent: 'Tighten', replaces: 'Old' })
+  assert.equal(seen[2].agent, 'Codex')
+  assert.deepEqual(seen[3].body, { body: 'Check this', anchor_text: 'Current' })
+  assert.equal(seen[3].agent, 'Scout')
+})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   delete "logout", to: "sessions#destroy", as: :logout
   get "signup", to: "registrations#new", as: :signup
   post "signup", to: "registrations#create"
+  get "cli/authorize", to: "cli_authorizations#show", as: :cli_authorize
+  post "cli/authorize", to: "cli_authorizations#create"
   match "/auth/:provider/callback", to: "oauth_callbacks#create", via: %i[get post]
   get "/auth/failure", to: "oauth_callbacks#failure"
 
@@ -39,6 +41,13 @@ Rails.application.routes.draw do
   post "/rails/active_storage/direct_uploads", to: "api/direct_uploads#create"
 
   namespace :api do
+    namespace :cli do
+      post "device_authorizations", to: "device_authorizations#create"
+      post "device_authorizations/token", to: "device_authorizations#token"
+      get "session", to: "sessions#show"
+      delete "session", to: "sessions#destroy"
+    end
+
     post "uploads", to: "uploads#create"
     post "docs", to: "docs#create"
     get "docs/:slug", to: "docs#show", as: :doc

--- a/db/migrate/20260626130000_create_cli_authentication.rb
+++ b/db/migrate/20260626130000_create_cli_authentication.rb
@@ -1,0 +1,28 @@
+class CreateCliAuthentication < ActiveRecord::Migration[8.1]
+  def change
+    create_table :cli_device_authorizations do |t|
+      t.string :device_code_digest, null: false, limit: 64
+      t.string :user_code, null: false, limit: 9
+      t.references :user, foreign_key: true
+      t.datetime :expires_at, null: false
+      t.datetime :approved_at
+      t.datetime :consumed_at
+      t.datetime :last_polled_at
+
+      t.timestamps
+    end
+    add_index :cli_device_authorizations, :device_code_digest, unique: true
+    add_index :cli_device_authorizations, :user_code, unique: true
+
+    create_table :cli_access_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token_digest, null: false, limit: 64
+      t.string :name, null: false, default: "Thinkroom CLI", limit: 255
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+
+      t.timestamps
+    end
+    add_index :cli_access_tokens, :token_digest, unique: true
+  end
+end

--- a/db/migrate/20260626130100_index_cli_device_authorization_expiry.rb
+++ b/db/migrate/20260626130100_index_cli_device_authorization_expiry.rb
@@ -1,0 +1,5 @@
+class IndexCliDeviceAuthorizationExpiry < ActiveRecord::Migration[8.1]
+  def change
+    add_index :cli_device_authorizations, :expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_130100) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -61,6 +61,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_120000) do
     t.datetime "updated_at", null: false
     t.index ["document_id", "agent_name"], name: "index_agent_presences_on_document_id_and_agent_name", unique: true
     t.index ["document_id"], name: "index_agent_presences_on_document_id"
+  end
+
+  create_table "cli_access_tokens", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "last_used_at"
+    t.string "name", limit: 255, default: "Thinkroom CLI", null: false
+    t.datetime "revoked_at"
+    t.string "token_digest", limit: 64, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["token_digest"], name: "index_cli_access_tokens_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_cli_access_tokens_on_user_id"
+  end
+
+  create_table "cli_device_authorizations", force: :cascade do |t|
+    t.datetime "approved_at"
+    t.datetime "consumed_at"
+    t.datetime "created_at", null: false
+    t.string "device_code_digest", limit: 64, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "last_polled_at"
+    t.datetime "updated_at", null: false
+    t.string "user_code", limit: 9, null: false
+    t.integer "user_id"
+    t.index ["device_code_digest"], name: "index_cli_device_authorizations_on_device_code_digest", unique: true
+    t.index ["expires_at"], name: "index_cli_device_authorizations_on_expires_at"
+    t.index ["user_code"], name: "index_cli_device_authorizations_on_user_code", unique: true
+    t.index ["user_id"], name: "index_cli_device_authorizations_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -147,6 +175,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_120000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activities", "documents"
   add_foreign_key "agent_presences", "documents"
+  add_foreign_key "cli_access_tokens", "users"
+  add_foreign_key "cli_device_authorizations", "users"
   add_foreign_key "comments", "documents"
   add_foreign_key "document_assets", "documents"
   add_foreign_key "documents", "users"

--- a/docs/plans/2026-06-26-017-feat-thinkroom-cli-plan.md
+++ b/docs/plans/2026-06-26-017-feat-thinkroom-cli-plan.md
@@ -1,0 +1,97 @@
+---
+title: "feat: Add an account-linked Thinkroom CLI and agent skill"
+type: feat
+status: active
+date: 2026-06-26
+issue: 91
+---
+
+# Account-linked Thinkroom CLI and agent skill
+
+## Goal
+
+Ship a small, zero-dependency `thinkroom` command that an agent or person can install quickly, connect to a Thinkroom account through a browser approval flow without copying credentials, use for the core document workflow, and initialize as a reusable agent skill. Keep repository priming useful offline by surfacing durable project instructions, concepts, plans, and documented solutions.
+
+## Product contract
+
+- `thinkroom login` starts a ten-minute device authorization, opens a browser when possible, prints the same URL as a fallback, polls at the server-provided interval, and stores the returned token with user-only file permissions.
+- The browser requires an existing Thinkroom session, clearly names the CLI request and account, and does not approve access until the person submits the CSRF-protected confirmation.
+- `thinkroom whoami` and `thinkroom logout` make account state visible and revocable.
+- `thinkroom new`, `show`, `update`, `suggest`, and `comment` cover the common agent document lifecycle. Commands accept a slug or share URL, read content from a file or stdin, emit script-friendly output, and return non-zero on API errors.
+- Authenticated CLI document creation attaches the document to the approving account while preserving agent attribution through `X-Agent-Name`. Existing anonymous/share-link API behavior remains compatible.
+- `thinkroom init` installs the bundled `thinkroom` skill into detected project-local agent directories and then runs `thinkroom prime`.
+- `thinkroom prime` never requires network access. It emits the current account/host when known, the local Thinkroom workflow, and discovered `AGENTS.md`, `CLAUDE.md`, `CONCEPTS.md`, `docs/solutions`, and active plan paths so an agent can load relevant durable context.
+- Installation works immediately from a one-line repository installer; the same CLI is also an npm-ready package named `thinkroom`.
+
+## Security and lifecycle boundaries
+
+- Store only SHA-256 digests of long-lived API tokens and the high-entropy device secret. The short user code is display-only correlation, is shown on both surfaces, and expires with the grant; raw access tokens are returned exactly once.
+- Device grants expire after ten minutes, are single-use, and cannot be approved without a signed-in browser session.
+- Reject invalid bearer credentials instead of silently degrading an intended authenticated request into an anonymous write.
+- Rate-limit device initiation and token polling. Poll responses distinguish pending, slow-down, expired, and consumed states without exposing account data before approval.
+- The CLI writes its config atomically under `XDG_CONFIG_HOME` or `~/.config/thinkroom`, sets directory mode `0700` and file mode `0600`, and lets `THINKROOM_TOKEN`/`THINKROOM_URL` override disk state for automation.
+- Logging out revokes the server token before removing local state; an already-revoked token can still be removed locally.
+- No password, browser cookie, OAuth credential, or raw API token is persisted in application logs or database columns.
+
+## Implementation units
+
+### 1. Device authorization and revocable access tokens
+
+- Add `CliDeviceAuthorization` and `CliAccessToken` tables/models with digest lookup, a unique human-readable user code, expiration/single-use state, user ownership, and token issuance/revocation helpers.
+- Add public JSON endpoints to start and poll device authorization plus bearer-protected identity and revoke endpoints.
+- Extend `Api::BaseController` with optional bearer authentication that rejects an explicitly invalid token and throttles `last_used_at` writes.
+- Attach documents created with a valid bearer token to that token's user and make the create response accurately describe account ownership.
+- Cover model invariants, expiry, one-time issuance, invalid credentials, revocation, anonymous compatibility, and account-owned API creation.
+
+### 2. Browser approval flow
+
+- Add signed-in GET/POST routes and a focused Inertia page for CLI approval. The complete browser URL carries only the short user code; the high-entropy polling secret never enters browser history or server request paths.
+- Preserve the complete local approval URL through login/signup, show the matching user code, reject expired/unknown grants, and render a clear success state after approval.
+- Reuse the existing authentication, typography, card, button, and responsive patterns rather than creating a separate account system.
+- Cover redirect-to-login, approval by the current user, expiry, replay, CSRF-protected form shape, and desktop/mobile rendering.
+
+### 3. Zero-dependency CLI
+
+- Add an npm-ready `cli/` package for Node 20+ using built-in `fetch`, `fs`, `child_process`, and `node:test` only.
+- Implement argument parsing, config storage, browser opening, polling, slug normalization, stdin/file input, JSON/plain output, API error rendering, and commands: `login`, `logout`, `whoami`, `new`, `show`, `update`, `suggest`, `comment`, `init`, `skill install`, `prime`, `help`, and `version`.
+- Keep standard output composable: content or the requested URL on success; progress and diagnostics on standard error; `--json` for structured automation.
+- Add deterministic tests with temporary homes/projects and a local fake HTTP server; package/installer smoke tests must not touch the real account or production service.
+
+### 4. Agent skill and offline priming
+
+- Bundle a concise `thinkroom` `SKILL.md` that triggers when an agent needs to start, share, revise, comment on, or hand work to a human through Thinkroom.
+- Teach the agent to run `thinkroom prime`, read relevant durable project context, use account-linked creation for handoffs, read live state before edits, prefer targeted suggestions after human involvement, and return the share URL.
+- Install project-locally into detected `.agents/skills`, `.claude/skills`, and `.codex/skills` roots without overwriting unrelated files. Support an explicit `--agent agents|claude|codex|all` override, default to `.agents/skills` when no client directory exists, and make reruns update only the managed Thinkroom skill.
+- Validate the source skill with the skill-creator validator and verify installed copies byte-for-byte in CLI tests.
+
+### 5. Distribution, documentation, and CI
+
+- Add a POSIX installer that places the single CLI entrypoint in `${THINKROOM_INSTALL_DIR:-$HOME/.local/bin}` with executable permissions and explains PATH setup when necessary.
+- Add root scripts/CI coverage for CLI tests and npm packaging without adding runtime dependencies to the Rails frontend.
+- Document the install/login/init/new/show workflow in the README and keep `THINKROOM_URL` documented for self-hosted installations.
+- Verify `npm pack` contains only the intended CLI, license, and bundled skill assets.
+
+## Acceptance examples
+
+- A signed-out person runs `thinkroom login`, follows the printed browser URL, signs in, approves the named request, and the waiting command completes without asking them to paste a code or token.
+- After login, `printf '# Draft' | thinkroom new --title Draft --agent Codex` prints a share URL and the document appears under the approving account on the home page with Codex seed attribution.
+- An invalid or revoked token produces an actionable authentication error and never creates an unowned document.
+- `thinkroom show <share-url>` prints the current source; `update` revises an untouched seed document; after a human starts editing, the same command surfaces the API's suggestion guidance and non-zero status.
+- In a repository with `AGENTS.md`, `CONCEPTS.md`, and categorized `docs/solutions`, `thinkroom init` installs the requested skill and `thinkroom prime` lists those sources without making an HTTP request.
+- Running the one-line installer in a temporary home produces an executable `thinkroom` whose `--version`, `help`, and `prime` commands work before login.
+
+## Verification
+
+- Focused model/integration tests for device grants, tokens, API authentication, browser approval, and account-owned CLI creation.
+- `node --test cli/test/*.test.js` and `npm pack --dry-run --workspace thinkroom` (or the package-directory equivalent).
+- Skill validation with `quick_validate.py`.
+- Full `bin/rails test`, `bin/rubocop`, `npm run check`, test and production Vite builds, and security scans in CI.
+- Browser verification of login handoff, approval, account-linked creation, home ownership, revoke behavior, and 390px layout.
+- After merge, deploy the exact commit and repeat the device-login/create/revoke path against production using a temporary account and document, then remove both.
+
+## Deferred
+
+- Refresh tokens, multiple token management UI, token naming/editing, and audit-history UI.
+- Native binaries, Homebrew, Windows installers, and publishing credentials/automation for the public npm registry.
+- Using CLI bearer tokens to bypass a document's current share-link access level or live-edit an already-started CRDT document.
+- Automatic mutation of `AGENTS.md` or other repository instruction files; initialization only installs the skill and reports durable context.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "yjs": "^13.6.31"
   },
   "scripts": {
-    "check": "tsc -p tsconfig.app.json && tsc -p tsconfig.node.json",
+    "check": "tsc -p tsconfig.app.json && tsc -p tsconfig.node.json && npm run check:cli",
+    "check:cli": "node --test cli/test/*.test.js",
     "check:exports": "node script/export_check.mjs",
     "check:html": "node script/html_document_check.mjs",
     "check:links": "node script/link_check.mjs"

--- a/script/install_thinkroom_cli.sh
+++ b/script/install_thinkroom_cli.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+repository="https://raw.githubusercontent.com/kieranklaassen/thinkroom/main"
+install_dir="${THINKROOM_INSTALL_DIR:-$HOME/.local/bin}"
+share_dir="$(dirname "$install_dir")/share/thinkroom/skill/thinkroom"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+
+mkdir -p "$install_dir" "$share_dir/agents"
+
+fetch_file() {
+  source_path="$1"
+  destination="$2"
+  if [ -n "${THINKROOM_SOURCE_ROOT:-}" ]; then
+    cp "$THINKROOM_SOURCE_ROOT/$source_path" "$destination"
+  else
+    curl -fsSL "$repository/$source_path" -o "$destination"
+  fi
+}
+
+fetch_file "cli/bin/thinkroom.js" "$temporary/thinkroom"
+fetch_file "cli/skill/thinkroom/SKILL.md" "$temporary/SKILL.md"
+fetch_file "cli/skill/thinkroom/agents/openai.yaml" "$temporary/openai.yaml"
+
+install -m 0755 "$temporary/thinkroom" "$install_dir/thinkroom"
+install -m 0644 "$temporary/SKILL.md" "$share_dir/SKILL.md"
+install -m 0644 "$temporary/openai.yaml" "$share_dir/agents/openai.yaml"
+
+printf 'Installed Thinkroom CLI at %s\n' "$install_dir/thinkroom"
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *) printf 'Add %s to PATH, then run: thinkroom init\n' "$install_dir" ;;
+esac

--- a/test/integration/cli_authentication_flow_test.rb
+++ b/test/integration/cli_authentication_flow_test.rb
@@ -6,6 +6,10 @@ class CliAuthenticationFlowTest < ActionDispatch::IntegrationTest
     @user = User.create!(name: "Kieran", email: "cli-flow@example.com", password: "thoughtful-passphrase")
   end
 
+  teardown do
+    WriteRateLimited::STORE.clear
+  end
+
   test "device authorization exposes a browser link and polling status" do
     post "/api/cli/device_authorizations", as: :json
 

--- a/test/integration/cli_authentication_flow_test.rb
+++ b/test/integration/cli_authentication_flow_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+class CliAuthenticationFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    WriteRateLimited::STORE.clear
+    @user = User.create!(name: "Kieran", email: "cli-flow@example.com", password: "thoughtful-passphrase")
+  end
+
+  test "device authorization exposes a browser link and polling status" do
+    post "/api/cli/device_authorizations", as: :json
+
+    assert_response :created
+    payload = response.parsed_body
+    assert payload["device_code"].present?
+    assert_match(/\A[A-Z2-9]{4}-[A-Z2-9]{4}\z/, payload["user_code"])
+    assert_equal payload["user_code"], Rack::Utils.parse_query(URI(payload["verification_url"]).query)["code"]
+    assert_equal CliDeviceAuthorization::POLL_INTERVAL.to_i, payload["interval"]
+
+    post "/api/cli/device_authorizations/token", params: { device_code: payload["device_code"] }, as: :json
+    assert_response :too_early
+    assert_equal "authorization_pending", response.parsed_body["error"]
+  end
+
+  test "browser approval exchanges for an account token exactly once" do
+    authorization, raw_device_code = CliDeviceAuthorization.start!
+    post login_path, params: { email: @user.email, password: "thoughtful-passphrase" }
+
+    get cli_authorize_path(code: authorization.user_code)
+    assert_inertia_component "cli/authorize"
+    assert_inertia_props do |props|
+      props[:status] == "ready" && props[:user_code] == authorization.user_code &&
+        props.dig(:account, :email) == @user.email
+    end
+
+    post cli_authorize_path, params: { code: authorization.user_code }
+    assert_response :see_other
+    assert_equal @user, authorization.reload.user
+
+    post "/api/cli/device_authorizations/token", params: { device_code: raw_device_code }, as: :json
+    assert_response :success
+    payload = response.parsed_body
+    assert payload["access_token"].start_with?(CliAccessToken::TOKEN_PREFIX)
+    assert_equal @user.email, payload.dig("account", "email")
+
+    post "/api/cli/device_authorizations/token", params: { device_code: raw_device_code }, as: :json
+    assert_response :gone
+    assert_equal "access_denied", response.parsed_body["error"]
+  end
+
+  test "approval redirects through login and preserves the complete local return path" do
+    authorization, = CliDeviceAuthorization.start!
+
+    get cli_authorize_path(code: authorization.user_code)
+    assert_response :see_other
+    assert_includes response.location, "/login?"
+
+    follow_redirect!
+    assert_inertia_component "auth/show"
+    assert_inertia_props do |props|
+      props[:return_to] == cli_authorize_path(code: authorization.user_code)
+    end
+
+    post login_path, params: { email: @user.email, password: "thoughtful-passphrase" }
+    assert_redirected_to cli_authorize_path(code: authorization.user_code)
+  end
+
+  test "authorization page reports invalid, expired, and completed codes" do
+    post login_path, params: { email: @user.email, password: "thoughtful-passphrase" }
+
+    get cli_authorize_path(code: "NOPE-NOPE")
+    assert_inertia_props { |props| props[:status] == "invalid" }
+
+    expired, = CliDeviceAuthorization.start!
+    expired.update_column(:expires_at, 1.minute.ago)
+    get cli_authorize_path(code: expired.user_code)
+    assert_inertia_props { |props| props[:status] == "expired" }
+
+    approved, raw_device_code = CliDeviceAuthorization.start!
+    approved.approve!(@user)
+    get cli_authorize_path(code: approved.user_code)
+    assert_inertia_props { |props| props[:status] == "approved" }
+    CliDeviceAuthorization.exchange!(raw_device_code)
+    get cli_authorize_path(code: approved.user_code)
+    assert_inertia_props { |props| props[:status] == "consumed" }
+  end
+
+  test "bearer identity, account-owned creation, and revocation work together" do
+    token, raw_token = CliAccessToken.issue!(user: @user, name: "Test terminal")
+    bearer = { "Authorization" => "Bearer #{raw_token}" }
+
+    get "/api/cli/session", headers: bearer
+    assert_response :success
+    assert_equal @user.email, response.parsed_body.dig("account", "email")
+    assert_equal "Test terminal", response.parsed_body.dig("token", "name")
+
+    post "/api/docs",
+         params: { title: "CLI Doc", content: "# From the CLI" },
+         headers: bearer.merge("X-Agent-Name" => "Codex"), as: :json
+    assert_response :created
+    document = Document.find_by!(slug: response.parsed_body["slug"])
+    assert_equal @user, document.user
+    assert_equal @user.name, document.owner_name
+    assert_equal "Codex", document.seed_author_name
+    assert_includes response.parsed_body["note"], "your Thinkroom account"
+
+    delete "/api/cli/session", headers: bearer
+    assert_response :no_content
+    assert token.reload.revoked_at
+
+    get "/api/cli/session", headers: bearer
+    assert_response :unauthorized
+  end
+
+  test "an explicit invalid bearer token never degrades to anonymous creation" do
+    assert_no_difference("Document.count") do
+      post "/api/docs",
+           params: { title: "Must not exist", content: "# Nope" },
+           headers: { "Authorization" => "Bearer trm_invalid", "X-Agent-Name" => "Codex" },
+           as: :json
+    end
+
+    assert_response :unauthorized
+    assert_includes response.parsed_body["next_action"], "thinkroom login"
+  end
+
+  test "existing anonymous agent creation remains unclaimed" do
+    post "/api/docs",
+         params: { title: "Anonymous API", content: "# Shared" },
+         headers: { "X-Agent-Name" => "Scout" }, as: :json
+
+    assert_response :created
+    document = Document.find_by!(slug: response.parsed_body["slug"])
+    assert_not document.claimed?
+    assert_includes response.parsed_body["note"], "unclaimed"
+  end
+end

--- a/test/models/cli_access_token_test.rb
+++ b/test/models/cli_access_token_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class CliAccessTokenTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(name: "Kieran", email: "cli-token@example.com", password: "thoughtful-passphrase")
+  end
+
+  test "issue stores only a digest and authenticate returns the user token" do
+    record, raw_token = CliAccessToken.issue!(user: @user, name: "Laptop")
+
+    assert raw_token.start_with?(CliAccessToken::TOKEN_PREFIX)
+    assert_not_equal raw_token, record.token_digest
+    assert_equal 64, record.token_digest.length
+    assert_equal record, CliAccessToken.authenticate(raw_token)
+    assert_equal @user, record.user
+    assert record.reload.last_used_at
+  end
+
+  test "invalid and revoked tokens do not authenticate" do
+    record, raw_token = CliAccessToken.issue!(user: @user)
+
+    assert_nil CliAccessToken.authenticate("not-a-token")
+    record.revoke!
+    assert_nil CliAccessToken.authenticate(raw_token)
+  end
+end

--- a/test/models/cli_device_authorization_test.rb
+++ b/test/models/cli_device_authorization_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class CliDeviceAuthorizationTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(name: "Kieran", email: "cli-device@example.com", password: "thoughtful-passphrase")
+  end
+
+  test "start stores a digest and creates a readable expiring code" do
+    authorization, raw_device_code = CliDeviceAuthorization.start!
+
+    assert_match(/\A[A-Z2-9]{4}-[A-Z2-9]{4}\z/, authorization.user_code)
+    assert_not_equal raw_device_code, authorization.device_code_digest
+    assert_in_delta CliDeviceAuthorization::LIFETIME.from_now, authorization.expires_at, 2.seconds
+    assert_equal authorization.user_code,
+                 CliDeviceAuthorization.normalize_user_code(authorization.user_code.delete("-").downcase)
+  end
+
+  test "exchange waits for approval, enforces polling interval, and issues once" do
+    authorization, raw_device_code = CliDeviceAuthorization.start!
+    now = Time.current
+
+    assert_raises(CliDeviceAuthorization::AuthorizationPending) do
+      CliDeviceAuthorization.exchange!(raw_device_code, now:)
+    end
+    assert_raises(CliDeviceAuthorization::PollingTooQuickly) do
+      CliDeviceAuthorization.exchange!(raw_device_code, now: now + 1.second)
+    end
+
+    authorization.approve!(@user, now: now + 1.second)
+    token, raw_token = CliDeviceAuthorization.exchange!(raw_device_code, now: now + 2.seconds)
+
+    assert_equal @user, token.user
+    assert_equal token, CliAccessToken.authenticate(raw_token)
+    assert authorization.reload.consumed_at
+    assert_raises(CliDeviceAuthorization::AlreadyConsumed) do
+      CliDeviceAuthorization.exchange!(raw_device_code, now: now + 4.seconds)
+    end
+  end
+
+  test "approval rejects expired grants and another account cannot replace approval" do
+    authorization, = CliDeviceAuthorization.start!
+    other = User.create!(name: "Other", email: "cli-other@example.com", password: "thoughtful-passphrase")
+
+    authorization.approve!(@user)
+    assert_raises(CliDeviceAuthorization::AlreadyApproved) { authorization.approve!(other) }
+
+    expired, = CliDeviceAuthorization.start!
+    assert_raises(CliDeviceAuthorization::Expired) do
+      expired.approve!(@user, now: expired.expires_at + 1.second)
+    end
+  end
+
+  test "unknown and expired device secrets do not issue tokens" do
+    assert_raises(CliDeviceAuthorization::InvalidDeviceCode) do
+      CliDeviceAuthorization.exchange!("unknown")
+    end
+
+    authorization, raw_device_code = CliDeviceAuthorization.start!
+    authorization.approve!(@user)
+    assert_raises(CliDeviceAuthorization::Expired) do
+      CliDeviceAuthorization.exchange!(raw_device_code, now: authorization.expires_at + 1.second)
+    end
+  end
+
+  test "starting a grant prunes only authorizations expired for more than a day" do
+    stale, = CliDeviceAuthorization.start!
+    stale.update_column(:expires_at, 2.days.ago)
+    recent, = CliDeviceAuthorization.start!
+    recent.update_column(:expires_at, 1.hour.ago)
+
+    CliDeviceAuthorization.start!
+
+    assert_not CliDeviceAuthorization.exists?(stale.id)
+    assert CliDeviceAuthorization.exists?(recent.id)
+  end
+end


### PR DESCRIPTION
## Summary
- add browser-approved device login with revocable, digest-only CLI access tokens
- ship a zero-dependency CLI for account-linked document creation, reading, updates, suggestions, comments, priming, and skill installation
- add a responsive approval page, one-line installer, npm-ready package, security docs, and full backend/CLI coverage

## Verification
- `bin/rails test` (430 tests, 2,040 assertions)
- `bin/rubocop`
- `npm run check`
- `bin/vite build --clear --mode=test`
- `bin/vite build`
- `bin/brakeman --no-pager -q`
- `npm audit --omit=dev --audit-level=moderate`
- skill validator and `npm pack --dry-run ./cli`
- local desktop/mobile browser flow through signup, approval, CLI polling, account-linked create, ownership, delete, revoke, and cleanup

Closes #91