### PR TITLE
Widen sketches and tables independently

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,6 +3,8 @@ class DocumentsController < InertiaController
   rate_limit_document_creation
 
   SIGNED_IN_AUTO_CLAIM_WINDOW = 10.minutes
+  MIN_RICH_CONTENT_WIDTH = 640
+  MAX_RICH_CONTENT_WIDTH = 1_200
 
   # SSR is scoped to the read-only document surfaces — #show (shell, header,
   # static content_html preview) and #index (the landing page) — so their
@@ -452,11 +454,13 @@ class DocumentsController < InertiaController
 
   def ui_prefs(mode:)
     document_width = Integer(cookies[:pruf_width], exception: false)
+    rich_content_width = Integer(cookies[:pruf_rich_width], exception: false)
     {
       panel_open: cookies[:pruf_panel] != "0",
       focus_mode: cookies[:pruf_focus] == "1",
       mode:,
-      document_width: document_width&.clamp(MIN_DOCUMENT_WIDTH, MAX_DOCUMENT_WIDTH)
+      document_width: document_width&.clamp(MIN_DOCUMENT_WIDTH, MAX_DOCUMENT_WIDTH),
+      rich_content_width: rich_content_width&.clamp(MIN_RICH_CONTENT_WIDTH, MAX_RICH_CONTENT_WIDTH)
     }
   end
 

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -85,6 +85,7 @@ import {
 import { configureSlashMenu, slashMenu } from './slash_menu'
 import { readPointerAwarenessCtx, readPointers } from './read_pointers'
 import { mermaidDiagrams } from './mermaid'
+import { richBlockWidthControls } from './rich_block_width'
 
 export interface EditorHandle {
   editor: Editor
@@ -467,6 +468,7 @@ function CollabEditor({
         .use(frontmatter)
         .use(sketchSchemaPlugins)
         .use(sketchNodeViewPlugins)
+        .use(richBlockWidthControls)
         .use(slashMenu)
         .use(suggestChangesMarks)
         // Order matters: provenanceWriter (inside provenance) runs its

--- a/app/frontend/editor/rich_block_width.ts
+++ b/app/frontend/editor/rich_block_width.ts
@@ -1,0 +1,195 @@
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state'
+import { $prose } from '@milkdown/kit/utils'
+
+export const DEFAULT_RICH_CONTENT_WIDTH = 960
+export const MIN_RICH_CONTENT_WIDTH = 640
+export const MAX_RICH_CONTENT_WIDTH = 1200
+export const RICH_BLOCK_WIDTH_EVENT = 'thinkroom:rich-block-width'
+
+export interface RichBlockWidthEventDetail {
+  width: number | null
+  commit: boolean
+}
+
+interface DragState {
+  pointerId: number
+  startX: number
+  startWidth: number
+  maxWidth: number
+  reviewAligned: boolean
+}
+
+const richBlockWidthKey = new PluginKey('RICH_BLOCK_WIDTH')
+const BLOCK_SELECTOR = '.thinkroom-sketch, .milkdown-table-block'
+
+const dispatchWidth = (width: number | null, commit: boolean) => {
+  window.dispatchEvent(new CustomEvent<RichBlockWidthEventDetail>(RICH_BLOCK_WIDTH_EVENT, {
+    detail: { width, commit },
+  }))
+}
+
+const isReviewAligned = (block: HTMLElement) => {
+  const page = block.closest('.doc-page')
+  const canvas = block.closest('.doc-canvas')
+  return !page?.classList.contains('is-read-mode') && !canvas?.classList.contains('is-focus')
+}
+
+const widthBounds = (block: HTMLElement) => {
+  const prose = block.closest('.ProseMirror')
+  const proseRect = prose?.getBoundingClientRect()
+  const minimum = Math.max(MIN_RICH_CONTENT_WIDTH, Math.round(proseRect?.width ?? 0))
+  const proseCenter = proseRect ? proseRect.left + proseRect.width / 2 : window.innerWidth / 2
+  const available = isReviewAligned(block)
+    ? Math.round((proseRect?.right ?? window.innerWidth) - 24)
+    : Math.round(2 * Math.min(proseCenter - 24, window.innerWidth - 24 - proseCenter))
+
+  return {
+    minimum,
+    maximum: Math.max(minimum, Math.min(MAX_RICH_CONTENT_WIDTH, available)),
+  }
+}
+
+const clampWidth = (block: HTMLElement, width: number, maximum?: number) => {
+  const bounds = widthBounds(block)
+  return Math.round(Math.min(Math.max(width, bounds.minimum), maximum ?? bounds.maximum))
+}
+
+const syncHandleValue = (handle: HTMLButtonElement) => {
+  const block = handle.closest<HTMLElement>(BLOCK_SELECTOR)
+  if (!block) return
+
+  const width = Math.round(block.getBoundingClientRect().width)
+  const { minimum, maximum } = widthBounds(block)
+  handle.setAttribute('aria-valuemin', String(minimum))
+  handle.setAttribute('aria-valuemax', String(maximum))
+  handle.setAttribute('aria-valuenow', String(width))
+  handle.setAttribute('aria-valuetext', `${width} pixels. Press Home or double-click to reset.`)
+}
+
+const buildHandle = (block: HTMLElement) => {
+  const handle = document.createElement('button')
+  const grip = document.createElement('span')
+  let drag: DragState | null = null
+  let lastWidth: number | null = null
+
+  handle.type = 'button'
+  handle.className = 'rich-block-width-handle'
+  handle.contentEditable = 'false'
+  handle.setAttribute('role', 'separator')
+  handle.setAttribute('aria-label', 'Sketch and table width')
+  handle.setAttribute('aria-orientation', 'vertical')
+  handle.title = 'Drag to resize sketches and tables · Arrow keys adjust · Double-click resets'
+  grip.setAttribute('aria-hidden', 'true')
+  grip.textContent = '•••'
+  handle.append(grip)
+
+  const stop = (event: Event) => event.stopPropagation()
+  handle.addEventListener('mousedown', stop)
+  handle.addEventListener('click', stop)
+
+  handle.addEventListener('dblclick', (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    dispatchWidth(null, true)
+  })
+
+  handle.addEventListener('keydown', (event) => {
+    event.stopPropagation()
+    if (event.key === 'Home') {
+      event.preventDefault()
+      dispatchWidth(null, true)
+      return
+    }
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+    event.preventDefault()
+    const reviewAligned = isReviewAligned(block)
+    const spatialDirection = event.key === 'ArrowRight' ? 1 : -1
+    const widthDirection = reviewAligned ? -spatialDirection : spatialDirection
+    const step = event.shiftKey ? 96 : 32
+    const nextWidth = clampWidth(block, block.getBoundingClientRect().width + widthDirection * step)
+    dispatchWidth(nextWidth, true)
+  })
+
+  const finishDrag = (event: PointerEvent) => {
+    if (!drag || drag.pointerId !== event.pointerId) return
+    drag = null
+    handle.classList.remove('is-dragging')
+    if (lastWidth !== null) dispatchWidth(lastWidth, true)
+  }
+
+  handle.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    handle.setPointerCapture(event.pointerId)
+    const bounds = widthBounds(block)
+    drag = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: block.getBoundingClientRect().width,
+      maxWidth: bounds.maximum,
+      reviewAligned: isReviewAligned(block),
+    }
+    lastWidth = Math.round(drag.startWidth)
+    handle.classList.add('is-dragging')
+  })
+
+  handle.addEventListener('pointermove', (event) => {
+    if (!drag || drag.pointerId !== event.pointerId) return
+    const delta = event.clientX - drag.startX
+    const scale = drag.reviewAligned ? -1 : 2
+    lastWidth = clampWidth(block, drag.startWidth + delta * scale, drag.maxWidth)
+    dispatchWidth(lastWidth, false)
+  })
+  handle.addEventListener('pointerup', finishDrag)
+  handle.addEventListener('pointercancel', finishDrag)
+
+  block.append(handle)
+  syncHandleValue(handle)
+}
+
+const richBlockWidthControlsProse = $prose(
+  () =>
+    new Plugin({
+      key: richBlockWidthKey,
+      view: (view) => {
+        let frame: number | null = null
+
+        const sync = () => {
+          frame = null
+          view.dom.querySelectorAll<HTMLElement>(BLOCK_SELECTOR).forEach((block) => {
+            if (!block.querySelector(':scope > .rich-block-width-handle')) buildHandle(block)
+          })
+          view.dom.querySelectorAll<HTMLButtonElement>('.rich-block-width-handle').forEach(syncHandleValue)
+        }
+        const scheduleSync = () => {
+          if (frame !== null) return
+          frame = requestAnimationFrame(sync)
+        }
+
+        sync()
+        const mutationObserver = new MutationObserver(scheduleSync)
+        mutationObserver.observe(view.dom, { childList: true, subtree: true })
+        const resizeObserver = typeof ResizeObserver === 'undefined'
+          ? null
+          : new ResizeObserver(scheduleSync)
+        resizeObserver?.observe(view.dom)
+        window.addEventListener('resize', scheduleSync)
+        window.addEventListener(RICH_BLOCK_WIDTH_EVENT, scheduleSync)
+
+        return {
+          update: scheduleSync,
+          destroy: () => {
+            if (frame !== null) cancelAnimationFrame(frame)
+            mutationObserver.disconnect()
+            resizeObserver?.disconnect()
+            window.removeEventListener('resize', scheduleSync)
+            window.removeEventListener(RICH_BLOCK_WIDTH_EVENT, scheduleSync)
+          },
+        }
+      },
+    }),
+)
+
+export const richBlockWidthControls = [richBlockWidthControlsProse].flat()

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -36,6 +36,11 @@
   --code-bg: #f3f0e9;
   --measure: 44rem;
   --document-width: var(--measure);
+  --rich-content-width: 960px;
+  --review-gutter-width: 15rem;
+  --review-gutter-half-width: 7.5rem;
+  --activity-rail-width: 21rem;
+  --activity-rail-half-width: 10.5rem;
 
   --sketch-surface: #fffef9;
   --sketch-surface-muted: #fffaf1;
@@ -1046,11 +1051,11 @@ a:focus-visible {
   align-items: stretch;
   min-width: 0;
   flex: 1;
-  max-width: calc(var(--document-width) + 15rem);
+  max-width: calc(var(--document-width) + var(--review-gutter-width));
 }
 
 .margin-gutter {
-  width: 15rem;
+  width: var(--review-gutter-width);
   flex: none;
   position: relative;
   transition: width 200ms ease;
@@ -1182,6 +1187,113 @@ a:focus-visible {
 
 .doc-static-preview {
   user-select: none;
+}
+
+/* Sketches and tables can use the screen's visual bandwidth without making
+   prose harder to read. Read/focus layouts grow around the prose center;
+   review layouts hold the gutter-side edge steady and grow into open space. */
+.milkdown .ProseMirror > .thinkroom-sketch,
+.milkdown .ProseMirror > .milkdown-table-block,
+.doc-static-preview .ProseMirror > .doc-sketch-skeleton,
+.doc-static-preview .ProseMirror > table {
+  position: relative;
+  width: min(max(100%, var(--rich-content-width)), calc(100vw - 3rem));
+  max-width: none;
+  margin-left: 50%;
+  transform: translateX(-50%);
+}
+
+:where(.doc-page:not(.is-read-mode) .doc-canvas:not(.is-focus)) .milkdown .ProseMirror > .thinkroom-sketch,
+:where(.doc-page:not(.is-read-mode) .doc-canvas:not(.is-focus)) .milkdown .ProseMirror > .milkdown-table-block,
+:where(.doc-page:not(.is-read-mode) .doc-canvas:not(.is-focus)) .doc-static-preview .ProseMirror > .doc-sketch-skeleton,
+:where(.doc-page:not(.is-read-mode) .doc-canvas:not(.is-focus)) .doc-static-preview .ProseMirror > table {
+  /* The activity rail shares the centered body row. Half of its width
+     shifts the canvas left, so include it when deriving the safe left edge. */
+  width: min(
+    max(100%, var(--rich-content-width)),
+    calc(50vw + 50% - var(--review-gutter-half-width) - var(--activity-rail-half-width) - 1.5rem)
+  );
+  margin-left: 100%;
+  transform: translateX(-100%);
+}
+
+:where(.doc-page.is-panel-hidden:not(.is-read-mode) .doc-canvas:not(.is-focus)) .milkdown .ProseMirror > .thinkroom-sketch,
+:where(.doc-page.is-panel-hidden:not(.is-read-mode) .doc-canvas:not(.is-focus)) .milkdown .ProseMirror > .milkdown-table-block,
+:where(.doc-page.is-panel-hidden:not(.is-read-mode) .doc-canvas:not(.is-focus)) .doc-static-preview .ProseMirror > .doc-sketch-skeleton,
+:where(.doc-page.is-panel-hidden:not(.is-read-mode) .doc-canvas:not(.is-focus)) .doc-static-preview .ProseMirror > table {
+  width: min(
+    max(100%, var(--rich-content-width)),
+    calc(50vw + 50% - var(--review-gutter-half-width) - 1.5rem)
+  );
+}
+
+/* Focus collapses suggestion cards but intentionally leaves the activity rail.
+   Keep the breakout centered on prose while respecting the nearer viewport edge. */
+:where(.doc-page:not(.is-panel-hidden) .doc-canvas.is-focus) .milkdown .ProseMirror > .thinkroom-sketch,
+:where(.doc-page:not(.is-panel-hidden) .doc-canvas.is-focus) .milkdown .ProseMirror > .milkdown-table-block,
+:where(.doc-page:not(.is-panel-hidden) .doc-canvas.is-focus) .doc-static-preview .ProseMirror > .doc-sketch-skeleton,
+:where(.doc-page:not(.is-panel-hidden) .doc-canvas.is-focus) .doc-static-preview .ProseMirror > table {
+  width: min(
+    max(100%, var(--rich-content-width)),
+    max(100%, calc(100vw - var(--review-gutter-width) - var(--activity-rail-width) - 3rem))
+  );
+}
+
+.rich-block-width-handle {
+  position: absolute;
+  z-index: 8;
+  top: 50%;
+  right: -10px;
+  display: grid;
+  width: 20px;
+  height: 48px;
+  place-items: center;
+  margin: 0;
+  border: 0;
+  border-radius: 999px;
+  outline: none;
+  background: transparent;
+  color: var(--ink-faint);
+  cursor: col-resize;
+  opacity: 0.52;
+  padding: 0;
+  touch-action: none;
+  transform: translateY(-50%);
+  transition: color 140ms ease, opacity 140ms ease;
+}
+
+.rich-block-width-handle::before {
+  position: absolute;
+  inset: 0 2px;
+  border: 1px solid color-mix(in srgb, var(--ink-faint) 42%, transparent);
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--surface-raised) 90%, transparent);
+  box-shadow: 0 1px 5px rgb(0 0 0 / 5%);
+  content: '';
+}
+
+.rich-block-width-handle span {
+  position: relative;
+  font: 600 7px/1 var(--font-ui);
+  letter-spacing: -1px;
+  writing-mode: vertical-rl;
+}
+
+.rich-block-width-handle:hover,
+.rich-block-width-handle:focus-visible,
+.rich-block-width-handle.is-dragging {
+  color: var(--accent);
+  opacity: 1;
+}
+
+.rich-block-width-handle:focus-visible::before {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+:where(.doc-page:not(.is-read-mode) .doc-canvas:not(.is-focus)) .rich-block-width-handle {
+  right: auto;
+  left: -10px;
 }
 
 /* Neutral box standing in for a sketch canvas until Excalidraw mounts, so a
@@ -1504,7 +1616,7 @@ a:focus-visible {
 
 /* Normal flow, no inner scrollbar — the whole page is one scroll surface. */
 .doc-rail {
-  width: 21rem;
+  width: var(--activity-rail-width);
   flex: none;
   border-left: 1px solid var(--line);
   padding: 1.5rem 1.25rem 4rem;
@@ -3323,6 +3435,20 @@ a:focus-visible {
     display: none;
   }
 
+  .milkdown .ProseMirror > .thinkroom-sketch,
+  .milkdown .ProseMirror > .milkdown-table-block,
+  .doc-static-preview .ProseMirror > .doc-sketch-skeleton,
+  .doc-static-preview .ProseMirror > table {
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    transform: none;
+  }
+
+  .rich-block-width-handle {
+    display: none;
+  }
+
   .milkdown .ProseMirror {
     font-size: 1rem;
     line-height: 1.65;
@@ -4120,8 +4246,17 @@ a:focus-visible {
   .sketch-add-inline,
   .sketch-delete-tape,
   .sketch-download-button,
-  .thinkroom-sketch-editor-mount {
+  .thinkroom-sketch-editor-mount,
+  .rich-block-width-handle {
     display: none !important;
+  }
+
+  .milkdown .ProseMirror > .thinkroom-sketch,
+  .milkdown .ProseMirror > .milkdown-table-block {
+    width: auto;
+    max-width: 100%;
+    margin-left: 0;
+    transform: none;
   }
 
   .doc-body,

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -85,6 +85,10 @@ import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import { patchJSON } from '../../lib/csrf'
 import type { ViewerPayload } from '../../types/viewer'
 import { setCookie, setCookieFlag } from '../../lib/cookies'
+import {
+  RICH_BLOCK_WIDTH_EVENT,
+  type RichBlockWidthEventDetail,
+} from '../../editor/rich_block_width'
 import './show.css'
 
 export interface ActivityPayload {
@@ -119,6 +123,7 @@ export interface DocumentProps {
     focus_mode: boolean
     mode: EditorMode
     document_width: number | null
+    rich_content_width: number | null
   }
   ownership: OwnershipPayload
   suggestions: SuggestionPayload[]
@@ -251,6 +256,17 @@ export default function DocumentShow({
   const [panelOpen, setPanelOpen] = useState(ui.panel_open)
   const [focusMode, setFocusMode] = useState(ui.focus_mode)
   const [documentWidth, setDocumentWidth] = useState<number | null>(ui.document_width)
+  const [richContentWidth, setRichContentWidth] = useState<number | null>(ui.rich_content_width)
+
+  useEffect(() => {
+    const handleRichBlockWidth = (event: Event) => {
+      const detail = (event as CustomEvent<RichBlockWidthEventDetail>).detail
+      setRichContentWidth(detail.width)
+      if (detail.commit) setCookie('pruf_rich_width', detail.width === null ? 'default' : String(detail.width))
+    }
+    window.addEventListener(RICH_BLOCK_WIDTH_EVENT, handleRichBlockWidth)
+    return () => window.removeEventListener(RICH_BLOCK_WIDTH_EVENT, handleRichBlockWidth)
+  }, [])
   // Demo doc always opens in Edit and stays locked there. Ordinary documents
   // take mode directly from the Inertia page props/history entry.
   const demoModeLocked = doc.slug === 'demo'
@@ -1159,14 +1175,17 @@ export default function DocumentShow({
     view.focus()
   }, [])
 
+  const documentStyle = {
+    ...(documentWidth === null ? {} : { '--document-width': `${documentWidth}px` }),
+    ...(richContentWidth === null ? {} : { '--rich-content-width': `${richContentWidth}px` }),
+  } as CSSProperties
+
   return (
     <>
       <Head title={documentTitle} />
       <div
         className={`doc-page ${panelOpen ? '' : 'is-panel-hidden'} ${isReading ? 'is-read-mode' : ''}`}
-        style={documentWidth === null
-          ? undefined
-          : ({ '--document-width': `${documentWidth}px` } as CSSProperties)}
+        style={Object.keys(documentStyle).length === 0 ? undefined : documentStyle}
       >
         <header className="doc-header">
           <div className="doc-header-left">

--- a/docs/plans/2026-06-26-018-feat-rich-block-width-plan.md
+++ b/docs/plans/2026-06-26-018-feat-rich-block-width-plan.md
@@ -1,0 +1,39 @@
+---
+title: "feat: Let sketches and tables break out wider than prose"
+type: feat
+status: active
+date: 2026-06-26
+issue: 94
+---
+
+# Wider sketch and table blocks
+
+## Goal
+
+Let information-dense Excalidraw sketches and tables use more of a wide screen than the readable prose measure, with a separate accessible drag control and persisted viewer preference.
+
+## Decisions
+
+- Use one viewer-level rich-block width preference for sketches and tables. The existing document width is also a viewer preference; keeping this parallel avoids adding non-portable width metadata to Markdown tables or changing shared document source merely because one viewer resized their screen.
+- Default rich blocks to 960px on desktop while never shrinking below their containing prose width. Allow adjustment from 640px through 1200px and clamp again to viewport-safe space.
+- Put a quiet width control on every live sketch/table so the affordance appears where its effect is visible. Dragging one updates all rich blocks, persists to `pruf_rich_width`, and remains separate from the existing prose-edge control.
+- Center breakouts in Read mode and suggestion-focus mode. In ordinary Edit/Suggest/Comment layouts, keep the block's review-gutter edge aligned with prose and expand toward the unused opposite side, capped to the viewport, so margin cards never cover the rich content.
+- Support ArrowLeft/ArrowRight, Shift for larger steps, Home, and double-click reset with separator value semantics.
+- Keep the first paint aligned with the final editor by applying the server-sanitized cookie as a CSS variable to both static preview blocks and live Milkdown blocks.
+- At the existing compact/coarse-pointer breakpoint, rich blocks return to 100% width and controls disappear; tables retain inner horizontal scrolling instead of causing page overflow.
+
+## Implementation
+
+1. Parse and clamp `pruf_rich_width` in `DocumentsController#ui_prefs`, expose it in `DocumentProps`, and initialize a hydration-safe React state/CSS variable.
+2. Add a small Milkdown ProseMirror plugin that attaches a shared-width handle to sketch and table node views, observes newly mounted blocks, and emits page-level width change/commit/reset events.
+3. Add centered desktop breakout styles for live sketches/tables and their static-preview equivalents, plus mobile, print, focus, and table-scroll containment rules.
+4. Add integration tests for preference sanitization and a focused browser check for default breakout, drag/keyboard/reset persistence, table behavior, prose-width independence, read/edit modes, and 390px overflow safety.
+
+## Verification
+
+- Referenced production geometry improves from a 640px sketch at 1440px viewport to the 960px default without page overflow.
+- Rich-block drag and keyboard changes do not change `--document-width` or `pruf_width`.
+- Reload and another document use the saved rich width on first paint.
+- Wide tables use the breakout width and preserve `.table-wrapper` scrolling.
+- At 1024px, 768px, and 390px, rich blocks are 100% of the prose content box, handles are hidden, and page overflow is zero.
+- Full Rails, RuboCop, TypeScript, Vite builds, focused browser checks, PR CI, deploy, and production verification pass.

--- a/script/rich_block_width_check.mjs
+++ b/script/rich_block_width_check.mjs
@@ -1,0 +1,274 @@
+// Focused sketch/table breakout regression check using Playwright.
+// Usage: BASE_URL=http://localhost:3000 node script/rich_block_width_check.mjs
+import { chromium, request } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
+const failures = []
+const check = (condition, message, detail = '') => {
+  if (condition) {
+    console.log(`✓ ${message}`)
+  } else {
+    failures.push(message)
+    console.error(`✗ ${message}${detail ? `: ${detail}` : ''}`)
+  }
+}
+const closeTo = (actual, expected, tolerance = 2) => Math.abs(actual - expected) <= tolerance
+
+const sketch = {
+  id: 'rich_width_fixture',
+  formatVersion: 1,
+  description: 'A wide planning sketch',
+  height: 280,
+  scene: {
+    type: 'excalidraw',
+    version: 2,
+    elements: [],
+    appState: { viewBackgroundColor: '#fffef9' },
+    files: {},
+  },
+}
+const content = `# Rich block width check
+
+This prose should retain its comfortable reading measure.
+
+\`\`\`excalidraw
+${JSON.stringify(sketch)}
+\`\`\`
+
+| Workstream | Owner | Status | Detailed next action that should remain readable |
+| --- | --- | --- | --- |
+| ResearchAndSynthesisWithoutWrapping | Ada | Active | Compare the complete evidence set before review |
+| ProductAndEngineeringCoordination | Grace | Pending | Resolve the remaining interface constraints |
+`
+
+const api = await request.newContext({
+  baseURL: BASE,
+  extraHTTPHeaders: { 'X-Agent-Name': 'Rich block width check' },
+})
+const browser = await chromium.launch()
+const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } })
+const page = await context.newPage()
+const errors = []
+let slug
+
+page.on('pageerror', (error) => errors.push(error.stack ?? String(error)))
+page.on('console', (message) => {
+  if (message.type() === 'error') errors.push(message.text())
+})
+
+const liveGeometry = () => page.evaluate(() => {
+  const prose = document.querySelector('.doc-live-editor .ProseMirror')
+  const sketchBlock = document.querySelector('.thinkroom-sketch')
+  const tableBlock = document.querySelector('.milkdown-table-block')
+  const tableWrapper = tableBlock?.querySelector('.table-wrapper')
+  const rect = (node) => node?.getBoundingClientRect()
+  return {
+    prose: rect(prose),
+    sketch: rect(sketchBlock),
+    table: rect(tableBlock),
+    tableWrapper: rect(tableWrapper),
+    tableOverflow: tableWrapper ? getComputedStyle(tableWrapper).overflowX : null,
+    documentWidth: getComputedStyle(document.querySelector('.doc-page')).getPropertyValue('--document-width').trim(),
+    richWidth: getComputedStyle(document.querySelector('.doc-page')).getPropertyValue('--rich-content-width').trim(),
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }
+})
+
+try {
+  const created = await api.post('/api/docs', {
+    data: { title: 'Rich block width check', format: 'markdown', content },
+  })
+  check(created.ok(), 'created a temporary sketch-and-table document', String(created.status()))
+  slug = (await created.json()).slug
+
+  // Open the live editor first so this browser receives and persists the
+  // one-time seed claim. A JavaScript-disabled first visit would claim the
+  // seed without ever mounting Milkdown, leaving a second session empty.
+  await page.goto(`${BASE}/d/${slug}`)
+  await page.locator('.doc-status--live').waitFor({ timeout: 15_000 })
+  await page.locator('.thinkroom-sketch .rich-block-width-handle').waitFor({ timeout: 15_000 })
+  await page.locator('.milkdown-table-block .rich-block-width-handle').waitFor({ timeout: 15_000 })
+
+  const staticContext = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    javaScriptEnabled: false,
+  })
+  await staticContext.addCookies([{ name: 'pruf_rich_width', value: '1088', url: BASE }])
+  const staticPage = await staticContext.newPage()
+  await staticPage.goto(`${BASE}/d/${slug}`)
+  await staticPage.locator('.doc-static-preview .doc-sketch-skeleton').waitFor()
+  const staticGeometry = await staticPage.evaluate(() => ({
+    prose: document.querySelector('.doc-static-preview .ProseMirror')?.getBoundingClientRect().width ?? 0,
+    sketch: document.querySelector('.doc-sketch-skeleton')?.getBoundingClientRect().width ?? 0,
+    table: document.querySelector('.doc-static-preview table')?.getBoundingClientRect().width ?? 0,
+    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }))
+  check(
+    closeTo(staticGeometry.sketch, 1088) && closeTo(staticGeometry.table, 1088) && staticGeometry.prose < 700,
+    'server preview applies the saved rich width before the editor boots',
+    JSON.stringify(staticGeometry),
+  )
+  check(staticGeometry.overflow === 0, 'server preview has no horizontal page overflow')
+  await staticContext.close()
+
+  const initial = await liveGeometry()
+  check(
+    closeTo(initial.sketch.width, 960) && closeTo(initial.table.width, 960) && initial.prose.width < 700,
+    'read mode gives sketches and tables a shared 960px default',
+    JSON.stringify(initial),
+  )
+  check(initial.overflow === 0, 'default read layout has no horizontal page overflow')
+  check(
+    initial.tableOverflow === 'auto' && initial.tableWrapper.width <= initial.table.width,
+    'wide tables retain their contained horizontal scroll region',
+    JSON.stringify(initial),
+  )
+
+  const initialDocumentWidth = initial.documentWidth
+  const sketchHandle = page.locator('.thinkroom-sketch .rich-block-width-handle')
+  const handleBox = await sketchHandle.boundingBox()
+  if (!handleBox) throw new Error('Rich block handle has no geometry')
+  await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(handleBox.x + handleBox.width / 2 + 32, handleBox.y + handleBox.height / 2)
+  await page.mouse.up()
+  await page.waitForFunction(() => document.querySelector('.thinkroom-sketch')?.getBoundingClientRect().width > 1000)
+  const dragged = await liveGeometry()
+  check(
+    closeTo(dragged.sketch.width, 1024) && closeTo(dragged.table.width, 1024),
+    'dragging one handle resizes every rich block together',
+    JSON.stringify(dragged),
+  )
+  check(
+    await page.evaluate(() => document.cookie.includes('pruf_rich_width=1024')),
+    'drag completion persists the shared width',
+  )
+  await sketchHandle.dblclick()
+  await page.waitForFunction(() => Math.abs((document.querySelector('.thinkroom-sketch')?.getBoundingClientRect().width ?? 0) - 960) < 2)
+
+  await sketchHandle.focus()
+  await page.keyboard.press('ArrowLeft')
+  await page.waitForFunction(() => document.querySelector('.thinkroom-sketch')?.getBoundingClientRect().width < 950)
+  const keyed = await liveGeometry()
+  check(
+    closeTo(keyed.sketch.width, 928) && closeTo(keyed.table.width, 928),
+    'keyboard resizing updates every rich block together',
+    JSON.stringify(keyed),
+  )
+  check(keyed.documentWidth === initialDocumentWidth, 'rich resizing leaves the prose-width preference unchanged')
+
+  await page.reload()
+  await page.locator('.thinkroom-sketch .rich-block-width-handle').waitFor({ timeout: 15_000 })
+  const reloaded = await liveGeometry()
+  check(closeTo(reloaded.sketch.width, 928), 'saved rich width survives reload on first live paint', JSON.stringify(reloaded))
+
+  await page.locator('.thinkroom-sketch .rich-block-width-handle').dblclick()
+  await page.waitForFunction(() => Math.abs((document.querySelector('.thinkroom-sketch')?.getBoundingClientRect().width ?? 0) - 960) < 2)
+  check((await liveGeometry()).richWidth === '960px', 'double-click resets the shared width to its responsive default')
+
+  await page.goto(`${BASE}/d/${slug}/edit`)
+  await page.locator('.thinkroom-sketch .rich-block-width-handle').waitFor({ timeout: 15_000 })
+  const review = await liveGeometry()
+  check(
+    review.sketch.width > review.prose.width &&
+      closeTo(review.sketch.right, review.prose.right) &&
+      review.sketch.left >= 23,
+    'review layout expands left while keeping the suggestion-gutter edge aligned',
+    JSON.stringify(review),
+  )
+  const reviewHandle = page.locator('.thinkroom-sketch .rich-block-width-handle')
+  const handleSide = await reviewHandle.evaluate((node) => ({
+    handleLeft: node.getBoundingClientRect().left,
+    blockLeft: node.parentElement?.getBoundingClientRect().left ?? 0,
+  }))
+  check(
+    closeTo(handleSide.handleLeft, handleSide.blockLeft - 9),
+    'review layout puts the drag handle on the expanding edge',
+    JSON.stringify(handleSide),
+  )
+
+  await reviewHandle.focus()
+  await page.keyboard.press('ArrowRight')
+  await page.waitForFunction(
+    (before) => (document.querySelector('.thinkroom-sketch')?.getBoundingClientRect().width ?? 0) < before - 20,
+    review.sketch.width,
+  )
+  const reviewKeyed = await liveGeometry()
+  check(
+    closeTo(reviewKeyed.sketch.width, reviewKeyed.table.width) && closeTo(reviewKeyed.sketch.right, reviewKeyed.prose.right),
+    'review-mode keyboard resizing remains shared and gutter-safe',
+    JSON.stringify(reviewKeyed),
+  )
+
+  await reviewHandle.dblclick()
+  await page.evaluate(() => {
+    document.cookie = 'pruf_panel=1;path=/;samesite=lax'
+    document.cookie = 'pruf_focus=1;path=/;samesite=lax'
+  })
+  await page.reload()
+  await page.locator('.doc-canvas.is-focus .thinkroom-sketch').waitFor({ timeout: 15_000 })
+  const focused = await liveGeometry()
+  const focusedCenter = focused.sketch.left + focused.sketch.width / 2
+  const proseCenter = focused.prose.left + focused.prose.width / 2
+  check(
+    focused.sketch.width > focused.prose.width &&
+      closeTo(focusedCenter, proseCenter) &&
+      focused.sketch.left >= 23,
+    'focus mode centers the breakout without clipping beside the activity rail',
+    JSON.stringify(focused),
+  )
+
+  await page.evaluate(() => {
+    document.cookie = 'pruf_panel=0;path=/;samesite=lax'
+    document.cookie = 'pruf_focus=0;path=/;samesite=lax'
+  })
+  await page.reload()
+  await page.locator('.doc-page.is-panel-hidden .thinkroom-sketch').waitFor({ timeout: 15_000 })
+  const panelHidden = await liveGeometry()
+  check(
+    panelHidden.sketch.width > reviewKeyed.sketch.width &&
+      panelHidden.sketch.left >= 23 &&
+      closeTo(panelHidden.sketch.right, panelHidden.prose.right),
+    'hiding the activity rail releases its space without clipping the breakout',
+    JSON.stringify(panelHidden),
+  )
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.waitForTimeout(100)
+  const mobile = await liveGeometry()
+  const handleDisplay = await reviewHandle.evaluate((node) => getComputedStyle(node).display)
+  check(
+    closeTo(mobile.sketch.width, mobile.prose.width) && closeTo(mobile.table.width, mobile.prose.width),
+    'compact layouts return rich blocks to the prose width',
+    JSON.stringify(mobile),
+  )
+  check(handleDisplay === 'none' && mobile.overflow === 0, 'compact layouts hide handles without page overflow', JSON.stringify(mobile))
+  check(errors.length === 0, 'browser run completed without console errors', errors.join(' | '))
+} finally {
+  if (slug) {
+    try {
+      await page.setViewportSize({ width: 1440, height: 1000 })
+      await page.goto(`${BASE}/d/${slug}`)
+      const csrf = await page.locator('meta[name="csrf-token"]').getAttribute('content')
+      const headers = { 'X-CSRF-Token': csrf ?? '' }
+      const claimed = await context.request.post(`${BASE}/d/${slug}/claim`, {
+        form: { name: 'Rich block width check' },
+        headers,
+        maxRedirects: 0,
+      })
+      if (claimed.status() !== 303) throw new Error(`claim returned ${claimed.status()}`)
+      const removed = await context.request.delete(`${BASE}/d/${slug}`, { headers, maxRedirects: 0 })
+      if (removed.status() !== 303) throw new Error(`delete returned ${removed.status()}`)
+      const deleted = await api.get(`/api/docs/${slug}`)
+      check(deleted.status() === 404, 'deleted the temporary document')
+    } catch (error) {
+      failures.push('cleaned up the temporary document')
+      console.error(`✗ cleaned up the temporary document: ${error}`)
+    }
+  }
+  await context.close()
+  await browser.close()
+  await api.dispose()
+}
+
+if (failures.length > 0) process.exitCode = 1

--- a/test/integration/document_ui_preferences_test.rb
+++ b/test/integration/document_ui_preferences_test.rb
@@ -31,6 +31,31 @@ class DocumentUiPreferencesTest < ActionDispatch::IntegrationTest
     assert_inertia_props { |props| props.dig(:ui, :document_width).nil? }
   end
 
+  test "rich content width preference is exposed and clamped independently" do
+    cookies[:pruf_width] = "704"
+    cookies[:pruf_rich_width] = "1088"
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props.dig(:ui, :document_width) == 704 && props.dig(:ui, :rich_content_width) == 1088
+    end
+
+    cookies[:pruf_rich_width] = "20"
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props { |props| props.dig(:ui, :rich_content_width) == 640 }
+
+    cookies[:pruf_rich_width] = "9000"
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props { |props| props.dig(:ui, :rich_content_width) == 1200 }
+  end
+
+  test "invalid rich content width uses the responsive default" do
+    cookies[:pruf_rich_width] = "default"
+
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props { |props| props.dig(:ui, :rich_content_width).nil? }
+  end
+
   private
 
   def browser


### PR DESCRIPTION
## Summary

- let Excalidraw sketches and Markdown tables break out beyond the prose measure, defaulting to 960px on wide read surfaces
- add one accessible, viewer-level width preference shared by both block types, with drag, arrow-key, reset, and first-paint persistence
- keep review, focus, panel-hidden, print, and compact layouts viewport-safe without covering suggestion or activity lanes

## Verification

- `bundle exec rails test` (432 tests, 2,044 assertions)
- `bundle exec rubocop` (131 files, no offenses)
- `npm run check`
- `bin/vite build --clear --mode=test`
- `bin/vite build`
- focused Playwright coverage for SSR width, drag/keyboard/reset persistence, shared sketch/table sizing, read/review/focus/panel-hidden geometry, table scrolling, mobile containment, console errors, and cleanup
- agent-browser desktop read/edit visual and geometry inspection

Closes #94

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
