### PR TITLE
Make agent-start creation a primary home action

### DIFF
--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -315,8 +315,13 @@ a:focus-visible {
 .landing-actions {
   margin-top: 1.75rem;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   justify-content: center;
+}
+
+.landing-actions .btn {
+  min-height: 2.75rem;
 }
 
 /* ---------------------------- Document library -------------------------- */
@@ -657,62 +662,16 @@ a:focus-visible {
   }
 }
 
-/* --------------------------- Agent create card ---------------------------- */
+/* --------------------------- Agent create panel --------------------------- */
 .landing-agent {
-  margin-top: 2.5rem;
+  max-width: 36rem;
+  margin: 1rem auto 0;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--ink) 24%, var(--line));
+  border-radius: 12px;
+  background: var(--surface-raised);
+  box-shadow: 0 8px 24px rgb(38 28 16 / 7%);
   text-align: left;
-}
-
-.landing-agent-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem 0;
-  border-top: 1px solid color-mix(in srgb, var(--ink) 18%, var(--line));
-  border-bottom: 1px solid color-mix(in srgb, var(--ink) 18%, var(--line));
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-  font-weight: 650;
-  cursor: pointer;
-  list-style: none;
-}
-
-.landing-agent-summary::-webkit-details-marker {
-  display: none;
-}
-
-.landing-agent-summary:hover {
-  color: var(--ink);
-}
-
-.landing-agent-summary:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-}
-
-.landing-agent-summary-action {
-  margin-left: auto;
-  color: var(--ink-faint);
-  font-size: 0.68rem;
-  font-weight: 550;
-}
-
-.landing-agent-summary-action--open,
-.landing-agent:not([open]) .landing-agent-content {
-  display: none;
-}
-
-.landing-agent[open] .landing-agent-summary-action--closed {
-  display: none;
-}
-
-.landing-agent[open] .landing-agent-summary-action--open {
-  display: inline;
-}
-
-.landing-agent-content {
-  padding-top: 0.9rem;
 }
 
 .landing-agent-hint {
@@ -837,6 +796,19 @@ a:focus-visible {
 .btn-primary:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+.btn-agent {
+  border: 1px solid color-mix(in srgb, var(--ink) 50%, var(--line));
+  background: var(--surface-raised);
+  color: var(--ink);
+  box-shadow: 0 2px 7px rgb(38 28 16 / 8%);
+}
+
+.btn-agent:hover,
+.btn-agent[aria-expanded='true'] {
+  border-color: var(--ink);
+  background: color-mix(in srgb, var(--surface-raised) 82%, var(--accent-soft));
 }
 
 .btn-ghost {

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -221,6 +221,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     name: identityName,
   }))
   const [copied, setCopied] = useState(false)
+  const [agentInstructionsOpen, setAgentInstructionsOpen] = useState(false)
   const [selectedTag, setSelectedTag] = useState<string | null>(null)
   const [showAllEarlier, setShowAllEarlier] = useState(false)
   const isClient = useIsClient()
@@ -290,6 +291,16 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
               >
                 {processing ? 'Creating…' : 'New document'}
               </button>
+              <button
+                id="agent-start-trigger"
+                className="btn btn-agent"
+                type="button"
+                aria-expanded={agentInstructionsOpen}
+                aria-controls="agent-start-instructions"
+                onClick={() => setAgentInstructionsOpen((open) => !open)}
+              >
+                Have an agent start one
+              </button>
               {recent.some((document) => document.slug === 'demo') && (
                 <Link href="/d/demo" className="btn btn-ghost" prefetch>
                   Open the demo
@@ -297,6 +308,24 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
               )}
             </div>
           </header>
+
+          {agentInstructionsOpen && (
+            <section
+              id="agent-start-instructions"
+              className="landing-agent"
+              aria-labelledby="agent-start-trigger"
+            >
+              <p className="landing-agent-hint">
+                Paste this to any agent that can make HTTP requests:
+              </p>
+              <div className="landing-agent-block">
+                <code>{agentInstruction}</code>
+                <button className="share-copy" type="button" onClick={copyInstruction}>
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            </section>
+          )}
 
           <section className="document-library" aria-labelledby="your-documents-heading">
             <div className="document-library-heading">
@@ -364,28 +393,6 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
             </section>
           )}
 
-          <details className="landing-agent">
-            <summary className="landing-agent-summary">
-              <span>Have an agent start a doc</span>
-              <span className="landing-agent-summary-action landing-agent-summary-action--closed">
-                Show instructions
-              </span>
-              <span className="landing-agent-summary-action landing-agent-summary-action--open">
-                Hide instructions
-              </span>
-            </summary>
-            <div className="landing-agent-content">
-              <p className="landing-agent-hint">
-                Paste this to any agent that can make HTTP requests:
-              </p>
-              <div className="landing-agent-block">
-                <code>{agentInstruction}</code>
-                <button className="share-copy" onClick={copyInstruction}>
-                  {copied ? 'Copied' : 'Copy'}
-                </button>
-              </div>
-            </div>
-          </details>
         </main>
         <footer className="landing-footer">
           <a

--- a/docs/plans/2026-06-26-019-feat-prominent-agent-start-plan.md
+++ b/docs/plans/2026-06-26-019-feat-prominent-agent-start-plan.md
@@ -1,0 +1,75 @@
+---
+title: "feat: Make agent-start creation a primary home action"
+type: feat
+date: 2026-06-26
+issue: 96
+---
+
+# feat: Make agent-start creation a primary home action
+
+## Summary
+
+Put agent-start creation beside manual document creation in the home hero, while keeping the HTTP prompt behind one clear, reversible interaction.
+
+## Problem Frame
+
+Thinkroom is explicitly agent-native, but the home page currently hides “Have an agent start a doc” in a quiet disclosure below the document library. That hierarchy makes an agent-created document feel secondary even though the product strategy treats external agents and human judgment as peers in the workflow.
+
+## Requirements
+
+- R1. The home hero presents agent-start creation beside “New document” without requiring users to scan below the document library.
+- R2. The agent action has enough contrast and visual weight to read as a peer path while “New document” remains the solid primary action.
+- R3. Activating the agent action reveals the existing copyable HTTP instruction without creating a document or mutating the clipboard automatically.
+- R4. The trigger exposes its expanded state and controls relationship to assistive technology and works from the keyboard.
+- R5. The action row and instruction panel remain legible and free of horizontal overflow on narrow screens.
+- R6. Document grouping, tags, recents, account controls, feedback, and the agent API contract remain unchanged.
+
+## Assumptions
+
+- The concise hero label is “Have an agent start one”; the revealed panel provides the document and HTTP context.
+- The instruction begins closed so protocol detail does not compete with the two creation paths.
+- “Open the demo” remains a lower-emphasis optional third action.
+
+## Key Technical Decisions
+
+- KTD1. Use a React-controlled button and panel instead of moving the native disclosure intact. The trigger and content occupy separate hero-width regions, and explicit `aria-expanded`/`aria-controls` preserves accessible disclosure semantics.
+- KTD2. Give the agent action a bordered, raised treatment with the same sizing and typography as the primary action. This makes the path prominent without presenting two indistinguishable solid-primary buttons.
+- KTD3. Keep one instruction and copy implementation. Remove the old lower-page disclosure rather than exposing duplicate actions that can drift.
+- KTD4. Reveal before copying. Clipboard writes remain an explicit second action so the first click is predictable and permission-safe.
+
+## Implementation Units
+
+### U1. Promote agent-start creation into the hero
+
+- **Files:** `app/frontend/pages/documents/index.tsx`
+- **Approach:** Add controlled disclosure state, render the agent trigger beside “New document,” place the instruction panel immediately below the hero, and remove the old lower-page disclosure. Keep the existing instruction generation and copy feedback.
+- **Verification:** The top action is visible on first paint; it reports closed/open state; opening reveals one copyable prompt; manual creation and demo navigation still work.
+
+### U2. Establish a clear responsive hierarchy
+
+- **Files:** `app/frontend/entrypoints/application.css`
+- **Approach:** Add a high-contrast secondary action treatment and hero-adjacent panel styles. Let actions wrap and make the instruction block contain long protocol text at compact widths.
+- **Verification:** Desktop shows the two creation paths together; 390px layout has no clipping or horizontal overflow; focus indicators remain visible.
+
+### U3. Update landing regression coverage
+
+- **Files:** `script/browser_check.mjs`
+- **Approach:** Replace the bottom-disclosure assertions with checks for the hero-level agent action, initial collapsed state, accessible expansion, and visible copyable instructions.
+- **Verification:** The focused browser smoke check passes alongside TypeScript, Vite, Rails, and responsive browser checks.
+
+## Acceptance Examples
+
+- AE1. Given the home page, then “New document” and “Have an agent start one” are visible together before any document list.
+- AE2. Given the agent panel is closed, when its trigger is activated by pointer or keyboard, then the prompt appears and the trigger reports expanded state.
+- AE3. Given the prompt is visible, when Copy is activated, then the prompt is written to the clipboard and the control briefly confirms success.
+- AE4. Given a 390px viewport, then the action row and full instruction fit within the page without horizontal overflow.
+
+## Scope Boundaries
+
+- In scope: home-page prominence, disclosure behavior, responsive styling, and regression coverage.
+- Out of scope: changing the agent API payload, embedding an agent, adding a creation wizard, or redesigning the document library.
+
+## Sources
+
+- `STRATEGY.md` — agent-native work is an active product track; Thinkroom does not run an embedded agent.
+- `docs/plans/2026-06-26-009-feat-menu-home-ux-audit-plan.md` — prior hierarchy decision and the existing progressive-disclosure implementation that issue #96 intentionally revises.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -46,18 +46,28 @@ try {
   } else {
     fail('fresh home still renders an empty recently-opened section')
   }
-  const agentDisclosure = landing.locator('.landing-agent')
+  const agentStart = landing.getByRole('button', { name: 'Have an agent start one' })
+  const newDocument = landing.getByRole('button', { name: 'New document' })
   if (
-    !(await agentDisclosure.evaluate((el) => el.open)) &&
-    (await landing.locator('.landing-agent-content').evaluate((el) => getComputedStyle(el).display)) === 'none'
+    (await agentStart.isVisible()) &&
+    (await newDocument.isVisible()) &&
+    (await agentStart.getAttribute('aria-expanded')) === 'false' &&
+    (await landing.locator('#agent-start-instructions').count()) === 0
   ) {
-    ok('agent creation instructions are collapsed by default')
+    ok('human and agent creation paths are prominent while instructions start closed')
   } else {
-    fail('agent creation instructions compete with the primary home content')
+    fail('home does not present both creation paths with closed agent instructions')
   }
-  await landing.locator('.landing-agent-summary').click()
+  await agentStart.click()
   await landing.locator('.landing-agent-block').waitFor({ state: 'visible' })
-  ok('agent creation disclosure reveals the copyable instructions')
+  if ((await agentStart.getAttribute('aria-expanded')) === 'true') {
+    ok('agent creation action reveals the copyable instructions and reports its state')
+  } else {
+    fail('agent creation action does not report its expanded state')
+  }
+  await landing.locator('.landing-agent-block .share-copy').click()
+  await landing.locator('.landing-agent-block .share-copy', { hasText: 'Copied' }).waitFor()
+  ok('agent creation instructions provide explicit copy confirmation')
   if ((await landing.locator('.format-label').count()) === 0) {
     ok('landing page organizes documents without format labels')
   } else {


### PR DESCRIPTION
Closes #96

## Summary
- put “Have an agent start one” beside “New document” in the home hero
- reveal the existing HTTP prompt in an accessible, responsive panel
- remove the duplicate lower-page disclosure and strengthen browser coverage

## Verification
- `npm run --silent check`
- `bin/rubocop`
- `bin/vite build --clear --mode=test`
- `bin/rails test` (432 tests, 2,044 assertions)
- `bin/vite build`
- agent-browser desktop and 390px visual/interaction checks