### PR TITLE
fix(cli): allow owners to replace live documents

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -58,18 +58,14 @@ module Api
       render json: AgentGuide.state(document, request.base_url)
     end
 
-    # PATCH/PUT /api/docs/:slug — revise a document's seed in place while it is
-    # still a seed-stage draft. Same slug, same share URL, so the link already
-    # shared keeps working. Two audiences can write the seed: an unclaimed draft
-    # (the agent/anonymous flow) and the authenticated CLI account that owns the
-    # document — an owner must never be locked out of revising their own draft
-    # just because creating it claimed it. The seed_stage gate still applies to
-    # both: once an editor snapshot / live CRDT exists, the live document is
-    # authoritative and the seed is no longer what readers see, so a seed write
-    # would 200 while changing nothing. That case returns 409 and routes the
-    # caller to the right next action instead of lying about success.
+    # PATCH/PUT /api/docs/:slug — revise a document in place. Unclaimed drafts
+    # still use the seed-stage path; authenticated account owners may also
+    # replace their own live document by resetting stale CRDT/snapshot state to
+    # the new source. Non-owners on claimed/live documents keep the suggestion
+    # workflow so a full replacement never bypasses ownership.
     def update
-      return render_update_conflict unless document.seed_stage? && updatable_in_place?
+      live_owner_replacement = !document.seed_stage? && owner_via_cli_token?
+      return render_update_conflict unless live_owner_replacement || (document.seed_stage? && updatable_in_place?)
 
       requested_format = request.request_parameters["format"].presence
       if requested_format && requested_format != document.content_format
@@ -90,19 +86,32 @@ module Api
       normalized = false
       warning = nil
       source = nil
+      content_reset = false
       if content.present?
         source, normalized, warning = normalized_source_and_signal(document.content_format, content)
-        document.seed_content = source
         # Only (re)attribute when an agent identifies itself; an anonymous
         # update preserves the original seed authorship rather than erasing it.
         kind, name = agent_seed_attribution(content)
-        if kind
-          document.seed_author_kind = kind
-          document.seed_author_name = name
+        if live_owner_replacement
+          document.replace_content!(
+            source:,
+            title: new_title,
+            seed_author_kind: kind,
+            seed_author_name: name
+          )
+          content_reset = true
+        else
+          document.seed_content = source
+          if kind
+            document.seed_author_kind = kind
+            document.seed_author_name = name
+          end
         end
       end
-      document.title = new_title if new_title.present?
-      document.save!
+      unless live_owner_replacement && content.present?
+        document.title = new_title if new_title.present?
+        document.save!
+      end
       # Claim assets only after the content that references them is persisted,
       # so a failed save never binds assets to content that was never stored.
       DocumentAsset.claim_from_html!(document:, source:) if source && document.html?
@@ -113,6 +122,7 @@ module Api
           action: "updated_document", detail: document.title
         )
       end
+      DocumentMetaChannel.broadcast_event(document, :content_reset) if content_reset
 
       render json: agent_document_response(document, normalized:, warning:), status: :ok
     end
@@ -167,8 +177,6 @@ module Api
     # collaboratively edited document. Teach the correct next action rather than
     # failing opaquely or silently no-opping a seed write.
     def render_update_conflict
-      return render_owner_update_conflict if owner_via_cli_token?
-
       revision_workflow = AgentGuide.revision_workflow(document, request.base_url)
       steps = revision_workflow.fetch(:steps).index_by { |step| step.fetch(:action) }
       render json: {
@@ -178,20 +186,6 @@ module Api
         propose_suggestion: steps.fetch("propose_targeted_suggestion").fetch(:url),
         resolve_comment: steps.fetch("resolve_addressed_comment").fetch(:url),
         revision_workflow:
-      }, status: :conflict
-    end
-
-    # The owner's own document has progressed past the seed stage: an editor
-    # session made the live Yjs/CRDT state authoritative, so a full replacement
-    # through this endpoint would change nothing readers see. Replacing live
-    # collaborative content server-side is intentionally not offered (it would
-    # clobber live edits), so route the owner to the browser editor — where they
-    # have full edit access — with suggestions as a secondary option.
-    def render_owner_update_conflict
-      render json: {
-        error: "You own this document, but it is now a live collaborative document — its editor (Yjs/CRDT) state is authoritative, so a full replacement here would change nothing readers see. Edit it directly in the browser, or propose a suggestion.",
-        edit_in_browser: document_page_url(document.slug),
-        propose_suggestion: AgentGuide.endpoints(document, request.base_url).fetch(:propose_suggestion).fetch(:url)
       }, status: :conflict
     end
 

--- a/app/frontend/lib/use_meta_channel.ts
+++ b/app/frontend/lib/use_meta_channel.ts
@@ -15,6 +15,8 @@ interface MetaChannelOptions {
   onVersionAvailable?: (version: string) => void
   /** Fired when the owner changes document write access. */
   onEditingLock?: (locked: boolean) => void
+  /** Fired when an owner replaces the document source outside the live editor. */
+  onContentReset?: () => void
   /** Recreate the shared socket when guest/account authentication changes. */
   connectionIdentity?: string
 }
@@ -41,6 +43,8 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
   onVersionAvailableRef.current = options?.onVersionAvailable
   const onEditingLockRef = useRef(options?.onEditingLock)
   onEditingLockRef.current = options?.onEditingLock
+  const onContentResetRef = useRef(options?.onContentReset)
+  onContentResetRef.current = options?.onContentReset
   const loadedVersionRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -92,6 +96,10 @@ export function useMetaChannel(slug: string, options?: MetaChannelOptions): void
           }
           if (event === 'editing_lock' && typeof locked === 'boolean') {
             onEditingLockRef.current?.(locked)
+            return
+          }
+          if (event === 'content_reset') {
+            onContentResetRef.current?.()
             return
           }
           pending.add(event)

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -564,11 +564,16 @@ export default function DocumentShow({
   const recoverDeniedWrite = useCallback(() => {
     router.reload({ only: ['document', 'ownership', 'viewer'], async: true })
   }, [])
+  const reloadAfterContentReset = useCallback(() => {
+    presencePoll.stop()
+    window.location.reload()
+  }, [presencePoll])
   useMetaChannel(doc.slug, {
     onDeleted: onDocumentGone,
     onTitle: setDocumentTitle,
     onVersionAvailable: () => setNewVersionAvailable(true),
     onEditingLock: reloadEditingAccess,
+    onContentReset: reloadAfterContentReset,
     connectionIdentity,
   })
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -157,6 +157,27 @@ class Document < ApplicationRecord
     end
   end
 
+  def replace_content!(source:, title: nil, seed_author_kind: nil, seed_author_name: nil)
+    with_lock do
+      reload
+      attributes = {
+        seed_content: source,
+        content_snapshot: nil,
+        provenance_spans: [],
+        yjs_state: nil,
+        seed_state: "pending",
+        seed_claimed_at: nil
+      }
+      attributes[:title] = title if title.present?
+      if seed_author_kind.present?
+        attributes[:seed_author_kind] = seed_author_kind
+        attributes[:seed_author_name] = seed_author_name
+      end
+      update!(attributes)
+    end
+    self
+  end
+
   def with_comment_access(token: nil, user: nil)
     with_lock do
       reload

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -154,7 +154,7 @@ class AgentGuide
                            returns: { slug: "Unchanged identifier", share_url: "Unchanged share URL",
                                       content: "Updated canonical source", plain_text: "Updated rendered text",
                                       normalized: "Whether source changed during normalization", warning: "Normalization detail" },
-                           purpose: "Revise the document you created in place — same slug, same share URL — while it is still seed-stage (no human has opened it to edit). An authenticated owner (CLI Bearer token) can revise their own document this way even after it is claimed, as long as it is still seed-stage. Once a human starts editing, the live collaborative document is authoritative: this returns 409, and you propose a suggestion instead." }
+                           purpose: "Revise the document you created in place — same slug, same share URL. An authenticated owner (CLI Bearer token) can replace their own document even after live editing has started; non-owners receive 409 and should propose a suggestion instead." }
       }
     end
 
@@ -263,7 +263,7 @@ class AgentGuide
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
         "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
-        "Updating: PATCH /api/docs/:slug rewrites your document's seed in place — same slug, same share URL — so revisions stay at the link you already shared, as long as no human has started editing. An authenticated owner (a Bearer token from `thinkroom login`) can keep updating their own document this way even after it is claimed, while it is still seed-stage. Once an editor takes over you get a 409: from then on, propose suggestions, which is how every edit to a live document works.",
+        "Updating: PATCH /api/docs/:slug rewrites your document in place — same slug, same share URL — so revisions stay at the link you already shared. An authenticated owner (a Bearer token from `thinkroom login`) can replace their own live document; non-owners get a 409 and should propose suggestions instead.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported. To author one in Markdown, embed a fenced excalidraw block following content_contract.sketches.markdown_source (formatVersion, id, description, height, and a full excalidraw scene with type/version/appState/files) — copy its example to start. A recognized sketch shows in plain_text as \"Sketch: <description> — <labels>\"; raw scene JSON in plain_text means the block was not recognized, and the create response then returns normalized: true with a warning.",
@@ -405,18 +405,17 @@ class AgentGuide
            payload, poll events while waiting for review, then sign off.
 
         ## Revise a document you created
-        While no human has opened the document to edit it, you can rewrite it
-        in place — same slug, same share URL, so the link you shared keeps
-        working. Send a new title, content, or both:
+        You can rewrite an owned document in place — same slug, same share URL,
+        so the link you shared keeps working. Send a new title, content, or
+        both:
            curl -X PATCH #{base_url}/api/docs/RETURNED_SLUG \\
              -H "X-Agent-Name: YOUR_NAME" -H "Content-Type: application/json" \\
              -d '{"title": "Revised", "content": "..."}'
         format is immutable; omit it or send the document's existing format.
         If you authenticate with a Bearer token (thinkroom login) and own the
-        document, you can keep updating it in place even after it is claimed,
-        while it is still seed-stage. Once a human starts editing, the live
-        collaborative document becomes authoritative and PATCH returns 409 —
-        from then on, propose a suggestion instead.
+        document, you can keep updating it in place even after it is claimed or
+        after live editing has started. If you do not own the document, PATCH
+        returns 409 once it is claimed or live; propose a suggestion instead.
 
         HTML is sanitized and normalized to Thinkroom's editable schema. Create and
         suggestion responses include normalized=true plus a warning when

--- a/cli/skill/thinkroom/SKILL.md
+++ b/cli/skill/thinkroom/SKILL.md
@@ -45,9 +45,9 @@ For a document that is still an untouched seed, revise it in place:
 thinkroom update SHARE_URL revision.md --title "Updated title" --agent "Codex"
 ```
 
-If you are logged in (`thinkroom login`) and own the document, you can update it in place this way even after it is claimed — being the owner is not a lock-out. The seed stage is the only constraint: updating works until a human opens the document in the browser and starts a live editing session.
+If you are logged in (`thinkroom login`) and own the document, you can update it in place this way even after it is claimed or after a live editing session exists. Owner updates are full replacements of the document source at the same share URL.
 
-Once the document has a live editing session — a collaborator has opened it in the browser, so its live state is authoritative — do not try to overwrite it from the CLI. Owners edit a live document directly in the browser; otherwise propose the smallest exact replacement and include intent:
+If you do not own the document, do not try to overwrite a claimed or live document from the CLI. Propose the smallest exact replacement and include intent:
 
 ```bash
 thinkroom suggest SHARE_URL \

--- a/cli/test/thinkroom.test.js
+++ b/cli/test/thinkroom.test.js
@@ -180,6 +180,9 @@ test('document commands normalize share URLs and surface API failures', async (t
     if (request.method === 'PATCH' && request.url === '/api/docs/slug123') {
       return sendJson(response, 409, { error: 'Live state is authoritative.', how_to_revise: 'Propose a suggestion.' })
     }
+    if (request.method === 'PATCH' && request.url === '/api/docs/owned123') {
+      return sendJson(response, 200, { share_url: `${server.url}/d/owned123` })
+    }
     if (request.method === 'POST' && request.url === '/api/docs/slug123/suggestions') {
       return sendJson(response, 201, { suggestion: { id: 12 } })
     }
@@ -202,6 +205,12 @@ test('document commands normalize share URLs and surface API failures', async (t
   assert.equal(updated.code, 1)
   assert.match(updated.stderr, /Propose a suggestion/)
 
+  const ownerUpdated = await runCli(['update', 'owned123', '-', '--agent', 'Codex'], {
+    cwd: root, configHome, env, input: '# Owner revision',
+  })
+  assert.equal(ownerUpdated.code, 0, ownerUpdated.stderr)
+  assert.equal(ownerUpdated.stdout.trim(), `${server.url}/d/owned123`)
+
   const suggested = await runCli([
     'suggest', `${server.url}/d/slug123`, '--body', 'New', '--replaces', 'Old', '--intent', 'Tighten', '--agent', 'Codex',
   ], { cwd: root, configHome, env })
@@ -214,10 +223,10 @@ test('document commands normalize share URLs and surface API failures', async (t
   assert.equal(commented.code, 0, commented.stderr)
   assert.match(commented.stdout, /Comment 13/)
 
-  assert.deepEqual(seen[2].body, { body: 'New', intent: 'Tighten', replaces: 'Old' })
-  assert.equal(seen[2].agent, 'Codex')
-  assert.deepEqual(seen[3].body, { body: 'Check this', anchor_text: 'Current' })
-  assert.equal(seen[3].agent, 'Scout')
+  assert.deepEqual(seen[3].body, { body: 'New', intent: 'Tighten', replaces: 'Old' })
+  assert.equal(seen[3].agent, 'Codex')
+  assert.deepEqual(seen[4].body, { body: 'Check this', anchor_text: 'Current' })
+  assert.equal(seen[4].agent, 'Scout')
 })
 
 test('writes warn on the generic identity fallback and honor THINKROOM_AGENT', async (t) => {

--- a/docs/plans/2026-06-28-001-fix-owner-live-cli-replacement-plan.md
+++ b/docs/plans/2026-06-28-001-fix-owner-live-cli-replacement-plan.md
@@ -1,0 +1,223 @@
+---
+title: "fix: Allow CLI owners to replace live documents"
+type: fix
+date: 2026-06-28
+origin: https://github.com/kieranklaassen/thinkroom/issues/116
+---
+
+# fix: Allow CLI owners to replace live documents
+
+## Summary
+
+`thinkroom update` currently returns `409 Conflict` when an authenticated owner tries to replace a document after the browser editor has created Yjs/CRDT state. Issue #116 asks for owner authority to be enough for full replacement: the same slug and share URL should keep working, but the live document state should be reset to the new source instead of rejecting the write.
+
+This plan keeps non-owner behavior unchanged. Only the authenticated account that owns the document can perform a destructive replacement past seed stage; everyone else still gets the suggestion workflow.
+
+---
+
+## Problem Frame
+
+The current `Api::DocsController#update` path was built for seed-stage updates. That protected callers from a silent no-op: once `content_snapshot` or `yjs_state` exists, updating `seed_content` alone no longer changes what readers see. The owner-aware conflict added for the earlier owner update fix is accurate for that design, but it blocks the intended agent workflow: an agent drafts a document, the user claims and edits it in the browser, and the agent later needs to publish a full revised version into the same Thinkroom.
+
+The replacement must operate on the authoritative read model and CRDT lifecycle, not merely bypass the error. A successful owner update needs subsequent API reads and browser opens to show the replacement content.
+
+---
+
+## Requirements
+
+- R1. An authenticated CLI Bearer token whose account owns the document can `PATCH /api/docs/:slug` with replacement content even when `yjs_state` or `content_snapshot` is present.
+- R2. Owner replacement keeps the document slug, share URL, ownership, immutable `content_format`, rate limits, byte limits, normalization, and agent attribution behavior from the existing update path.
+- R3. Replacement resets the authoritative live-editor state so readers and future browser editors see the new content, not the previous CRDT/snapshot state.
+- R4. Title-only owner updates past seed stage can still rename the document without resetting content.
+- R5. Non-owners, other authenticated accounts, guest-cookie owners without the account owner, and unclaimable documents still cannot replace live content through the API.
+- R6. Existing suggestion workflow guidance remains the conflict path for callers who do not own the document.
+- R7. CLI and agent-facing docs describe that authenticated owners may replace live documents, while non-owners should propose suggestions.
+
+---
+
+## Key Technical Decisions
+
+- **KTD-1 - Treat owner replacement as a destructive owner action.** The account owner already has browser edit/delete authority. The API should honor the same authority for full replacement, but only through the authenticated account owner predicate already used by owner update tests.
+- **KTD-2 - Reset the authoritative document state, not just the seed.** Past seed stage, `current_content` reads `content_snapshot`, and the editor hydrates from `yjs_state_b64` when present. The replacement path must clear or rebuild the stale live state and persist the new source where API reads and first paint consume it.
+- **KTD-3 - Prefer a server-owned reset boundary over a `--force` CLI flag for the first implementation.** The CLI already sends the Bearer token and content. Authorization and behavior belong on the server; adding a flag would not solve the stale CRDT state by itself.
+- **KTD-4 - Preserve non-owner conflict semantics.** The existing revision workflow is still correct for non-owners and agents editing someone else's live document. Issue #116 changes the owner path only.
+- **KTD-5 - Do not hand-roll ProseMirror/Yjs structure casually.** The browser editor uses `y-prosemirror` with Milkdown, not the plain `Y.Text` helpers used by older service tests. If the implementation rebuilds `yjs_state`, it must use a proven compatible builder; otherwise it should reset the persisted CRDT state and force the normal seed/template path to create fresh editor state from the replacement source.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[PATCH /api/docs/:slug] --> B{valid content or title?}
+  B -->|no| E422[422]
+  B -->|yes| C{seed_stage?}
+  C -->|yes| D{claimable? or account owner?}
+  D -->|yes| S[existing seed-stage update]
+  D -->|no| N[non-owner conflict workflow]
+  C -->|no| O{account owner and not unclaimable?}
+  O -->|no| N
+  O -->|yes, content present| R[replace authoritative content and reset live editor state]
+  O -->|yes, title only| T[rename without content reset]
+  R --> OK[200 with updated state]
+  T --> OK
+  S --> OK
+```
+
+The key state transition is from a live document back to a replacement source:
+
+```mermaid
+stateDiagram-v2
+  [*] --> SeedStage: new API doc
+  SeedStage --> LiveState: browser editor seeds/snapshots
+  LiveState --> LiveState: collaborative edits
+  LiveState --> ReplacementSeed: owner CLI replacement
+  ReplacementSeed --> LiveState: next browser editor applies replacement template
+```
+
+---
+
+## Implementation Units
+
+### U1. Extract owner replacement state handling
+
+**Goal:** Add a single server-side operation that replaces an owned document's source and resets stale live-editor state safely.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** none
+
+**Files:**
+- `app/models/document.rb`
+- `app/services/yjs_persistence.rb`
+- `test/models/document_test.rb`
+- `test/services/yjs_persistence_test.rb`
+
+**Approach:** Implement the replacement as a model/service-owned transition under a document lock. It should persist the normalized replacement source, clear stale `content_snapshot`/provenance data, and reset `yjs_state`/seed lifecycle so the next editor session hydrates from the replacement source rather than merging the old CRDT state. If the implementation instead builds a fresh Yjs document server-side, add compatibility tests that prove the browser/editor binding can read that state; plain `Y.Text` tests alone are not sufficient.
+
+**Patterns to follow:** `Document#with_write_access`, `Document#seed_stage?`, `YjsPersistence.merge`, `YjsPersistence.persist_snapshot`, and the seed-claim tests in `test/integration/document_seed_claim_test.rb`.
+
+**Test scenarios:**
+- A live document with both `yjs_state` and `content_snapshot` is replaced by its account owner; after reload, `current_content` is the new source and stale provenance spans are gone.
+- A replacement resets seed lifecycle fields so a future browser session can seed the new source without waiting for the stale-claim timeout.
+- Invalid or oversized replacement content leaves the old live state untouched.
+- If a fresh Yjs state is generated server-side, `YjsPersistence.state_b64` round-trips into a fresh Y doc with the replacement content using the same structure the editor expects.
+
+**Verification:** Unit tests prove the transition is atomic and stale live state cannot shadow the replacement.
+
+### U2. Update `PATCH /api/docs/:slug` owner behavior
+
+**Goal:** Route owner PATCH requests past seed stage into the replacement operation while preserving existing seed-stage and conflict paths.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/controllers/api/docs_controller.rb`
+- `test/integration/agent_api_test.rb`
+
+**Approach:** Keep `owner_via_cli_token?` as the account-owner gate. For seed-stage documents, preserve the existing update path. For non-seed-stage documents, branch only account owners into the replacement path when `content` is present; title-only owner updates should update `title` and return the normal response without resetting content. Non-owners should continue through `render_update_conflict`.
+
+**Patterns to follow:** Existing owner update tests around `owner_via_cli_token?`, format immutability checks, `reject_oversized_content`, `normalized_source_and_signal`, `agent_seed_attribution`, and `Activity.log!`.
+
+**Test scenarios:**
+- Authenticated owner replaces a document with `yjs_state` present and receives `200`; response content and persisted `current_content` include the replacement.
+- Authenticated owner replaces a document with only `content_snapshot` present and receives `200`.
+- Owner title-only update on a live document renames it and leaves existing content state untouched.
+- Bearer token from a different account still receives `409` and the original content remains unchanged.
+- Anonymous/agent request on a claimed live document still receives the existing revision workflow response.
+- Guest-cookie ownership is not enough for account-token owner replacement.
+- Demo/unclaimable document remains protected even if a future bug assigns it an owner.
+- Format mismatch, empty PATCH, and byte cap behavior match the existing update path.
+
+**Verification:** `test/integration/agent_api_test.rb` covers owner, non-owner, title-only, validation, and conflict branches.
+
+### U3. Broadcast or otherwise invalidate open editor sessions after replacement
+
+**Goal:** Prevent currently open browser editors from continuing to display or later re-persist the pre-replacement CRDT state.
+
+**Requirements:** R3
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `app/channels/document_meta_channel.rb`
+- `app/frontend/lib/use_meta_channel.ts`
+- `app/frontend/pages/documents/show.tsx`
+- `app/frontend/editor/milkdown_editor.tsx`
+- `test/channels/document_meta_channel_test.rb`
+
+**Approach:** Add a document-level reset signal if clearing persisted CRDT state is not enough for connected clients. The signal should cause open editors to discard the current Yjs session and reload the document props, similar to how delete and metadata changes already route through `DocumentMetaChannel`. The client must not merge the old local Y doc back into the freshly reset document.
+
+**Patterns to follow:** `DocumentMetaChannel.broadcast_event`, `useMetaChannel`'s special handling for `document_deleted`, editor session teardown in `milkdown_editor.tsx`, and `editorSessionKey` handling in `documents/show.tsx`.
+
+**Test scenarios:**
+- Owner replacement broadcasts a reset/content event after commit.
+- A client receiving the reset event recreates the editor session rather than applying the replacement as a normal partial prop reload over the old Y doc.
+- Deletion, title, ownership, activities, and suggestions meta events keep their existing behavior.
+
+**Verification:** Channel tests cover the broadcast contract. Browser verification in the work phase should open a live document in one tab, run the owner update through the API/CLI, and confirm the tab shows the replacement after the reset.
+
+### U4. Update CLI fixtures and user-facing guidance
+
+**Goal:** Make `thinkroom update` tests and documentation reflect that account owners can replace live documents.
+
+**Requirements:** R7
+
+**Dependencies:** U2
+
+**Files:**
+- `cli/test/thinkroom.test.js`
+- `cli/skill/thinkroom/SKILL.md`
+- `app/services/agent_guide.rb`
+- `test/integration/agent_api_test.rb`
+
+**Approach:** The CLI command probably needs no transport change, because it already sends the configured Bearer token and PATCH body. Update tests that currently expect a `409` for live update to distinguish non-owner conflicts from owner success. Update the skill and agent guide to say authenticated owners may replace their own live documents; non-owners and agents without ownership should still propose suggestions.
+
+**Patterns to follow:** Existing CLI update test fixture, `AgentGuide.endpoints`, `AgentGuide.notes`, and plain-text share guide tests.
+
+**Test scenarios:**
+- CLI fixture for owner-style update returns a successful share URL.
+- CLI fixture for a non-owner `409` still surfaces the server's suggestion guidance.
+- JSON state payload advertises the updated owner capability without promising non-owner overwrite.
+- Plain-text guide and `cli/skill/thinkroom/SKILL.md` no longer tell owners that live documents can only be edited in the browser.
+
+**Verification:** `npm --prefix cli test` or the repo's CLI test command passes, and API guide tests assert the new copy.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add a `thinkroom update --force` flag. The first implementation should make the authenticated owner path work without new CLI syntax.
+- This plan does not let non-owners overwrite collaborative documents. Suggestions remain the collaboration-safe path.
+- This plan does not change document ownership acquisition. CLI replacement depends on the account owner created by login/authenticated creation or account ownership promotion.
+- This plan does not make CRDT merging smarter. A full replacement is destructive by design and should reset or rebuild the live state.
+
+---
+
+## System-Wide Impact
+
+This changes an external HTTP API contract used by the installed CLI and agent workflows. It also changes a live-collaboration lifecycle: a server-side owner action can invalidate existing editor sessions. The implementation should therefore keep authorization checks narrow, make the state transition explicit, and verify both API reads and browser editor behavior.
+
+---
+
+## Risks & Dependencies
+
+- **Stale client re-persistence:** An open editor with the old Y doc could push old state back after the server clears it. U3 exists to close this risk.
+- **Yjs structure mismatch:** Ruby-side `Y.Text` helpers may not represent the same structure produced by Milkdown/y-prosemirror. Avoid claiming success from a plain text round-trip unless the browser editor can hydrate it.
+- **Over-broad authorization:** Owner replacement must use account ownership, not any Bearer token or guest token association.
+- **Documentation drift:** The Thinkroom CLI skill and `AgentGuide` currently describe live CRDT state as a hard stop. They must change with the behavior.
+
+---
+
+## Sources & Research
+
+- GitHub issue #116: `https://github.com/kieranklaassen/thinkroom/issues/116`
+- Existing owner seed-stage fix plan: `docs/plans/2026-06-27-002-fix-cli-owner-update-claimed-docs-plan.md`
+- API update path and conflict behavior: `app/controllers/api/docs_controller.rb`
+- Live state persistence: `app/services/yjs_persistence.rb`
+- Document state predicates: `app/models/document.rb`
+- API regression tests: `test/integration/agent_api_test.rb`
+- Editor Yjs binding and seed flow: `app/frontend/editor/milkdown_editor.tsx`, `app/frontend/editor/cable_provider.ts`
+- Meta-channel reload pattern: `app/frontend/lib/use_meta_channel.ts`, `app/channels/document_meta_channel.rb`

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -804,28 +804,44 @@ class AgentApiTest < ActionDispatch::IntegrationTest
                  "another account's bearer token must not overwrite a claimed document"
   end
 
-  test "owner update past the seed stage returns an ownership-aware conflict" do
+  test "owner update past the seed stage replaces live content and broadcasts reset" do
     user = cli_user(email: "owner-live@example.com")
     _record, raw_token = CliAccessToken.issue!(user:)
     doc = Document.create!(
       title: "Live", user:, owner_name: user.name,
-      seed_content: "# Seed", yjs_state: "binary-crdt-state"
+      seed_content: "# Seed",
+      content_snapshot: "# editor snapshot",
+      yjs_state: "binary-crdt-state",
+      provenance_spans: [ { "kind" => "human", "chars" => 15 } ],
+      seed_state: "seeded",
+      seed_claimed_at: Time.current
     )
 
-    patch "/api/docs/#{doc.slug}",
-          params: { content: "# replace" },
-          headers: bearer(raw_token), as: :json
+    assert_broadcast_on(DocumentMetaChannel.broadcasting_for(doc), event: "content_reset") do
+      patch "/api/docs/#{doc.slug}",
+            params: { title: "Replaced", content: "# replace" },
+            headers: bearer(raw_token), as: :json
+    end
 
-    assert_response :conflict
+    assert_response :ok
     body = response.parsed_body
-    assert_includes body["error"], "You own this document"
-    assert_equal "/d/#{doc.slug}", URI(body["edit_in_browser"]).path
-    assert_includes body["propose_suggestion"], "/api/docs/#{doc.slug}/suggestions"
-    assert_nil body["revision_workflow"], "the owner conflict is ownership-aware, not the agent workflow"
-    assert_equal "# Seed", doc.reload.seed_content, "a live document's seed must stay untouched"
+    assert_equal doc.slug, body["slug"]
+    assert_equal "Replaced", body["title"]
+    assert_includes body["content"], "# replace"
+
+    doc.reload
+    assert_equal "Replaced", doc.title
+    assert_equal "# replace", doc.current_content
+    assert_equal "# replace", doc.seed_content
+    assert_nil doc.content_snapshot
+    assert_nil doc.yjs_state
+    assert_equal [], doc.provenance_spans
+    assert_equal "pending", doc.seed_state
+    assert_nil doc.seed_claimed_at
+    assert_equal "updated_document", doc.activities.last.action
   end
 
-  test "owner update past a content snapshot returns an ownership-aware conflict" do
+  test "owner update past a content snapshot replaces snapshot content" do
     user = cli_user(email: "owner-snapshot@example.com")
     _record, raw_token = CliAccessToken.issue!(user:)
     doc = Document.create!(
@@ -837,9 +853,29 @@ class AgentApiTest < ActionDispatch::IntegrationTest
           params: { content: "# replace" },
           headers: bearer(raw_token), as: :json
 
-    assert_response :conflict
-    assert_includes response.parsed_body["error"], "You own this document"
-    assert_equal "# Seed", doc.reload.seed_content
+    assert_response :ok
+    assert_equal "# replace", doc.reload.current_content
+    assert_nil doc.content_snapshot
+  end
+
+  test "owner title-only update past live state renames without resetting content" do
+    user = cli_user(email: "owner-live-title@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Live", user:, owner_name: user.name,
+      seed_content: "# Seed", content_snapshot: "# editor snapshot",
+      yjs_state: "binary-crdt-state"
+    )
+
+    patch "/api/docs/#{doc.slug}",
+          params: { title: "Renamed" },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :ok
+    doc.reload
+    assert_equal "Renamed", doc.title
+    assert_equal "# editor snapshot", doc.current_content
+    assert_equal "binary-crdt-state", doc.yjs_state
   end
 
   test "an unclaimable document is not updatable even with a bearer token" do
@@ -1055,7 +1091,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "PATCH", update["method"]
     assert_equal 409, update["conflict_status"]
     assert_includes update["url"], "/api/docs/#{response.parsed_body['slug']}"
-    assert_includes update["purpose"], "seed-stage"
+    assert_includes update["purpose"], "replace their own document"
   end
 
   test "state payload advertises the update endpoint and explains it in notes" do

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -102,6 +102,37 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "", html.current_content
   end
 
+  test "replace content resets stale live state back to a seedable source" do
+    doc = Document.create!(
+      title: "Live",
+      seed_content: "# Seed",
+      content_snapshot: "# Snapshot",
+      yjs_state: "old-crdt-state",
+      provenance_spans: [ { "kind" => "human", "chars" => 8 } ],
+      seed_state: "seeded",
+      seed_claimed_at: Time.current
+    )
+
+    doc.replace_content!(
+      source: "# Replacement",
+      title: "Replaced",
+      seed_author_kind: "agent",
+      seed_author_name: "Codex"
+    )
+
+    doc.reload
+    assert_equal "Replaced", doc.title
+    assert_equal "# Replacement", doc.current_content
+    assert_equal "# Replacement", doc.seed_content
+    assert_nil doc.content_snapshot
+    assert_nil doc.yjs_state
+    assert_equal [], doc.provenance_spans
+    assert_equal "pending", doc.seed_state
+    assert_nil doc.seed_claimed_at
+    assert_equal "agent", doc.seed_author_kind
+    assert_equal "Codex", doc.seed_author_name
+  end
+
   test "database rejects unknown content formats" do
     doc = Document.create!(title: "Constrained")
 


### PR DESCRIPTION
## Summary

`thinkroom update` can now replace a live collaborative document when the caller is authenticated as the account owner. Before this, owned live documents returned 409 and forced the agent workflow to create a new document; now the same slug/share URL is preserved while stale snapshot/Yjs state is reset to the replacement source.

Non-owners still get the existing suggestion workflow, and unclaimable documents remain protected.

## Design Notes

- Owner live replacement is treated as a destructive owner action behind the existing CLI Bearer-token account ownership check.
- Replacement clears stale `content_snapshot`, provenance spans, Yjs state, and seed-claim lifecycle so future browser sessions seed from the replacement source.
- Open browser editors receive a `content_reset` meta event and reload the page, preventing an old local Yjs session from re-persisting stale state.
- Agent guide and bundled CLI skill copy now distinguish owner replacement from non-owner suggestions.

## Validation

- `bin/rails test test/models/document_test.rb test/integration/agent_api_test.rb test/channels/document_meta_channel_test.rb`
- `bin/rubocop app/controllers/api/docs_controller.rb app/models/document.rb test/integration/agent_api_test.rb test/models/document_test.rb`
- `env -u FORCE_COLOR npm run check`
- `agent-browser` smoke test opened `/d/demo` and rendered the document editor shell.

Closes kieranklaassen/thinkroom#116

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
