### PR TITLE
Document safe Kamal deployment prerequisites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@
 
 # Deploying
 
-- Production runs on [Kamal](https://kamal-deploy.org/) (hosts: `thinkroom.kieranklaassen.com`, `pruf.kieranklaassen.com`). Deploy with `set -a; source .kamal/deploy.env; set +a; bin/kamal deploy`. See `DEPLOYING.md` for first-time setup and secrets.
+- Production runs on [Kamal](https://kamal-deploy.org/) (hosts: `thinkroom.kieranklaassen.com`, `pruf.kieranklaassen.com`). See `DEPLOYING.md` for first-time setup, secrets, and the complete deploy procedure.
+- Always run Kamal with the Ruby version from `.ruby-version`, not macOS's system Ruby/Bundler: `export PATH="$HOME/.rbenv/versions/$(cat .ruby-version)/bin:$PATH"` before `bin/kamal` commands.
+- Isolated worktrees do not inherit ignored deployment files. Before deploying from one, verify that `.kamal/deploy.env`, `.kamal/secrets`, and `config/master.key` exist and are non-empty; copy them from the primary checkout if needed without printing their contents.
 - There is no auto-deploy on merge — deploys are run manually after merging to `main`.
 
 # Documented knowledge

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -51,15 +51,32 @@ https://thinkroom.kieranklaassen.com/auth/google_oauth2/callback
 https://pruf.kieranklaassen.com/auth/google_oauth2/callback
 ```
 
-Both local files are ignored by Git. Never commit registry tokens, the Rails
-master key, SSH private keys, or production `.env` files.
+These local deployment files are ignored by Git. Never commit registry tokens,
+the Rails master key, SSH private keys, or production `.env` files.
 
 ## Deploy
 
-Load the non-secret deployment identifiers into the shell, validate the
-rendered configuration, and deploy:
+Run Kamal with the project Ruby from `.ruby-version`. macOS's system Ruby and
+Bundler cannot parse this application's Gemfile platforms and will fail before
+the deploy starts.
+
+An isolated Git worktree does not inherit ignored files from the primary
+checkout. Before deploying from a worktree, copy `.kamal/deploy.env`,
+`.kamal/secrets`, and `config/master.key` into it, then verify that all three are
+non-empty without printing their contents:
 
 ```bash
+test -s .kamal/deploy.env
+test -s .kamal/secrets
+test -s config/master.key
+```
+
+Load the non-secret deployment identifiers, validate the rendered
+configuration, and deploy:
+
+```bash
+export PATH="$HOME/.rbenv/versions/$(cat .ruby-version)/bin:$PATH"
+
 set -a
 source .kamal/deploy.env
 set +a


### PR DESCRIPTION
## Summary
- force Kamal to use the Ruby version declared by the project
- verify ignored deployment inputs before deploying from an isolated worktree
- keep secret values out of verification output

## Verification
- `git diff --check`
- production smoke checks passed after deploying `aa0b290`