### PR TITLE
feat(cli): warn when writes fall back to the generic agent identity

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -10,4 +10,6 @@ thinkroom new draft.md --title "Decision memo" --agent "Codex"
 ```
 
 Use `thinkroom help` for commands. Set `THINKROOM_URL` for a self-hosted server
-and `THINKROOM_TOKEN` for non-interactive automation.
+and `THINKROOM_TOKEN` for non-interactive automation. Pass `--agent NAME` (or set
+`THINKROOM_AGENT`) on writes so edits are attributed to you; without it the CLI
+falls back to a generic `Thinkroom CLI` identity and warns.

--- a/cli/bin/thinkroom.js
+++ b/cli/bin/thinkroom.js
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url'
 
 const VERSION = '0.1.0'
 const DEFAULT_URL = 'https://thinkroom.kieranklaassen.com'
+const DEFAULT_AGENT_NAME = 'Thinkroom CLI'
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
 
 class CliError extends Error {
@@ -159,8 +160,20 @@ function printJson(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)
 }
 
-function agentName(options) {
-  return options.agent || process.env.THINKROOM_AGENT || 'Thinkroom CLI'
+function resolveAgent(options) {
+  const explicit = options.agent || process.env.THINKROOM_AGENT
+  return { name: explicit || DEFAULT_AGENT_NAME, explicit: Boolean(explicit) }
+}
+
+function writeAgent(options) {
+  const { name, explicit } = resolveAgent(options)
+  if (!explicit) {
+    process.stderr.write(
+      `Warning: No agent identity set; attributing this write to "${name}". ` +
+        'Pass --agent NAME or set THINKROOM_AGENT so your edits are attributed to you.\n',
+    )
+  }
+  return name
 }
 
 function slugFrom(value) {
@@ -283,7 +296,7 @@ async function createDocument(positionals, options) {
     method: 'POST',
     body,
     requireToken: true,
-    agent: agentName(options),
+    agent: writeAgent(options),
   })
   if (options.json) printJson(result.payload)
   else process.stdout.write(`${result.payload.share_url}\n`)
@@ -291,7 +304,7 @@ async function createDocument(positionals, options) {
 
 async function showDocument(positionals, options) {
   const slug = slugFrom(positionals[0])
-  const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, { agent: agentName(options) })
+  const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, { agent: resolveAgent(options).name })
   if (options.json) printJson(result.payload)
   else process.stdout.write(`${result.payload.content ?? result.payload.markdown ?? ''}\n`)
 }
@@ -307,7 +320,7 @@ async function updateDocument(positionals, options) {
   const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, {
     method: 'PATCH',
     body,
-    agent: agentName(options),
+    agent: writeAgent(options),
   })
   if (options.json) printJson(result.payload)
   else process.stdout.write(`${result.payload.share_url}\n`)
@@ -319,7 +332,7 @@ async function suggest(positionals, options) {
   if (!bodyText) throw new CliError('Suggestion body is required via --body, a file, or stdin.')
   const result = await request(`/api/docs/${encodeURIComponent(slug)}/suggestions`, options, {
     method: 'POST',
-    agent: agentName(options),
+    agent: writeAgent(options),
     body: {
       body: bodyText,
       intent: options.intent,
@@ -337,7 +350,7 @@ async function comment(positionals, options) {
   if (!bodyText) throw new CliError('Comment body is required via --body, a file, or stdin.')
   const result = await request(`/api/docs/${encodeURIComponent(slug)}/comments`, options, {
     method: 'POST',
-    agent: agentName(options),
+    agent: writeAgent(options),
     body: { body: bodyText, anchor_text: options.anchor },
   })
   if (options.json) printJson(result.payload)

--- a/cli/skill/thinkroom/SKILL.md
+++ b/cli/skill/thinkroom/SKILL.md
@@ -25,6 +25,8 @@ Write the complete draft to a file or pipe it on standard input. Identify the ac
 thinkroom new draft.md --title "Decision memo" --agent "Codex"
 ```
 
+Always pass `--agent` (or set `THINKROOM_AGENT`) on writes. Omitting it attributes the write to a generic `Thinkroom CLI` identity and prints a warning, which breaks per-agent provenance.
+
 Use `--format html` only when semantic HTML is genuinely needed. Return the printed share URL to the user.
 
 If the CLI asks for authentication, run `thinkroom login` and let the person approve the browser prompt. Never ask them to paste a token into chat.

--- a/cli/test/thinkroom.test.js
+++ b/cli/test/thinkroom.test.js
@@ -194,6 +194,7 @@ test('document commands normalize share URLs and surface API failures', async (t
   const shown = await runCli(['show', `${server.url}/d/slug123`], { cwd: root, configHome, env })
   assert.equal(shown.code, 0, shown.stderr)
   assert.equal(shown.stdout.trim(), '# Current')
+  assert.equal(shown.stderr, '', 'read-only show must not warn about agent identity')
 
   const updated = await runCli(['update', 'slug123', '-', '--agent', 'Codex'], {
     cwd: root, configHome, env, input: '# Revision',
@@ -217,4 +218,49 @@ test('document commands normalize share URLs and surface API failures', async (t
   assert.equal(seen[2].agent, 'Codex')
   assert.deepEqual(seen[3].body, { body: 'Check this', anchor_text: 'Current' })
   assert.equal(seen[3].agent, 'Scout')
+})
+
+test('writes warn on the generic identity fallback and honor THINKROOM_AGENT', async (t) => {
+  const root = await temporaryDirectory('agent-fallback')
+  const configHome = path.join(root, 'config')
+  await mkdir(path.join(configHome, 'thinkroom'), { recursive: true })
+
+  const seen = []
+  const server = await startServer(async (request, response) => {
+    if (request.url === '/api/docs' && request.method === 'POST') {
+      seen.push({ agent: request.headers['x-agent-name'], body: await jsonRequest(request) })
+      return sendJson(response, 201, { slug: 'doc1', share_url: `${server.url}/d/doc1` })
+    }
+    return sendJson(response, 404, { error: `Unexpected ${request.method} ${request.url}` })
+  })
+  t.after(() => server.close())
+
+  await writeFile(
+    path.join(configHome, 'thinkroom', 'config.json'),
+    JSON.stringify({ token: 'trm_test', url: server.url }),
+  )
+
+  // No --agent and no THINKROOM_AGENT: send the generic identity but warn loudly.
+  const fallback = await runCli(['new', '-', '--title', 'Anon draft'], {
+    cwd: root,
+    configHome,
+    input: '# Draft\n',
+    env: { THINKROOM_URL: server.url, THINKROOM_AGENT: '' },
+  })
+  assert.equal(fallback.code, 0, fallback.stderr)
+  assert.equal(fallback.stdout.trim(), `${server.url}/d/doc1`)
+  assert.match(fallback.stderr, /No agent identity set/)
+  assert.match(fallback.stderr, /--agent/)
+  assert.equal(seen[0].agent, 'Thinkroom CLI')
+
+  // THINKROOM_AGENT supplies identity: forward it and stay silent.
+  const fromEnv = await runCli(['new', '-', '--title', 'Env draft'], {
+    cwd: root,
+    configHome,
+    input: '# Draft\n',
+    env: { THINKROOM_URL: server.url, THINKROOM_AGENT: 'Claude' },
+  })
+  assert.equal(fromEnv.code, 0, fromEnv.stderr)
+  assert.equal(seen[1].agent, 'Claude')
+  assert.equal(fromEnv.stderr, '', 'an explicit THINKROOM_AGENT must suppress the fallback warning')
 })

--- a/docs/plans/2026-06-27-002-feat-cli-agent-identity-warning-plan.md
+++ b/docs/plans/2026-06-27-002-feat-cli-agent-identity-warning-plan.md
@@ -1,0 +1,109 @@
+---
+title: "feat: Warn when CLI writes fall back to a generic agent identity"
+type: feat
+date: 2026-06-27
+---
+
+# feat: Warn when CLI writes fall back to a generic agent identity
+
+## Summary
+
+The `--agent` flag the PR asks for is **already implemented** on `main`: `cli/bin/thinkroom.js` parses `--agent`, resolves it through `agentName()` (`--agent` → `THINKROOM_AGENT` → default `"Thinkroom CLI"`), and forwards it as the `X-Agent-Name` header on `new`, `update`, `suggest`, `comment`, and `show`. Every example in the PR works today.
+
+The residual gap is the PR's actual motivation: when an agent forgets `--agent` (and no `THINKROOM_AGENT` is set), writes are **silently** attributed to the generic `"Thinkroom CLI"` identity. The PR states this exact failure: "this makes provenance useless — you can't tell which agent wrote what." The raw HTTP API surfaces the missing-identity case loudly (suggestions/comments return 422 via `require_agent!`), but the CLI masks it with a default. This plan closes that gap with a non-breaking, stderr-only warning on write commands — the same pattern `git` uses when committing with a fallback identity.
+
+## Problem Frame
+
+`agentName()` always returns a non-empty string, so the CLI always sends `X-Agent-Name`. That is convenient but hides the difference between "I am Claude" and "I forgot to say who I am." In a multi-agent workflow the silent default produces misattributed provenance with no signal to the operator. We want to keep the convenient default (no breaking change) while making the fallback visible so agents and humans are nudged to identify themselves.
+
+## Requirements
+
+- R1. Running a write command (`new`, `update`, `suggest`, `comment`) without `--agent` and without `THINKROOM_AGENT` prints a single clear warning to **stderr** naming the generic identity in use and how to set a real one.
+- R2. The warning is suppressed when identity is provided via `--agent` **or** `THINKROOM_AGENT`.
+- R3. The warning does not change the `X-Agent-Name` header value (still `"Thinkroom CLI"` on fallback), stdout output, JSON output, or exit codes — behavior stays backward compatible.
+- R4. The read-only `show` command stays silent (no warning), since it does not create provenance.
+- R5. CLI test coverage verifies: fallback warns + still sends the default header; `THINKROOM_AGENT` suppresses the warning and sets the header; `show` without identity does not warn.
+
+## Key Technical Decisions
+
+- **Warn, do not error.** A non-zero exit would break the legitimate convenience default and the create path (the server permits header-less `POST /api/docs`). A stderr warning matches `git`'s default-identity nudge and keeps pipelines working.
+- **stderr only.** Warnings must never pollute stdout (share URLs) or `--json` payloads, both of which are parsed by callers. Existing tests assert stdout exactly and only use stderr as a failure message, so an added stderr line is safe.
+- **Distinguish explicit vs. fallback at resolution time.** Replace the single `agentName()` return value with a resolver that reports whether identity was explicit, then a write-only helper emits the warning. `show` calls the resolver without the helper.
+- **Keep the `"Thinkroom CLI"` default in one place.** Promote the literal to a `DEFAULT_AGENT_NAME` constant so the resolver and the warning message stay in sync.
+- **No version bump.** The `--version` test pins `0.1.0`; a release bump is the maintainer's call at publish time and is out of scope for this behavior fix.
+
+## Scope Boundaries
+
+- Does not make `--agent` required, nor change the resolution precedence (`--agent` → `THINKROOM_AGENT` → default).
+- Does not change the header sent on fallback (still `"Thinkroom CLI"`).
+- Does not touch server-side attribution (`Api::BaseController#current_agent`, `require_agent!`) — it already behaves correctly.
+- Does not disambiguate the unrelated `--agent` flag on `init` / `skill install` (selects a skill directory); that naming overlap is pre-existing and out of scope.
+
+### Deferred to Follow-Up Work
+
+- Optionally persisting a default agent name in the CLI config file (`thinkroom login`/`config.json`) so a machine can set its identity once. Not needed to fix provenance visibility.
+
+## Implementation Units
+
+### U1. Surface the fallback identity on writes
+
+**Goal:** Warn (stderr) when a write command resolves to the generic default identity, while preserving all existing behavior.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Files:**
+- `cli/bin/thinkroom.js` (modify)
+
+**Approach:**
+- Add `const DEFAULT_AGENT_NAME = 'Thinkroom CLI'` and use it inside the resolver.
+- Replace `agentName(options)` with `resolveAgent(options)` returning `{ name, explicit }`, where `explicit = Boolean(options.agent || process.env.THINKROOM_AGENT)`.
+- Add `writeAgent(options)`: calls `resolveAgent`, and when `!explicit` writes a one-line warning to `process.stderr` (e.g. `Warning: No agent identity set; attributing this write to "Thinkroom CLI". Pass --agent NAME or set THINKROOM_AGENT so your edits are attributed to you.`), then returns `name`.
+- `createDocument`, `updateDocument`, `suggest`, `comment` use `writeAgent(options)`; `showDocument` uses `resolveAgent(options).name` (no warning).
+
+**Patterns to follow:** existing `agentName(options)` usage and the `process.stderr.write(...)` calls already used in `login` for human-facing notices.
+
+**Test scenarios:** covered in U2 (the CLI is exercised end-to-end as a spawned binary, so behavior is verified there rather than via unit calls).
+
+**Verification:** `new`/`update`/`suggest`/`comment` without identity emit the warning to stderr; with `--agent` or `THINKROOM_AGENT` they do not; the `X-Agent-Name` header and stdout are unchanged in both cases.
+
+### U2. Cover the fallback-warning behavior
+
+**Goal:** Lock the new behavior with tests in the existing Node test suite.
+
+**Requirements:** R5 (and guards R1–R4).
+
+**Files:**
+- `cli/test/thinkroom.test.js` (modify)
+
+**Approach:** Add a test that logs in / configures a token against the local fake server (mirroring the existing `login` test setup) and then:
+- Runs `new` **without** `--agent` and without `THINKROOM_AGENT`: assert exit 0, assert the server received `x-agent-name: Thinkroom CLI`, assert `stderr` matches the warning, assert `stdout` still equals the share URL.
+- Runs `new` with `THINKROOM_AGENT=Claude` in env and no `--agent`: assert the server received `x-agent-name: Claude`, assert `stderr` does **not** contain the warning.
+- In the existing `document commands` test (or an added assertion), confirm `show` without identity produces no warning on `stderr`.
+
+**Test scenarios:**
+- Happy path: write with explicit `--agent` → no warning, header is the agent name (already covered by existing tests; keep them green).
+- Edge: write with no identity → warning printed, header is `Thinkroom CLI`, stdout unchanged, exit 0.
+- Edge: write with `THINKROOM_AGENT` only → no warning, header is the env value.
+- Edge: read-only `show` with no identity → no warning.
+
+**Verification:** `npm run check:cli` passes including the new assertions.
+
+### U3. Document the fallback behavior
+
+**Goal:** Make the default-identity behavior discoverable so agents know to pass `--agent`.
+
+**Files:**
+- `cli/skill/thinkroom/SKILL.md` (modify)
+- `cli/README.md` (modify)
+
+**Approach:** Add one sentence to the skill's "Start a document" guidance and the CLI README noting that omitting `--agent`/`THINKROOM_AGENT` attributes writes to a generic `"Thinkroom CLI"` identity and prints a warning. Keep it brief; the skill already instructs agents to identify themselves.
+
+**Test expectation:** none — documentation only.
+
+**Verification:** wording matches the actual warning string and the existing docs voice.
+
+## Verification Strategy
+
+- `npm run check:cli` (Node test runner) — primary gate for U1/U2.
+- `npm run check` — full TypeScript + CLI check to confirm nothing else regressed.
+- Manual terminal run of the built CLI against the local Rails server (`bin/dev`) showing: a write without `--agent` prints the warning and the document is attributed to "Thinkroom CLI"; a write with `--agent "Claude"` prints no warning and is attributed to "Claude".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The requested `--agent` flag **already exists** on `main`: `cli/bin/thinkroom.js` parses `--agent`, resolves it (`--agent` → `THINKROOM_AGENT` → default `"Thinkroom CLI"`), and forwards it as the `X-Agent-Name` header on `new`, `update`, `suggest`, `comment`, and `show`. Every example in the original report works today.

What remained was the report's actual motivation: when an agent forgets `--agent` (and no `THINKROOM_AGENT` is set), writes are **silently** attributed to the generic `"Thinkroom CLI"` identity — "this makes provenance useless — you can't tell which agent wrote what." The raw HTTP API surfaces missing identity loudly (`require_agent!` → 422 on suggestions/comments), but the CLI masked it with a convenient default.

## Change

Emit a single, non-breaking **stderr** warning on write commands (`new`, `update`, `suggest`, `comment`) when identity falls back to the generic default — the same pattern `git` uses for a default commit identity:

```
Warning: No agent identity set; attributing this write to "Thinkroom CLI". Pass --agent NAME or set THINKROOM_AGENT so your edits are attributed to you.
```

Deliberately conservative:
- **No behavior change** beyond the warning: the fallback header value (`Thinkroom CLI`), stdout (share URL), `--json` payloads, and exit codes are all unchanged.
- Suppressed when identity is supplied via `--agent` **or** `THINKROOM_AGENT`.
- Read-only `show` stays silent (it creates no provenance).
- Not an error: the create path legitimately permits a header-less `POST /api/docs`, and pipelines relying on the default keep working.

## Changes

- `cli/bin/thinkroom.js` — replace `agentName()` with `resolveAgent()` (`{ name, explicit }`) + `writeAgent()` (warns on fallback); writes use `writeAgent`, `show` uses `resolveAgent().name`. Add `DEFAULT_AGENT_NAME` constant.
- `cli/test/thinkroom.test.js` — new test: fallback warns + still sends `Thinkroom CLI`; `THINKROOM_AGENT` forwards + suppresses the warning. Plus an assertion that `show` stays silent.
- `cli/README.md`, `cli/skill/thinkroom/SKILL.md` — document the fallback/warning.
- `docs/plans/2026-06-27-002-feat-cli-agent-identity-warning-plan.md` — plan.

## Testing

- `npm run check` (TypeScript + `node --test cli/test/*.test.js`) — green, 5/5 CLI tests.
- End-to-end against the real Rails dev server (`bin/rails server` + a minted CLI token), verifying both the CLI warning and the server-side provenance it produces:

| CLI invocation | stderr warning? | `Document.seed_author_name` |
| --- | --- | --- |
| `new` (no `--agent`) | **yes** | `"Thinkroom CLI"` |
| `new --agent "Claude"` | no | `"Claude"` |
| `THINKROOM_AGENT=Codex new` | no | `"Codex"` |
| `suggest` (no `--agent`) | **yes** | suggestion `author_name = "Thinkroom CLI"` |
| `show` (read-only) | no | n/a |

Live terminal demonstration (warning present without `--agent`, absent with `--agent "Claude"`):

[Terminal showing the agent-identity warning on a write without --agent and no warning with --agent Claude](https://cursor.com/agents/bc-ab2b550f-e9fe-405d-b0ef-112d4d75e8b4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_agent_identity_warning_terminal.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab2b550f-e9fe-405d-b0ef-112d4d75e8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab2b550f-e9fe-405d-b0ef-112d4d75e8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

