### PR TITLE
fix: add docs API index

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -3,6 +3,17 @@ module Api
     rate_limit_document_creation
     rate_limit_document_update
 
+    # GET /api/docs — API entry point plus the authenticated account's docs.
+    def index
+      render json: {
+        documents: index_documents.map { |doc| index_document_response(doc) },
+        api: {
+          create_document: AgentGuide.create_document_endpoint(request.base_url)
+        },
+        notes: index_notes
+      }
+    end
+
     # POST /api/docs — create a typed source document, get back its slug.
     def create
       content = params[:content].presence
@@ -104,6 +115,30 @@ module Api
     end
 
     private
+
+    def index_documents
+      return Document.none unless current_api_user
+
+      current_api_user.documents.order(created_at: :desc).limit(50)
+    end
+
+    def index_document_response(doc)
+      {
+        slug: doc.slug,
+        title: doc.title,
+        share_url: document_page_url(doc.slug),
+        api_url: api_doc_url(doc.slug),
+        content_format: doc.content_format,
+        created_at: doc.created_at.iso8601,
+        updated_at: doc.updated_at.iso8601
+      }
+    end
+
+    def index_notes
+      return [ "Authenticated with a Thinkroom CLI token; documents are scoped to that account." ] if current_api_user
+
+      [ "Send a Bearer token from `thinkroom login` to list account documents. Anonymous requests can still create documents with POST /api/docs." ]
+    end
 
     # A well-formed request that conflicts with the document's current state: a
     # human has claimed or started editing it, so the live document — not the

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -141,21 +141,7 @@ class AgentGuide
                       success_status: 204,
                       body: { last_event_id: "(required) the ack_with value from poll_events" },
                       purpose: "Advance your event cursor." },
-        create_document: { method: "POST", url: "#{base_url}/api/docs",
-                           headers: { "X-Agent-Name": "recommended", "Content-Type": "application/json" },
-                           success_status: 201,
-                           rate_limits: document_creation_rate_limits,
-                           body: { title: "(optional)", format: "markdown | html", content: "(required with explicit format; canonical source)" },
-                           limits: { content_max_bytes: Document::MAX_CONTENT_BYTES },
-                           content_contracts: {
-                             markdown: content_contract("markdown", base_url),
-                             html: content_contract("html", base_url)
-                           },
-                           returns: { slug: "Document identifier", share_url: "Browser/editor URL",
-                                      content_format: "Immutable markdown or html", content: "Canonical source",
-                                      plain_text: "Rendered text", normalized: "Whether source changed during normalization",
-                                      content_contract: "Machine-readable source, HTML, CSS, and image rules" },
-                           purpose: "Create a new shared document. X-Agent-Name is recommended for seed attribution but creation also permits an unattributed request." },
+        create_document: create_document_endpoint(base_url),
         update_document: { method: "PATCH", url: api_base,
                            headers: { "X-Agent-Name": "recommended", "Content-Type": "application/json" },
                            success_status: 200,
@@ -170,6 +156,24 @@ class AgentGuide
                                       normalized: "Whether source changed during normalization", warning: "Normalization detail" },
                            purpose: "Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has opened it to edit). Once a human starts editing, the live collaborative document is authoritative: this returns 409, and you propose a suggestion instead." }
       }
+    end
+
+    def create_document_endpoint(base_url)
+      { method: "POST", url: "#{base_url}/api/docs",
+        headers: { "X-Agent-Name": "recommended", "Content-Type": "application/json" },
+        success_status: 201,
+        rate_limits: document_creation_rate_limits,
+        body: { title: "(optional)", format: "markdown | html", content: "(required with explicit format; canonical source)" },
+        limits: { content_max_bytes: Document::MAX_CONTENT_BYTES },
+        content_contracts: {
+          markdown: content_contract("markdown", base_url),
+          html: content_contract("html", base_url)
+        },
+        returns: { slug: "Document identifier", share_url: "Browser/editor URL",
+                   content_format: "Immutable markdown or html", content: "Canonical source",
+                   plain_text: "Rendered text", normalized: "Whether source changed during normalization",
+                   content_contract: "Machine-readable source, HTML, CSS, and image rules" },
+        purpose: "Create a new shared document. X-Agent-Name is recommended for seed attribution but creation also permits an unattributed request." }
     end
 
     def content_contract(format, base_url)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     end
 
     post "uploads", to: "uploads#create"
+    get "docs", to: "docs#index"
     post "docs", to: "docs#create"
     get "docs/:slug", to: "docs#show", as: :doc
     patch "docs/:slug", to: "docs#update"

--- a/docs/plans/2026-06-27-001-fix-api-docs-index-plan.md
+++ b/docs/plans/2026-06-27-001-fix-api-docs-index-plan.md
@@ -1,0 +1,77 @@
+---
+title: "fix: Add API docs index"
+type: fix
+date: 2026-06-27
+---
+
+# fix: Add API docs index
+
+## Summary
+
+`GET /api/docs` currently falls through to a 404 even though the API exposes `POST /api/docs` and document-specific `GET /api/docs/:slug` endpoints. This plan adds a collection read endpoint that helps agents discover accessible documents and the canonical creation contract without weakening document ownership rules.
+
+## Problem Frame
+
+The root document UI lists a viewer's documents and recent browser documents, while the agent API is document-specific after creation. A direct fetch of `/api/docs` should be a valid API entry point instead of an unhelpful 404. The fix should stay aligned with Thinkroom's agent-native strategy and avoid exposing a global document list.
+
+## Requirements
+
+- R1. `GET /api/docs` returns HTTP 200 with a JSON payload instead of 404.
+- R2. The response includes the current caller's account documents when authenticated with a valid CLI bearer token.
+- R3. Anonymous callers do not receive a global document listing.
+- R4. The response exposes the existing `POST /api/docs` creation contract so agents can recover from fetching the collection URL.
+- R5. Integration coverage verifies authenticated listing and anonymous non-leak behavior.
+
+## Key Technical Decisions
+
+- **Collection reads are scoped to the authenticated API user:** `Api::BaseController` already resolves CLI bearer tokens into `current_api_user`; the index action should use that identity and return an empty `documents` array without a token. This avoids inventing global or cookie-backed API discovery.
+- **Document summaries stay shallow:** The collection payload should include identifiers and links such as `slug`, `title`, `share_url`, `api_url`, `content_format`, and timestamps, not full document content. Full live state remains `GET /api/docs/:slug`.
+- **Reuse the existing API contract source:** The creation contract already lives in `AgentGuide.endpoints`; the index action should expose the `create_document` entry from that helper rather than duplicating request schema text.
+
+## Scope Boundaries
+
+- This plan does not add pagination or search. The existing UI caps document lists at 50, and the API index can follow the same practical bound.
+- This plan does not expose guest browser recents because `ActionController::API` does not carry the browser session/cookie ownership model.
+- This plan does not change `POST /api/docs`, `GET /api/docs/:slug`, or document write permissions.
+
+## Implementation Units
+
+### U1. Add the API collection read
+
+**Goal:** Route `GET /api/docs` to an index action that returns a scoped JSON entry point.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:** `config/routes.rb`, `app/controllers/api/docs_controller.rb`
+
+**Approach:** Add the GET route before the slug route. Implement `Api::DocsController#index` using `current_api_user&.documents&.order(created_at: :desc)&.limit(50)` and serialize shallow document summaries with `request.base_url` links. Include `api.create_document` from `AgentGuide.endpoints` using a representative document where needed, or extract a smaller helper if implementation shows that cleaner.
+
+**Test Scenarios:** Authenticated CLI token returns only that user's documents; anonymous `GET /api/docs` succeeds with an empty `documents` array and still includes the create-document contract; documents owned by another user are omitted.
+
+**Verification:** `bin/rails test test/integration/agent_api_test.rb`
+
+### U2. Cover collection endpoint behavior
+
+**Goal:** Add focused integration tests to lock the new collection contract.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:** `test/integration/agent_api_test.rb`
+
+**Approach:** Reuse the existing agent API integration test setup and CLI token model helpers already present in the suite. Assert response shape, URL paths, ownership scoping, and absence of unrelated documents.
+
+**Test Scenarios:** The endpoint returns 200 for anonymous requests; authenticated requests include account documents with `/d/:slug` and `/api/docs/:slug` URLs; documents for other users do not appear.
+
+**Verification:** `bin/rails test test/integration/agent_api_test.rb`
+
+## Sources & Research
+
+- `config/routes.rb` defines `POST /api/docs` and `GET/PATCH /api/docs/:slug`, but no collection GET route.
+- `app/controllers/api/docs_controller.rb` centralizes create/show/update behavior for agent documents.
+- `app/controllers/api/base_controller.rb` authenticates CLI bearer tokens and exposes `current_api_user`.
+- `app/services/agent_guide.rb` owns the machine-readable agent endpoint contract.
+- `app/controllers/documents_controller.rb` demonstrates the existing 50-document cap and account-scoped document ordering for the browser index.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -12,6 +12,51 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     @document = Document.create!(title: "Shared Doc", seed_markdown: "# Hello\n\nA paragraph about provenance.")
   end
 
+  test "docs index is an anonymous API entry point without leaking documents" do
+    get "/api/docs", headers: AGENT, as: :json
+
+    assert_response :success
+    body = response.parsed_body
+    assert_equal [], body["documents"]
+    assert_equal "POST", body.dig("api", "create_document", "method")
+    assert_equal "/api/docs", URI(body.dig("api", "create_document", "url")).path
+    assert body["notes"].any? { |note| note.include?("Bearer token") }
+  end
+
+  test "docs index lists only bearer token account documents" do
+    user = User.create!(
+      name: "Kieran",
+      email: "kieran@example.com",
+      password: "password1234",
+      password_confirmation: "password1234"
+    )
+    other_user = User.create!(
+      name: "Other",
+      email: "other@example.com",
+      password: "password1234",
+      password_confirmation: "password1234"
+    )
+    older = Document.create!(title: "Older", user:, content_format: "markdown", seed_content: "# Older")
+    newer = Document.create!(title: "Newer", user:, content_format: "html", seed_content: "<h1>Newer</h1>")
+    Document.create!(title: "Other Account", user: other_user)
+    _token, raw_token = CliAccessToken.issue!(user:, name: "Test terminal")
+
+    get "/api/docs",
+        headers: AGENT.merge("Authorization" => "Bearer #{raw_token}"),
+        as: :json
+
+    assert_response :success
+    documents = response.parsed_body["documents"]
+    slugs = documents.pluck("slug")
+    assert_equal [ newer.slug, older.slug ], slugs
+    assert_equal "Newer", documents.first["title"]
+    assert_equal "html", documents.first["content_format"]
+    assert_equal "/d/#{newer.slug}", URI(documents.first["share_url"]).path
+    assert_equal "/api/docs/#{newer.slug}", URI(documents.first["api_url"]).path
+    refute_includes slugs, @document.slug
+    assert response.parsed_body["notes"].any? { |note| note.include?("scoped to that account") }
+  end
+
   test "agent creates a document from markdown and gets a shareable slug" do
     post "/api/docs",
          params: { title: "Agent Doc", content: "# From an agent" },


### PR DESCRIPTION
## Summary

Fetching `/api/docs` now returns a useful agent API entry point instead of a 404. Anonymous callers get the creation contract without seeing any documents, while CLI-authenticated callers get a shallow list of only their account-owned documents with links to the browser and document API state endpoints.

The create-document contract is shared with existing document state responses, so agents see one source of truth for how to create docs from either `/api/docs` or `/api/docs/:slug` guidance.

## Validation

- `bin/rubocop`
- `bin/rails test test/integration/agent_api_test.rb`
- `bin/rails db:migrate` for the local development database before browser smoke testing
- `agent-browser open http://localhost:3000/api/docs` plus a JSON contract check confirming `documents` and `api.create_document.method == "POST"`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
