### PR TITLE
CLI: owner should be able to update their own claimed documents directly

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -59,14 +59,17 @@ module Api
     end
 
     # PATCH/PUT /api/docs/:slug — revise a document's seed in place while it is
-    # still an unclaimed draft. Same slug, same share URL, so the link the agent
-    # already shared keeps working. The moment a human gets involved — claiming
-    # the document, or opening it so an editor snapshot / live CRDT exists — the
-    # live document is authoritative and the seed is no longer what readers see.
-    # A seed write there would 200 while changing nothing, so this returns 409
-    # and points the agent at suggestions instead of lying about success.
+    # still a seed-stage draft. Same slug, same share URL, so the link already
+    # shared keeps working. Two audiences can write the seed: an unclaimed draft
+    # (the agent/anonymous flow) and the authenticated CLI account that owns the
+    # document — an owner must never be locked out of revising their own draft
+    # just because creating it claimed it. The seed_stage gate still applies to
+    # both: once an editor snapshot / live CRDT exists, the live document is
+    # authoritative and the seed is no longer what readers see, so a seed write
+    # would 200 while changing nothing. That case returns 409 and routes the
+    # caller to the right next action instead of lying about success.
     def update
-      return render_update_conflict unless document.seed_stage? && document.claimable?
+      return render_update_conflict unless document.seed_stage? && updatable_in_place?
 
       requested_format = request.request_parameters["format"].presence
       if requested_format && requested_format != document.content_format
@@ -140,11 +143,32 @@ module Api
       [ "Send a Bearer token from `thinkroom login` to list account documents. Anonymous requests can still create documents with POST /api/docs." ]
     end
 
-    # A well-formed request that conflicts with the document's current state: a
-    # human has claimed or started editing it, so the live document — not the
-    # seed — is authoritative. Teach the agent the correct next action rather
-    # than failing opaquely or silently no-opping a seed write.
+    # A seed-stage document is revisable in place by the agent/anonymous flow
+    # while it is still unclaimed, or by the authenticated CLI account that owns
+    # it. seed_stage? is checked separately and always required.
+    def updatable_in_place?
+      document.claimable? || owner_via_cli_token?
+    end
+
+    # True only when a valid CLI Bearer token's account owns a document that can
+    # be individually owned. Account ownership only (owned_by? with user:) — the
+    # CLI authenticates as an account, so a guest owner_token cookie is
+    # irrelevant. The unclaimable? guard keeps a permanently shared document
+    # (the demo) out of this path even if a future code path ever assigned it an
+    # owner, rather than relying on that invariant holding elsewhere.
+    def owner_via_cli_token?
+      current_api_user.present? && !document.unclaimable? &&
+        document.owned_by?(nil, user: current_api_user)
+    end
+
+    # A well-formed request that conflicts with the document's current state.
+    # The owner reaches it only past the seed stage (an editor session made the
+    # live CRDT authoritative); everyone else also lands here on a claimed or
+    # collaboratively edited document. Teach the correct next action rather than
+    # failing opaquely or silently no-opping a seed write.
     def render_update_conflict
+      return render_owner_update_conflict if owner_via_cli_token?
+
       revision_workflow = AgentGuide.revision_workflow(document, request.base_url)
       steps = revision_workflow.fetch(:steps).index_by { |step| step.fetch(:action) }
       render json: {
@@ -154,6 +178,20 @@ module Api
         propose_suggestion: steps.fetch("propose_targeted_suggestion").fetch(:url),
         resolve_comment: steps.fetch("resolve_addressed_comment").fetch(:url),
         revision_workflow:
+      }, status: :conflict
+    end
+
+    # The owner's own document has progressed past the seed stage: an editor
+    # session made the live Yjs/CRDT state authoritative, so a full replacement
+    # through this endpoint would change nothing readers see. Replacing live
+    # collaborative content server-side is intentionally not offered (it would
+    # clobber live edits), so route the owner to the browser editor — where they
+    # have full edit access — with suggestions as a secondary option.
+    def render_owner_update_conflict
+      render json: {
+        error: "You own this document, but it is now a live collaborative document — its editor (Yjs/CRDT) state is authoritative, so a full replacement here would change nothing readers see. Edit it directly in the browser, or propose a suggestion.",
+        edit_in_browser: document_page_url(document.slug),
+        propose_suggestion: AgentGuide.endpoints(document, request.base_url).fetch(:propose_suggestion).fetch(:url)
       }, status: :conflict
     end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -113,7 +113,12 @@ class Document < ApplicationRecord
 
   def claimed? = user_id.present? || owner_token.present?
 
-  def claimable? = !claimed? && UNCLAIMABLE_SLUGS.exclude?(slug)
+  # Permanently shared documents (the demo) that must never be owned, claimed,
+  # or replaced by a single party — claiming's only power is delete, and
+  # deleting the demo would take it away from everyone.
+  def unclaimable? = UNCLAIMABLE_SLUGS.include?(slug)
+
+  def claimable? = !claimed? && !unclaimable?
 
   # Never true for blank tokens — the delete-authorization predicate must not
   # match an unclaimed doc against a missing cookie.

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -154,7 +154,7 @@ class AgentGuide
                            returns: { slug: "Unchanged identifier", share_url: "Unchanged share URL",
                                       content: "Updated canonical source", plain_text: "Updated rendered text",
                                       normalized: "Whether source changed during normalization", warning: "Normalization detail" },
-                           purpose: "Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has opened it to edit). Once a human starts editing, the live collaborative document is authoritative: this returns 409, and you propose a suggestion instead." }
+                           purpose: "Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has opened it to edit). An authenticated owner (CLI Bearer token) can revise their own document this way even after it is claimed, as long as it is still seed-stage. Once a human starts editing, the live collaborative document is authoritative: this returns 409, and you propose a suggestion instead." }
       }
     end
 
@@ -263,7 +263,7 @@ class AgentGuide
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
         "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
-        "Updating: PATCH /api/docs/:slug rewrites your document's seed in place — same slug, same share URL — so revisions stay at the link you already shared, as long as no human has started editing. Once an editor takes over you get a 409: from then on, propose suggestions, which is how every edit to a live document works.",
+        "Updating: PATCH /api/docs/:slug rewrites your document's seed in place — same slug, same share URL — so revisions stay at the link you already shared, as long as no human has started editing. An authenticated owner (a Bearer token from `thinkroom login`) can keep updating their own document this way even after it is claimed, while it is still seed-stage. Once an editor takes over you get a 409: from then on, propose suggestions, which is how every edit to a live document works.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported. To author one in Markdown, embed a fenced excalidraw block following content_contract.sketches.markdown_source (formatVersion, id, description, height, and a full excalidraw scene with type/version/appState/files) — copy its example to start. A recognized sketch shows in plain_text as \"Sketch: <description> — <labels>\"; raw scene JSON in plain_text means the block was not recognized, and the create response then returns normalized: true with a warning.",
@@ -412,9 +412,11 @@ class AgentGuide
              -H "X-Agent-Name: YOUR_NAME" -H "Content-Type: application/json" \\
              -d '{"title": "Revised", "content": "..."}'
         format is immutable; omit it or send the document's existing format.
-        Once a human starts editing, the live collaborative document becomes
-        authoritative and PATCH returns 409 — from then on, propose a
-        suggestion instead.
+        If you authenticate with a Bearer token (thinkroom login) and own the
+        document, you can keep updating it in place even after it is claimed,
+        while it is still seed-stage. Once a human starts editing, the live
+        collaborative document becomes authoritative and PATCH returns 409 —
+        from then on, propose a suggestion instead.
 
         HTML is sanitized and normalized to Thinkroom's editable schema. Create and
         suggestion responses include normalized=true plus a warning when

--- a/cli/skill/thinkroom/SKILL.md
+++ b/cli/skill/thinkroom/SKILL.md
@@ -37,13 +37,15 @@ Read live state before changing anything:
 thinkroom show SHARE_URL --json
 ```
 
-For a document that is still an untouched agent seed, revise it in place:
+For a document that is still an untouched seed, revise it in place:
 
 ```bash
 thinkroom update SHARE_URL revision.md --title "Updated title" --agent "Codex"
 ```
 
-Once a person has claimed or edited the document, do not overwrite the seed. Propose the smallest exact replacement and include intent:
+If you are logged in (`thinkroom login`) and own the document, you can update it in place this way even after it is claimed — being the owner is not a lock-out. The seed stage is the only constraint: updating works until a human opens the document in the browser and starts a live editing session.
+
+Once the document has a live editing session — a collaborator has opened it in the browser, so its live state is authoritative — do not try to overwrite it from the CLI. Owners edit a live document directly in the browser; otherwise propose the smallest exact replacement and include intent:
 
 ```bash
 thinkroom suggest SHARE_URL \

--- a/docs/plans/2026-06-27-002-fix-cli-owner-update-claimed-docs-plan.md
+++ b/docs/plans/2026-06-27-002-fix-cli-owner-update-claimed-docs-plan.md
@@ -1,0 +1,299 @@
+---
+title: "fix: Let an authenticated CLI owner update their own claimed seed-stage document"
+type: fix
+status: active
+date: 2026-06-27
+origin: https://github.com/kieranklaassen/thinkroom/issues/112
+---
+
+# fix: Let an authenticated CLI owner update their own claimed seed-stage document
+
+## Summary
+
+`PATCH /api/docs/:slug` (the `thinkroom update` CLI command) gates on
+`document.seed_stage? && document.claimable?`. Because an authenticated
+`thinkroom new` immediately sets `user_id` (ownership), the document is no
+longer `claimable?`, so the very next `thinkroom update` returns `409 Conflict`
+— the owner is locked out of their own draft. This fix recognizes the
+authenticated CLI account as the owner and lets it revise its own document in
+place while the document is still seed-stage, even though the document is
+claimed.
+
+The fix deliberately keeps the existing `seed_stage?` boundary: once a human
+has opened the document in a browser and the live Yjs/CRDT state has taken
+over, the seed is no longer what readers see and a server-side overwrite of
+live CRDT state is explicitly outside the product's identity (see origin plan
+`docs/plans/2026-06-25-002-feat-patch-api-docs-update-plan.md`, "Outside this
+product's identity"). For that case the suggestion workflow remains, but the
+conflict message is made ownership-aware so the owner is told to edit in the
+browser rather than being told "a human has claimed it" (which is themselves).
+
+---
+
+## Problem Frame
+
+**Who:** A person using the `thinkroom` CLI while authenticated (`thinkroom login`).
+
+**What's broken:** After `thinkroom new` (which claims the document to the
+account) the owner cannot `thinkroom update` it — the endpoint rejects the
+update because the document is no longer `claimable?`. The only offered path is
+`thinkroom suggest`, which makes the owner propose and then accept a suggestion
+to themselves.
+
+**Why it matters:** Owners should not be locked out of revising their own
+unopened drafts. The suggestion workflow is for collaborative documents others
+have edited, not for an owner revising their own seed.
+
+**The constraint that shapes the solution:** `Api::DocsController#update` uses
+two orthogonal gates:
+- `claimable?` (`!claimed? && slug not in UNCLAIMABLE_SLUGS`) — an *ownership*
+  gate. This is what wrongly blocks the owner.
+- `seed_stage?` (`content_snapshot.nil? && yjs_state.blank?`) — a *CRDT-safety*
+  gate. A seed write once an editor has taken over is a silent no-op, so this
+  must stay. Server-side mutation of live CRDT state is out of scope by design.
+
+Authentication already exists: `Api::BaseController#authenticate_cli_bearer`
+sets `current_api_user` from the Bearer token. `Document#owned_by?(token, user:)`
+already encodes account ownership. The update action simply never consults them.
+
+---
+
+## Requirements
+
+- **R1.** When the request carries a valid CLI Bearer token whose account owns
+  the document (`document.owned_by?(nil, user: current_api_user)`), and the
+  document is still `seed_stage?`, `PATCH /api/docs/:slug` performs the normal
+  in-place seed update and returns `200`, even though the document is claimed
+  (`claimable?` is false).
+- **R2.** All existing behavior is preserved: an anonymous/agent request
+  (no Bearer) on a claimed document still returns `409`; a Bearer request from
+  an account that does *not* own the document still returns `409`; any request
+  on a past-seed-stage document (`yjs_state` or `content_snapshot` present)
+  still returns `409`.
+- **R3.** `UNCLAIMABLE_SLUGS` (the demo) can never be updated through this path —
+  the demo is unowned, so the ownership branch must not accidentally permit it.
+- **R4.** When an owner does hit the `409` (their document has progressed past
+  seed stage), the conflict response is ownership-aware: it explains the live
+  document is authoritative and points the owner at editing in the browser,
+  instead of telling them "a human has claimed it."
+- **R5.** Owner-update attribution and side effects match the existing update
+  path (seed re-attribution when `X-Agent-Name` is sent, `updated_document`
+  activity, rate limiting, format-immutability, byte cap).
+- **R6.** Agent-facing discovery (`AgentGuide`) and the CLI skill doc are
+  updated so the new capability is accurate and discoverable, without claiming
+  server-side live-CRDT replacement.
+- **R7.** Integration coverage proves R1–R4.
+
+---
+
+## Key Technical Decisions
+
+- **KTD-1 — Relax only the ownership gate, never the seed-stage gate.** The fix
+  adds an "owner OR claimable" branch while keeping `seed_stage?` mandatory.
+  This resolves the lock-out (the reported bug) without touching live CRDT
+  state, honoring the documented product identity.
+- **KTD-2 — Ownership is account-based via the Bearer token.** Use
+  `current_api_user.present? && document.owned_by?(nil, user: current_api_user)`.
+  Guest (`owner_token` cookie) ownership is intentionally not matched: the CLI
+  authenticates as an account, and a guest-owned doc is not owned by that
+  account. This also keeps the demo (`UNCLAIMABLE_SLUGS`, unowned) protected.
+- **KTD-3 — No CLI code change.** `thinkroom update` already attaches the Bearer
+  token (`request(..., useToken: true)`), so an authenticated owner's update
+  already sends identity; only the server must honor it.
+- **KTD-4 — Ownership-aware conflict, not a new endpoint or status.** When the
+  owner hits the seed-stage boundary, keep `409` but branch the body to explain
+  the live-document situation and point at the browser editor (the owner has
+  full edit access there). Non-owner/agent conflicts are unchanged.
+
+---
+
+## High-Level Technical Design
+
+Updated gate for `PATCH /api/docs/:slug`:
+
+```mermaid
+flowchart TD
+    A[PATCH /api/docs/:slug] --> S{seed_stage?}
+    S -- no, editor took over --> CFLICT{request owns doc?}
+    S -- yes --> O{claimable? OR owner-via-CLI?}
+    O -- no --> CFLICT
+    O -- yes --> WRITE[update seed + title + attribution -> 200]
+    CFLICT -- yes, owner --> C409O[409: live document is authoritative,<br/>edit in the browser]
+    CFLICT -- no, agent/other --> C409A[409: existing suggestion workflow]
+```
+
+Ownership predicate used at both branch points:
+`current_api_user.present? && document.owned_by?(nil, user: current_api_user)`.
+
+---
+
+## Implementation Units
+
+### U1. Recognize the authenticated owner in the update gate
+
+**Goal:** Let an authenticated owner update their own seed-stage document.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** none
+
+**Files:**
+- `app/controllers/api/docs_controller.rb`
+- `test/integration/agent_api_test.rb`
+
+**Approach:**
+- Add a private predicate (e.g. `owner_via_cli_token?`) returning
+  `current_api_user.present? && document.owned_by?(nil, user: current_api_user)`.
+- Change the gate from `document.seed_stage? && document.claimable?` to
+  `document.seed_stage? && (document.claimable? || owner_via_cli_token?)`.
+- Leave the rest of `#update` (format immutability, byte cap, normalization,
+  attribution, activity, response) untouched — owners flow through the same
+  path so attribution and side effects match (R5).
+
+**Patterns to follow:** `Document#owned_by?`, the browser controller's
+ownership checks (`DocumentsController#update_tags`, `#destroy`), and
+`current_api_user` from `Api::BaseController`.
+
+**Test scenarios (in `test/integration/agent_api_test.rb`):**
+1. Authenticated owner PATCHes their own claimed seed-stage doc with new content
+   → `200`, `current_content` updated, slug/share_url unchanged. *Covers R1.*
+2. Authenticated owner title-only update on their claimed doc → `200`, content
+   untouched. *Covers R1.*
+3. Owner update re-attributes the seed to the sent `X-Agent-Name` and logs an
+   `updated_document` activity. *Covers R5.*
+4. Bearer token from a *different* account on a claimed doc → `409`, seed
+   untouched. *Covers R2.*
+5. Authenticated owner on a doc with `yjs_state` present → `409`, seed
+   untouched (seed-stage gate still applies to owners). *Covers R2.*
+6. Authenticated owner on a doc with `content_snapshot` present (yjs blank) →
+   `409`. *Covers R2.*
+7. Existing "update returns 409 once a human has claimed the document"
+   (owner_token + agent header, no Bearer) stays green. *Covers R2.*
+8. Demo / unclaimable slug is not updatable even with a Bearer token (no owner
+   match). *Covers R3.*
+
+**Verification:** New tests pass; the seed for a past-seed-stage doc is never
+written; only the owning account unlocks the claimed-but-seed-stage update.
+
+### U2. Make the update conflict ownership-aware
+
+**Goal:** When an owner hits the seed-stage boundary, return a `409` that
+explains the live document is authoritative and to edit it in the browser,
+rather than "a human has claimed it."
+
+**Requirements:** R4
+
+**Dependencies:** U1
+
+**Files:**
+- `app/controllers/api/docs_controller.rb`
+- `test/integration/agent_api_test.rb`
+
+**Approach:**
+- In `render_update_conflict`, branch on `owner_via_cli_token?`. For the owner,
+  return a concise body: error stating the live collaborative document is
+  authoritative, the `share_url` to edit in the browser, and the suggestions
+  URL as a secondary option. For non-owners, keep the existing
+  `AgentGuide.revision_workflow`-based body verbatim (no regression).
+- Keep the HTTP status `409` in both cases.
+
+**Patterns to follow:** existing `render_update_conflict`,
+`AgentGuide.endpoints`/`revision_workflow`, `document_page_url`.
+
+**Test scenarios:**
+1. Authenticated owner PATCHing their past-seed-stage doc → `409` whose body
+   names the live-document situation and includes the browser share URL.
+   *Covers R4.*
+2. Non-owner/agent conflict body is unchanged (still includes
+   `revision_workflow`, `propose_suggestion`, `read_state`). *Covers R2/R4.*
+
+**Verification:** Owner sees actionable, accurate guidance; the agent contract
+is byte-for-byte unchanged for non-owners.
+
+### U3. Update agent-guide and CLI skill documentation
+
+**Goal:** Keep the discoverable contract honest: an authenticated owner can
+revise their own claimed seed-stage document; live documents still route to
+suggestions; no server-side live-CRDT replacement is promised.
+
+**Requirements:** R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/services/agent_guide.rb` (the `update_document` endpoint `purpose`, and
+  the update note if needed)
+- `cli/skill/thinkroom/SKILL.md`
+- `test/integration/agent_api_test.rb` and/or `test/integration/agent_discovery_test.rb`
+  only if an existing assertion pins the exact wording
+
+**Approach:**
+- Lightly extend the `update_document` `purpose` to note that an authenticated
+  owner may revise their own claimed document while it is seed-stage; the
+  seed-stage boundary and 409-to-suggestions behavior are unchanged.
+- Update `cli/skill/thinkroom/SKILL.md` so the "Work with an existing document"
+  section reflects that the owner can update their own document directly while
+  it is seed-stage (no human has opened it), and that suggestions are for
+  collaborative documents others have edited.
+- Adjust any test that asserts the exact endpoint `purpose` string.
+
+**Patterns to follow:** existing `AgentGuide` voice; the existing SKILL.md
+"update vs suggest" guidance.
+
+**Test scenarios:**
+- Test expectation: covered by existing discovery tests — if a test pins the
+  `update_document` purpose substring, update that assertion to match; no new
+  behavior test required for doc text.
+
+**Verification:** `bin/rails test` discovery tests pass; the CLI skill no longer
+tells an owner to avoid updating their own claimed document.
+
+---
+
+## Scope Boundaries
+
+**In scope:** Server-side recognition of the authenticated CLI owner for
+seed-stage in-place updates; ownership-aware conflict messaging; doc/contract
+text.
+
+**Outside this product's identity (do not build):** Server-side mutation or
+reset of live `yjs_state` / `content_markdown` to push a CLI "full replacement"
+into an open collaborative editor. This is explicitly forbidden by
+`docs/plans/2026-06-25-002` and risks clobbering live edits in connected
+browsers. The owner edits live documents in the browser (they have full edit
+access) or proposes suggestions.
+
+### Deferred to Follow-Up Work
+- A safe owner-initiated "reset this live document to new content" flow (would
+  require an epoch/generation guard in the Yjs sync path plus a forced
+  client reload). Only worth building if owners report the browser-edit and
+  suggestion paths are insufficient.
+
+---
+
+## Risks & Dependencies
+
+- **Risk — accidentally permitting non-owners or the demo.** Mitigation: gate
+  strictly on `current_api_user` + `owned_by?(nil, user:)`; the demo is unowned
+  so it cannot match. Explicit negative tests (different account, demo).
+- **Risk — wording-pinned discovery tests break.** Mitigation: search for
+  assertions on the `update_document` purpose / notes and update them in U3.
+- **Risk — conflict-message regression for agents.** Mitigation: branch only
+  for owners; assert the non-owner body is unchanged.
+
+No external dependencies or migrations. All touched code is in-repo and covered
+by `bin/rails test`.
+
+---
+
+## Sources & Research
+
+- Origin issue: https://github.com/kieranklaassen/thinkroom/issues/112
+- `app/controllers/api/docs_controller.rb` — `#update`, `render_update_conflict`.
+- `app/controllers/api/base_controller.rb` — `authenticate_cli_bearer`, `current_api_user`.
+- `app/models/document.rb` — `seed_stage?`, `claimable?`, `claimed?`, `owned_by?`.
+- `app/models/cli_access_token.rb` — Bearer token issue/authenticate.
+- `app/services/agent_guide.rb` — endpoint/notes/text discovery surface.
+- `docs/plans/2026-06-25-002-feat-patch-api-docs-update-plan.md` — seed-stage update + "do not mutate live CRDT" identity.
+- `docs/plans/2026-06-25-004-fix-claimed-document-revision-workflow-plan.md` — claimed-document revision workflow / conflict contract.
+- `test/integration/agent_api_test.rb`, `test/integration/cli_authentication_flow_test.rb` — test patterns.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -747,6 +747,164 @@ class AgentApiTest < ActionDispatch::IntegrationTest
                  "a claimed document's seed must not be overwritable through the agent API"
   end
 
+  # --- owner-authenticated updates of their own claimed document ---
+
+  test "authenticated owner updates their own claimed seed-stage document in place" do
+    user = cli_user(email: "owner-update@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:, name: "Owner terminal")
+    doc = Document.create!(title: "Draft", user:, owner_name: user.name, seed_content: "# First cut")
+    refute doc.claimable?, "creating it while authenticated claims it to the account"
+
+    patch "/api/docs/#{doc.slug}",
+          params: { title: "Revised", content: "# Second cut\n\nBetter now." },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :ok
+    body = response.parsed_body
+    assert_equal doc.slug, body["slug"], "slug stays stable across an owner update"
+    assert_equal "Revised", body["title"]
+    assert_includes body["content"], "Second cut"
+
+    doc.reload
+    assert_equal "Revised", doc.title
+    assert_includes doc.current_content, "Second cut"
+    assert_equal "updated_document", doc.activities.last.action
+    assert_equal "Scout", doc.activities.last.actor_name
+    assert_equal "Scout", doc.seed_author_name, "an owner update re-attributes the seed to the sender"
+  end
+
+  test "authenticated owner can rename their own claimed seed-stage document" do
+    user = cli_user(email: "owner-rename@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(title: "Draft", user:, owner_name: user.name, seed_content: "# Body stays")
+
+    patch "/api/docs/#{doc.slug}",
+          params: { title: "Renamed" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :ok
+    doc.reload
+    assert_equal "Renamed", doc.title
+    assert_includes doc.current_content, "Body stays"
+  end
+
+  test "a bearer token from a non-owner account cannot update a claimed document" do
+    owner = cli_user(email: "owner-real@example.com")
+    other = cli_user(email: "owner-impostor@example.com", name: "Other")
+    _record, raw_token = CliAccessToken.issue!(user: other)
+    doc = Document.create!(title: "Theirs", user: owner, owner_name: owner.name, seed_content: "# Owner content")
+
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# not yours" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_includes response.parsed_body["error"], "no longer an unclaimed draft"
+    assert_equal "# Owner content", doc.reload.seed_content,
+                 "another account's bearer token must not overwrite a claimed document"
+  end
+
+  test "owner update past the seed stage returns an ownership-aware conflict" do
+    user = cli_user(email: "owner-live@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Live", user:, owner_name: user.name,
+      seed_content: "# Seed", yjs_state: "binary-crdt-state"
+    )
+
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# replace" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    body = response.parsed_body
+    assert_includes body["error"], "You own this document"
+    assert_equal "/d/#{doc.slug}", URI(body["edit_in_browser"]).path
+    assert_includes body["propose_suggestion"], "/api/docs/#{doc.slug}/suggestions"
+    assert_nil body["revision_workflow"], "the owner conflict is ownership-aware, not the agent workflow"
+    assert_equal "# Seed", doc.reload.seed_content, "a live document's seed must stay untouched"
+  end
+
+  test "owner update past a content snapshot returns an ownership-aware conflict" do
+    user = cli_user(email: "owner-snapshot@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Snap", user:, owner_name: user.name,
+      seed_content: "# Seed", content_snapshot: "# editor snapshot"
+    )
+
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# replace" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_includes response.parsed_body["error"], "You own this document"
+    assert_equal "# Seed", doc.reload.seed_content
+  end
+
+  test "an unclaimable document is not updatable even with a bearer token" do
+    user = cli_user(email: "owner-demo@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    demo = Document.create!(slug: "demo", title: "Demo", seed_content: "# Demo seed")
+
+    patch "/api/docs/demo",
+          params: { content: "# hijack the demo" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_equal "# Demo seed", demo.reload.seed_content,
+                 "the unclaimable demo must never be writable through the owner path"
+  end
+
+  test "an account-owned unclaimable document still cannot be updated via the owner path" do
+    user = cli_user(email: "owner-demo-owned@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    # Defense-in-depth: even if a future bug ever assigned the demo an owner,
+    # the unclaimable guard must keep the owner update path closed.
+    demo = Document.create!(slug: "demo", title: "Demo", user:, owner_name: user.name, seed_content: "# Demo seed")
+
+    patch "/api/docs/demo",
+          params: { content: "# hijack the demo" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_equal "# Demo seed", demo.reload.seed_content
+  end
+
+  test "a bearer token cannot update a document claimed only by a guest cookie" do
+    user = cli_user(email: "owner-vs-guest@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Guest claimed", owner_token: SecureRandom.hex(8), owner_name: "Guest",
+      seed_content: "# Guest content"
+    )
+
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# not yours" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_equal "# Guest content", doc.reload.seed_content,
+                 "an account token does not own a guest-cookie-claimed document"
+  end
+
+  test "authenticated owner update without an agent name succeeds without spurious attribution" do
+    user = cli_user(email: "owner-no-agent@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(title: "Draft", user:, owner_name: user.name, seed_content: "# First")
+
+    # The real CLI always sends X-Agent-Name, but a bare request must still work
+    # for the owner and leave seed authorship unattributed (parity with create).
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# Second" },
+          headers: { "Authorization" => "Bearer #{raw_token}" }, as: :json
+
+    assert_response :ok
+    doc.reload
+    assert_includes doc.current_content, "Second"
+    assert_nil doc.seed_author_kind, "no X-Agent-Name means no agent seed attribution"
+  end
+
   test "title-only update leaves content and seed authorship untouched" do
     post "/api/docs", params: { title: "Draft", content: "# Body stays" }, headers: AGENT, as: :json
     slug = response.parsed_body["slug"]
@@ -941,6 +1099,17 @@ class AgentApiTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def cli_user(email:, name: "Owner")
+    User.create!(
+      name:, email:,
+      password: "password1234", password_confirmation: "password1234"
+    )
+  end
+
+  def bearer(raw_token)
+    AGENT.merge("Authorization" => "Bearer #{raw_token}")
+  end
 
   def valid_sketch_fence
     sketch_fence({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

When a document has been claimed by the authenticated user, `thinkroom update` failed with:

```
Error: This document is no longer an unclaimed draft — a human has claimed or started editing it, so its live state is authoritative.
```

Because an authenticated `thinkroom new` immediately sets `user_id` (claims the document to the account), `PATCH /api/docs/:slug` — which gated on `document.seed_stage? && document.claimable?` — rejected the very next `thinkroom update`. The owner was locked out of their own draft, with `thinkroom suggest` as the only path (proposing a suggestion they'd then accept from themselves).

Closes #112.

## Fix

`PATCH /api/docs/:slug` now recognizes the authenticated CLI account that **owns** the document and lets it revise its own seed in place, even when the document is claimed:

- Gate changed from `seed_stage? && claimable?` to `seed_stage? && (claimable? || owner_via_cli_token?)`.
- `owner_via_cli_token?` = a valid Bearer token whose account owns the document (`current_api_user` + `Document#owned_by?`). Account ownership only — a guest `owner_token` cookie or a different account cannot match.
- No CLI change needed: `thinkroom update` already sends the Bearer token when logged in.

### What stays the same (by design)

The orthogonal `seed_stage?` gate is **preserved**. Opening a document in a browser starts a live Yjs/CRDT editor session, after which the seed is no longer what readers see and server-side replacement of live collaborative content is explicitly outside the product's identity (see `docs/plans/2026-06-25-002-feat-patch-api-docs-update-plan.md`). For that case the document remains authoritative in the browser, where the owner has full edit access, and suggestions remain the path for collaborators.

To avoid the confusing "a human has claimed it" message when the owner hits that boundary on their *own* document, owners now get an ownership-aware `409` that points them at the browser editor (`edit_in_browser`) with suggestions as a secondary option.

A `Document#unclaimable?` predicate keeps the demo protected at the decision site rather than relying on the demo never being owned.

## Scope boundary

This fixes the ownership lock-out (the `claimable?` gate). It does **not** add server-side replacement of a live collaborative document's CRDT state — that is deliberately out of scope and risky (it would clobber live edits in connected browsers). See the plan's "Outside this product's identity" section.

## Testing

**Automated** — `bin/rails test` full suite green (468 runs, 0 failures), `bin/rubocop` clean, `npm run check` (tsc + CLI tests) green. New integration coverage:
- owner updates their own claimed seed-stage document → `200` (content + title, attribution, activity)
- owner past seed stage (`yjs_state` / `content_snapshot`) → ownership-aware `409`, seed untouched
- non-owner Bearer, guest-cookie-claimed doc, and an (account-owned) demo → `409`, seed untouched
- owner update without `X-Agent-Name` → `200`, no spurious attribution

**End-to-end** — verified with the real `thinkroom` CLI against a running server (full transcript in the `cli_owner_update_demo.txt` artifact):

```
$ thinkroom new draft.md --title 'Launch plan' --agent Codex
http://127.0.0.1:3000/d/MEm7EL5E15
# precondition: claimed?=true  claimable?=false  seed_stage?=true  owner=owner-cli-demo@example.com

# BEFORE this fix the next command 409'd. Now:
$ thinkroom update <url> revised.md --agent Codex     # owner, claimed, seed-stage
http://127.0.0.1:3000/d/MEm7EL5E15            -> exit 0 (SUCCESS)
$ thinkroom show <url>
# Launch plan (revised)

# ownership still enforced
$ THINKROOM_TOKEN= thinkroom update <url> ...          -> 409 (anonymous)
$ THINKROOM_TOKEN=<other account> thinkroom update ... -> 409 (not the owner)

# boundary: after a browser editor session takes over (yjs_state present)
$ thinkroom update <url> ...                           -> ownership-aware 409:
  "You own this document, but it is now a live collaborative document ...
   Edit it directly in the browser, or propose a suggestion."
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfb1ab5e-f430-4780-84bd-d3ab643fee94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb1ab5e-f430-4780-84bd-d3ab643fee94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

