### PR TITLE
Fix list replacements and selective Accept all

### DIFF
--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -48,8 +48,11 @@ class SuggestionsController < InertiaController
     # One name for both resolved_by and the activity row — two lookups with
     # different fallbacks silently diverge when no session name is set.
     by = preferred_name(params[:by], fallback: "Someone")
+    ids = if params.key?(:ids)
+      Array(params[:ids]).filter_map { |id| Integer(id, exception: false) }.uniq
+    end
     accepted = with_document_write_access(document) do
-      winners = Suggestion.accept_all!(document:, by:)
+      winners = Suggestion.accept_all!(document:, by:, ids:)
       if winners.any?
         Activity.log!(
           document:,

--- a/app/frontend/editor/suggestions.ts
+++ b/app/frontend/editor/suggestions.ts
@@ -1,5 +1,11 @@
 import { editorViewCtx, parserCtx, schemaCtx, type Editor } from '@milkdown/kit/core'
-import { Slice, type MarkType, type Node } from '@milkdown/kit/prose/model'
+import {
+  Fragment,
+  Slice,
+  type MarkType,
+  type Node,
+  type NodeType,
+} from '@milkdown/kit/prose/model'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import { SKIP_PROVENANCE } from './provenance'
 import {
@@ -112,49 +118,73 @@ function findTextRanges(doc: Node, search: string | null): { from: number; to: n
 
 const normalizeBlockText = (text: string): string => text.replace(/\s+/g, ' ').trim()
 
-/** Normalized plain text of each top-level block in a parsed fragment. */
-const blockTexts = (parsed: Node): string[] => {
-  const texts: string[] = []
-  parsed.forEach((child) => texts.push(normalizeBlockText(child.textContent)))
-  return texts
+const renderedBlockText = (node: Node): string =>
+  normalizeBlockText(node.textBetween(0, node.content.size, ' ', ' '))
+
+const isListNode = (node: Node): boolean =>
+  node.type.name === 'ordered_list' || node.type.name === 'bullet_list'
+
+interface StructuralRange {
+  from: number
+  to: number
+  kind: 'block' | 'list'
 }
 
 /**
- * First contiguous window of top-level doc blocks whose rendered text
- * matches `searchTexts` block-for-block (whitespace-normalized, full-block
- * equality). Returns the doc range spanning the window.
+ * Contiguous structural windows whose block-separated rendered text matches
+ * the agent-facing quote. Top-level windows cover section rewrites; partial
+ * list-child windows cover adjacent list items. A nested window containing
+ * every list item is excluded because the equivalent outer top-level list
+ * range is the replaceable unit that permits changing the list type.
  */
-function findBlockRanges(doc: Node, searchTexts: string[]): { from: number; to: number }[] {
-  if (searchTexts.length === 0 || searchTexts.every((t) => t === '')) return []
-  const blocks: { text: string; from: number; to: number }[] = []
-  doc.forEach((child, offset) => {
-    blocks.push({
-      text: normalizeBlockText(child.textContent),
-      from: offset,
-      to: offset + child.nodeSize,
+function findStructuralRanges(doc: Node, searchText: string): StructuralRange[] {
+  if (!searchText) return []
+  const results: StructuralRange[] = []
+
+  const visit = (parent: Node, contentStart: number) => {
+    const blocks: { text: string; from: number; to: number }[] = []
+    parent.forEach((child, offset) => {
+      const from = contentStart + offset
+      if (child.isBlock) {
+        blocks.push({
+          text: renderedBlockText(child),
+          from,
+          to: from + child.nodeSize,
+        })
+      }
+      if (child.childCount > 0) visit(child, from + 1)
     })
-  })
-  const results: { from: number; to: number }[] = []
-  for (let i = 0; i + searchTexts.length <= blocks.length; i += 1) {
-    let matched = true
-    for (let j = 0; j < searchTexts.length; j += 1) {
-      if (blocks[i + j].text !== searchTexts[j]) {
-        matched = false
-        break
+
+    const list = isListNode(parent)
+    if ((parent !== doc && !list) || blocks.length !== parent.childCount) return
+
+    for (let start = 0; start < blocks.length; start += 1) {
+      if (!blocks[start].text) continue
+      let text = ''
+      for (let end = start; end < blocks.length; end += 1) {
+        if (list && start === 0 && end === blocks.length - 1) continue
+        text = normalizeBlockText(`${text} ${blocks[end].text}`)
+        if (text.length > searchText.length) break
+        if (text === searchText && blocks[end].text) {
+          results.push({
+            from: blocks[start].from,
+            to: blocks[end].to,
+            kind: list ? 'list' : 'block',
+          })
+        }
       }
     }
-    if (matched) {
-      results.push({ from: blocks[i].from, to: blocks[i + searchTexts.length - 1].to })
-    }
   }
+
+  visit(doc, 0)
   return results
 }
 
 interface MatchedRange {
   from: number
   to: number
-  /** 'inline' = within one textblock; 'block' = a window of whole blocks. */
-  kind: 'inline' | 'block'
+  /** Inline text, top-level blocks, or a partial window of sibling list items. */
+  kind: 'inline' | 'block' | 'list'
 }
 
 // Parsing a quote is deterministic for a given source string, and the margin
@@ -197,6 +227,21 @@ const uniqueMatch = (
   return { status: 'matched', range: { ...ranges[0], kind } }
 }
 
+const uniqueStructuralMatch = (ranges: StructuralRange[]): MatchResult => {
+  if (ranges.length === 0) return { status: 'missing' }
+  if (ranges.length > 1) return { status: 'ambiguous' }
+  return { status: 'matched', range: ranges[0] }
+}
+
+const listReplacementContent = (parsed: Node, listItemType: NodeType | undefined) => {
+  if (parsed.childCount === 1 && parsed.firstChild && isListNode(parsed.firstChild)) {
+    return parsed.firstChild.content
+  }
+  if (!listItemType) return null
+  const item = listItemType.createAndFill(null, parsed.content)
+  return item ? Fragment.from(item) : null
+}
+
 /**
  * Locate suggestion-quoted text in the document. Agents quote the markdown
  * SOURCE they read from the API (`### Heading`, `**bold**`, `\~` escapes),
@@ -221,7 +266,9 @@ function matchQuotedText(
   const parsed = parseQuote(parser, cacheScope, search)
   if (!parsed || parsed.content.size === 0) return { status: 'missing' }
 
-  const block = uniqueMatch(findBlockRanges(doc, blockTexts(parsed)), 'block')
+  const block = uniqueStructuralMatch(
+    findStructuralRanges(doc, renderedBlockText(parsed)),
+  )
   if (block.status !== 'missing') return block
 
   // Source-styled inline quote (e.g. `**Date:** 2026` or `<strong>Date:</strong>`)
@@ -278,6 +325,12 @@ export function suggestionApplicability(
       const match = matchQuotedText(view.state.doc, parser, format, suggestion.replaces)
       if (match.status === 'ambiguous') return { ok: false, reason: 'ambiguous' }
       if (match.status === 'missing') return { ok: false, reason: 'missing' }
+      if (
+        match.range.kind === 'list' &&
+        !listReplacementContent(parsed, view.state.schema.nodes.list_item)
+      ) {
+        return { ok: false, reason: 'empty' }
+      }
     }
     return { ok: true }
   })
@@ -334,6 +387,12 @@ export function applySuggestion(
       tr = tr.replaceWith(target.from, target.to, inline)
       insertFrom = target.from
       insertTo = target.from + inline.size
+    } else if (target && target.kind === 'list') {
+      const replacement = listReplacementContent(parsed, state.schema.nodes.list_item)
+      if (!replacement) return
+      tr = tr.replaceWith(target.from, target.to, replacement)
+      insertFrom = target.from
+      insertTo = target.from + replacement.size
     } else if (target && target.kind === 'block') {
       tr = tr.replaceWith(target.from, target.to, parsed.content)
       insertFrom = target.from

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -170,6 +170,9 @@ const capAnchor = (text: string): string => {
   return new TextDecoder().decode(bytes.slice(0, ANCHOR_BYTE_CAP)).replace(/�+$/, '')
 }
 
+const skippedSuggestionNotice = (count: number): string =>
+  `${count} suggestion${count === 1 ? '' : 's'} skipped because the target is missing, ambiguous, or empty; ${count === 1 ? 'it remains' : 'they remain'} pending for individual review.`
+
 export default function DocumentShow({
   document: doc,
   viewer,
@@ -822,33 +825,46 @@ export default function DocumentShow({
     [acceptOne],
   )
 
-  // Accept all pending suggestions in ONE round trip: the server flips the
-  // batch atomically and returns the winners, then the bodies merge into
-  // the CRDT locally in id order — each merge re-anchors against the
+  // Accept all applicable suggestions in ONE round trip: the server flips
+  // the selected rows atomically and returns the winners, then the bodies
+  // merge into the CRDT locally in id order — each merge re-anchors against the
   // post-merge document, exactly as if the cards were clicked one by one,
   // minus the per-card network wait. Cards hide optimistically while the
   // request is in flight; the broadcast-driven props reload makes the
   // clearing durable, and a failed request lets the cards reappear.
-  const [acceptingAll, setAcceptingAll] = useState(false)
+  const [acceptingSuggestionIds, setAcceptingSuggestionIds] = useState<Set<number>>(
+    () => new Set(),
+  )
+  const acceptingAll = acceptingSuggestionIds.size > 0
   const acceptAllSuggestions = useCallback(async () => {
     if (acceptingAll || !handleRef.current) return
     const pending = suggestionsRef.current.filter((s) => s.id > 0)
     if (pending.length === 0) return
-    const blocked = pending.find(
-      (suggestion) =>
-        !suggestionApplicability(handleRef.current!.editor, suggestion, doc.content_format).ok,
-    )
-    if (blocked) {
-      setSuggestionNotice(
-        'Accept all paused because at least one suggestion has a missing, ambiguous, or empty target. Review that suggestion individually.',
+    const applicable: SuggestionPayload[] = []
+    const blocked: SuggestionPayload[] = []
+    for (const suggestion of pending) {
+      const result = suggestionApplicability(
+        handleRef.current.editor,
+        suggestion,
+        doc.content_format,
       )
+      if (result.ok) {
+        applicable.push(suggestion)
+      } else {
+        blocked.push(suggestion)
+      }
+    }
+    if (applicable.length === 0) {
+      setSuggestionNotice(skippedSuggestionNotice(blocked.length))
       return
     }
-    setAcceptingAll(true)
+    setSuggestionNotice(null)
+    setAcceptingSuggestionIds(new Set(applicable.map((suggestion) => suggestion.id)))
     let succeeded = false
     try {
       const response = await patchJSON(`/d/${doc.slug}/suggestions/accept_all`, {
         by: identity.name,
+        ids: applicable.map((suggestion) => suggestion.id),
       })
       if (response.ok) {
         const { accepted } = (await response.json()) as { accepted: SuggestionPayload[] }
@@ -883,15 +899,20 @@ export default function DocumentShow({
             }
           }
         }
+        const notices: string[] = []
+        if (blocked.length > 0) {
+          notices.push(skippedSuggestionNotice(blocked.length))
+        }
         if (reopenFailed > 0) {
-          setSuggestionNotice(
+          notices.push(
             `${reopenFailed} suggestion${reopenFailed === 1 ? '' : 's'} could not be restored to pending after the document changed. Refresh before reviewing again.`,
           )
         } else if (reopened > 0) {
-          setSuggestionNotice(
+          notices.push(
             `${reopened} suggestion${reopened === 1 ? '' : 's'} changed before merging and returned to pending.`,
           )
         }
+        setSuggestionNotice(notices.length > 0 ? notices.join(' ') : null)
         succeeded = true
       } else {
         console.warn('pruf: accept all rejected', response.status)
@@ -907,20 +928,20 @@ export default function DocumentShow({
         router.reload({
           only: ['suggestions', 'activities'],
           async: true,
-          onFinish: () => setAcceptingAll(false),
+          onFinish: () => setAcceptingSuggestionIds(new Set()),
         })
       } else {
         // Failure: release immediately so the cards reappear (rollback).
-        setAcceptingAll(false)
+        setAcceptingSuggestionIds(new Set())
       }
     }
   }, [acceptingAll, doc.slug, doc.content_format, identity.name, reopenSuggestion])
 
   // Optimistic clearing for the bulk path: server-backed cards vanish the
   // moment Accept all is clicked; optimistic placeholders (negative ids,
-  // not part of the batch) stay visible.
+  // not part of the batch) and blocked suggestions stay visible.
   const visibleSuggestions = acceptingAll
-    ? suggestions.filter((s) => s.id < 0)
+    ? suggestions.filter((s) => !acceptingSuggestionIds.has(s.id))
     : suggestions
 
   const rejectSuggestion = useCallback(

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -69,15 +69,16 @@ class Suggestion < ApplicationRecord
     reload
   end
 
-  # Batch accept for the Accept-all button: flips every pending suggestion
-  # in one transaction (one fsync instead of N round-trips) and returns the
-  # rows that actually transitioned, in id order. A suggestion resolved
-  # concurrently by a single accept loses its pending status and is simply
+  # Batch accept for the Accept-all button: flips the selected pending rows,
+  # or every pending row when ids are omitted, in one transaction. A row
+  # resolved concurrently by a single accept loses its pending status and is
   # excluded — the caller only merges winners, so no text applies twice.
-  def self.accept_all!(document:, by: nil)
+  def self.accept_all!(document:, by: nil, ids: nil)
     winners = []
     document.transaction do
-      document.suggestions.pending.order(:id).each do |suggestion|
+      pending = document.suggestions.pending
+      pending = pending.where(id: ids) unless ids.nil?
+      pending.order(:id).each do |suggestion|
         suggestion.accept!(by:)
         winners << suggestion
       rescue ActiveRecord::RecordInvalid

--- a/docs/plans/2026-06-26-020-fix-list-replacements-accept-all-plan.md
+++ b/docs/plans/2026-06-26-020-fix-list-replacements-accept-all-plan.md
@@ -1,0 +1,84 @@
+---
+title: "fix: Apply list replacements without jamming Accept all"
+type: fix
+date: 2026-06-26
+issue: 98
+---
+
+# fix: Apply list replacements without jamming Accept all
+
+## Summary
+
+Make browser suggestion matching honor the same space-separated rendered text agents receive, including adjacent list items, and let Accept all merge applicable suggestions while leaving invalid targets pending.
+
+## Problem Frame
+
+The agent API exposes a `plain_text` projection that separates rendered text nodes with spaces. It therefore permits a unique quote spanning multiple list items. Browser acceptance only searches within one textblock or across top-level document blocks, so that valid quote is reported missing. Accept all then aborts its entire preflight when any one row is missing, ambiguous, or empty.
+
+## Requirements
+
+- R1. A unique `replaces` quote spanning adjacent list items resolves against the live editor document.
+- R2. Replacing a subset of list items preserves a valid surrounding list, and replacing a whole list can change its list type, including ordered-list to task-list conversion.
+- R3. Existing inline and top-level multi-block replacement behavior remains unchanged.
+- R4. Missing, ambiguous, or empty targets remain pending and never mutate document content.
+- R5. Accept all submits and merges applicable suggestions even when other pending suggestions are blocked, and reports that blocked rows remain for individual review.
+- R6. The server transitions only the applicable IDs selected by the accepting client while preserving compare-and-set concurrency, one activity entry, and one suggestions broadcast.
+- R7. Accepted list content keeps the existing author provenance and persists across reload.
+
+## Assumptions
+
+- The browser remains the applicability authority because only it has the current collaborative ProseMirror/Yjs state.
+- A plain-text body replacing part of a list becomes one list item; a list-shaped body contributes its list items to the existing parent list.
+- A window covering an entire list resolves to the outer list node so a replacement may change ordered, bullet, or task-list structure.
+
+## Key Technical Decisions
+
+- KTD1. Match normalized rendered text windows at two structural levels: top-level document children and partial sibling windows inside list nodes. Use ProseMirror’s block-separated text projection so nested list text receives the spaces present in the agent API projection.
+- KTD2. Prefer the outer top-level node for a whole-list match by excluding a nested window that covers every child. This makes list-type conversions replace the list container instead of trying to insert one list inside another.
+- KTD3. Mark partial list windows separately from top-level block windows. The apply path can then wrap paragraph-shaped bodies as list items or reuse list-shaped bodies’ items, maintaining schema-valid content.
+- KTD4. Add optional suggestion IDs to the existing bulk endpoint. Omitting IDs retains the endpoint’s current all-pending behavior, while an explicit empty list accepts none.
+- KTD5. Keep create-time validation structural-neutral. Rails cannot reliably validate against a live collaborative document snapshot, and rejecting a quote that is valid in the current editor would create a second, stale applicability authority.
+
+## Implementation Units
+
+### U1. Reproduce the list-target failures
+
+- **Files:** `script/suggestion_list_replace_check.mjs`
+- **Approach:** Create disposable documents through the local agent API. Cover a partial adjacent-item replacement, a whole ordered-list to task-list conversion, and a bulk batch containing one unrelated valid suggestion plus one missing target.
+- **Verification:** The focused check fails on current `main` because the list targets pause or fail to apply.
+
+### U2. Align browser matching and list replacement
+
+- **Files:** `app/frontend/editor/suggestions.ts`
+- **Approach:** Replace top-level-only block matching with normalized structural-window matching. Return a list-window match kind for partial list children and adapt parsed replacement content to the list-item schema before dispatch.
+- **Verification:** Partial list replacement yields the intended remaining items; whole-list conversion renders task checkboxes; duplicate or missing quotes remain unapplied.
+
+### U3. Make bulk acceptance selective
+
+- **Files:** `app/frontend/pages/documents/show.tsx`, `app/controllers/suggestions_controller.rb`, `app/models/suggestion.rb`, `test/integration/suggestion_flow_test.rb`
+- **Approach:** Partition pending rows by live applicability, send applicable IDs, transition only those rows, keep blocked cards visible/pending, and show a concise skipped-target notice after successful merges. Preserve the no-ID compatibility path and compare-and-set loop.
+- **Verification:** Integration tests cover selected IDs, explicit empty IDs, omitted IDs, and cross-document exclusion. The focused browser check accepts valid rows while the blocked row remains.
+
+## Acceptance Examples
+
+- AE1. Given three ordered-list items, replacing the second and third items’ `plain_text` with “Merged item” leaves an ordered list containing the first item and the merged item.
+- AE2. Given an ordered list, replacing all item text with Markdown task items yields task checkboxes and removes the ordered list.
+- AE3. Given one applicable paragraph edit and one missing target, Accept all applies the paragraph edit, leaves the missing suggestion pending, and explains that one row was skipped.
+- AE4. Given a quote that occurs in two lists, acceptance treats it as ambiguous and changes neither list.
+
+## Scope Boundaries
+
+- In scope: Markdown/HTML rendered-text matching parity, list-window application, selective bulk transition, notices, and regression coverage.
+- Out of scope: server-side parsing of the live Yjs state, changing the public suggestion-create response, automatically rejecting stale suggestions, or resolving overlapping valid suggestions as a dependency graph.
+
+## Risks
+
+- Structural matches at multiple depths can create false ambiguity. Whole-container matches must suppress the equivalent all-children nested candidate.
+- Partial list replacement must produce content valid for the current list parent before the transaction dispatches.
+- The document can still change after preflight. The existing reopen compensation remains required for that collaboration race.
+
+## Sources
+
+- GitHub issue #98 and production repro document `4PzFN1Y2Pj`.
+- `app/services/document_plain_text.rb` — canonical agent-facing space-separated projection.
+- `docs/plans/2026-06-08-001-fix-suggestion-replace-duplication-plan.md` — prior quote-matching and no-duplicate acceptance constraints.

--- a/script/suggestion_list_replace_check.mjs
+++ b/script/suggestion_list_replace_check.mjs
@@ -1,0 +1,165 @@
+import { chromium } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+  console.log(`✓ ${message}`)
+}
+
+const createDocument = async (title, content) => {
+  const response = await fetch(`${BASE}/api/docs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Agent-Name': 'list-check' },
+    body: JSON.stringify({ title, format: 'markdown', content }),
+  })
+  assert(response.status === 201, `created ${title}`)
+  return response.json()
+}
+
+const propose = async (slug, payload) => {
+  const response = await fetch(`${BASE}/api/docs/${slug}/suggestions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Agent-Name': 'list-check' },
+    body: JSON.stringify(payload),
+  })
+  assert(response.status === 201, `proposed ${payload.intent}`)
+}
+
+const waitForEditor = async (page, slug) => {
+  await page.goto(`${BASE}/d/${slug}/edit`)
+  await page.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await page.waitForSelector('.milkdown .ProseMirror')
+  await page.waitForTimeout(500)
+}
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } })
+const errors = []
+page.on('pageerror', (error) => errors.push(String(error)))
+page.on('console', (message) => {
+  if (message.type() === 'error') errors.push(message.text())
+})
+
+try {
+  const partial = await createDocument(
+    'Partial list replacement check',
+    '# Partial list\n\n1. First item alpha.\n2. Second item beta.\n3. Third item gamma.\n',
+  )
+  await propose(partial.slug, {
+    intent: 'merge adjacent items',
+    replaces: 'Second item beta. Third item gamma.',
+    body: 'Merged second and third item.',
+  })
+
+  await waitForEditor(page, partial.slug)
+  await page.locator('.margin-card', { hasText: 'merge adjacent items' }).locator('.btn-accept').click()
+  await page.waitForFunction(
+    () => {
+      const items = [...document.querySelectorAll('.milkdown .ProseMirror ol > li')]
+        .map((item) => item.textContent?.trim())
+      return items.length === 2 &&
+        items[0] === 'First item alpha.' &&
+        items[1] === 'Merged second and third item.'
+    },
+    undefined,
+    { timeout: 10000 },
+  )
+  assert(true, 'partial plain-text list replacement preserves a valid two-item ordered list')
+
+  const ambiguous = await createDocument(
+    'Ambiguous list replacement check',
+    '# Ambiguous lists\n\n1. Shared item one.\n2. Shared item two.\n\nA separator.\n\n1. Shared item one.\n2. Shared item two.\n',
+  )
+  await propose(ambiguous.slug, {
+    intent: 'ambiguous duplicate lists',
+    replaces: 'Shared item one. Shared item two.',
+    body: 'This must not replace either list.',
+  })
+
+  await waitForEditor(page, ambiguous.slug)
+  await page.locator('.margin-card', { hasText: 'ambiguous duplicate lists' }).locator('.btn-accept').click()
+  await page.waitForFunction(
+    () => {
+      const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
+      const notice = document.querySelector('.doc-notice')?.textContent ?? ''
+      return document.querySelectorAll('.milkdown .ProseMirror ol').length === 2 &&
+        text.split('Shared item one.').length === 3 &&
+        !text.includes('This must not replace either list.') &&
+        document.querySelectorAll('.margin-card').length === 1 &&
+        notice.includes('appears more than once')
+    },
+    undefined,
+    { timeout: 10000 },
+  )
+  assert(true, 'duplicate list text remains ambiguous and unapplied')
+
+  const bulk = await createDocument(
+    'Bulk list replacement check',
+    '# Bulk list\n\nControl sentence stays.\n\n1. First item alpha.\n2. Second item beta.\n3. Third item gamma.\n',
+  )
+  await propose(bulk.slug, {
+    intent: 'update control paragraph',
+    replaces: 'Control sentence stays.',
+    body: 'Updated control sentence.',
+  })
+  await propose(bulk.slug, {
+    intent: 'convert ordered list to tasks',
+    replaces: 'First item alpha. Second item beta. Third item gamma.',
+    body: '- [ ] First item alpha.\n- [ ] Second item beta.\n- [ ] Third item gamma.',
+  })
+  await propose(bulk.slug, {
+    intent: 'stale target remains pending',
+    replaces: 'A target that does not exist.',
+    body: 'This must not be inserted.',
+  })
+
+  await waitForEditor(page, bulk.slug)
+  await page.locator('.accept-all-button').click()
+  await page.waitForFunction(
+    () => {
+      const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
+      const pendingCards = [...document.querySelectorAll('.margin-card')]
+      const notice = document.querySelector('.doc-notice')?.textContent?.toLowerCase() ?? ''
+      return text.includes('Updated control sentence.') &&
+        !text.includes('Control sentence stays.') &&
+        !text.includes('This must not be inserted.') &&
+        document.querySelectorAll('.milkdown .ProseMirror li[data-item-type="task"] input[type="checkbox"]').length === 3 &&
+        pendingCards.length === 1 &&
+        pendingCards[0]?.textContent?.includes('stale target remains pending') &&
+        notice.includes('skipped')
+    },
+    undefined,
+    { timeout: 15000 },
+  )
+  assert(true, 'Accept all applies paragraph and list changes while reporting one skipped target')
+
+  await page.waitForTimeout(1500)
+  await page.reload()
+  await page.waitForSelector('.doc-status--live', { timeout: 15000 })
+  await page.waitForFunction(
+    () => {
+      const text = document.querySelector('.milkdown .ProseMirror')?.textContent ?? ''
+      return text.includes('Updated control sentence.') &&
+        document.querySelectorAll('.milkdown .ProseMirror li[data-item-type="task"] input[type="checkbox"]').length === 3 &&
+        document.querySelectorAll('.milkdown .ProseMirror li[data-item-type="task"] [data-provenance][data-kind="ai"][data-author="list-check"]').length === 3 &&
+        document.querySelectorAll('.margin-card').length === 1
+    },
+    undefined,
+    { timeout: 10000 },
+  )
+  assert(true, 'selective bulk acceptance and task-list conversion persist across reload')
+
+  const fatalErrors = errors.filter(
+    (error) =>
+      !error.includes('ReactDOMClient.createRoot()') &&
+      !error.includes('Hydration failed because the server rendered'),
+  )
+  assert(
+    fatalErrors.length === 0,
+    `browser console stays clean${fatalErrors.length ? `: ${fatalErrors.join('; ')}` : ''}`,
+  )
+  console.log('\nAll list replacement checks passed.')
+} finally {
+  await browser.close()
+}

--- a/test/integration/suggestion_flow_test.rb
+++ b/test/integration/suggestion_flow_test.rb
@@ -272,6 +272,34 @@ class SuggestionFlowTest < ActionDispatch::IntegrationTest
     assert_equal "Earlier Window", @suggestion.reload.resolved_by
   end
 
+  test "accept_all with ids transitions only the selected pending suggestions" do
+    second = @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "b")
+    third = @document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "c")
+    other_document = Document.create!(title: "Other")
+    foreign = other_document.suggestions.create!(author_name: "Scout", author_kind: "agent", body: "d")
+
+    patch accept_all_document_suggestions_path(@document.slug),
+          params: { by: "Quiet Falcon", ids: [ second.id, third.id, foreign.id ] }, as: :json
+
+    assert_response :success
+    assert_equal [ second.id, third.id ], response.parsed_body["accepted"].map { |row| row["id"] }
+    assert_equal "pending", @suggestion.reload.status
+    assert_equal %w[accepted accepted], [ second, third ].map { |row| row.reload.status }
+    assert_equal "pending", foreign.reload.status
+    assert_includes @document.activities.last.detail, "2 suggestions"
+  end
+
+  test "accept_all with an explicit empty id list accepts nothing" do
+    assert_no_difference -> { @document.activities.count } do
+      patch accept_all_document_suggestions_path(@document.slug),
+            params: { ids: [] }, as: :json
+    end
+
+    assert_response :success
+    assert_empty response.parsed_body["accepted"]
+    assert_equal "pending", @suggestion.reload.status
+  end
+
   test "accept_all with nothing pending returns an empty list and logs no activity" do
     @suggestion.reject!
 


### PR DESCRIPTION
## Summary

- match suggestion targets across adjacent list items using the same rendered-text projection exposed to agents
- preserve valid list structure for partial replacements and allow whole-list type conversions such as ordered lists to task lists
- let Accept all merge applicable suggestions while leaving missing, ambiguous, or empty targets pending
- add selected-ID server support and focused integration/browser regression coverage

## Validation

- `bin/rails test` — 434 runs, 2057 assertions, 0 failures
- `bin/rubocop` — 131 files, no offenses
- `npm run --silent check` — TypeScript and CLI checks pass
- `bin/vite build --clear --mode=test`
- `bin/vite build`
- `BASE_URL=http://localhost:3002 node script/suggestion_list_replace_check.mjs`
- agent-browser visual and persisted-state verification

Closes #98