### PR TITLE
fix(editor): reseed documents after CLI replacement

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -96,6 +96,7 @@ class DocumentsController < InertiaController
       ui: ui_prefs(mode:),
       document: document.slice(:id, :slug, :title, :content_format).merge(
         seed_content: document.seed_content,
+        seed_version: document.updated_at.iso8601(6),
         seed_granted: seed_granted,
         seed_author_kind: document.seed_author_kind,
         seed_author_name: document.seed_author_name,

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -105,6 +105,8 @@ interface EditorProps {
   /** Seed template for a never-edited document. Applied at bind time when
    *  the page response granted this client the seed claim. */
   seedContent?: string | null
+  /** Changes whenever the server-side source generation changes. */
+  seedVersion?: string | null
   /** True when documents#show atomically claimed the seed for this page
    *  load — the props-first path that skips the WebSocket round-trip. */
   seedGranted?: boolean
@@ -281,21 +283,23 @@ function acquireSession(
 // with the original seed_granted: true long after the template was applied
 // and synced. Re-applying onto a fresh local doc would duplicate the
 // template when the server state merges in, so grant consumption is made
-// durable per tab. sessionStorage is per-tab, which matches the grant's
-// scope — other tabs get fresh props (seed_granted: false once claimed).
-const seedAppliedKey = (slug: string) => `pruf:seed-applied:${slug}`
+// durable per tab. The server generation is part of the key because owner
+// CLI replacement keeps the slug while resetting the CRDT state to a new
+// seed source; that new generation must be allowed to seed again.
+const seedAppliedKey = (slug: string, seedVersion?: string | null) =>
+  `pruf:seed-applied:${slug}:${seedVersion ?? 'unknown'}`
 
-function seedAlreadyApplied(slug: string): boolean {
+function seedAlreadyApplied(slug: string, seedVersion?: string | null): boolean {
   try {
-    return sessionStorage.getItem(seedAppliedKey(slug)) === '1'
+    return sessionStorage.getItem(seedAppliedKey(slug, seedVersion)) === '1'
   } catch {
     return false
   }
 }
 
-function markSeedApplied(slug: string): void {
+function markSeedApplied(slug: string, seedVersion?: string | null): void {
   try {
-    sessionStorage.setItem(seedAppliedKey(slug), '1')
+    sessionStorage.setItem(seedAppliedKey(slug, seedVersion), '1')
   } catch {
     // best effort — worst case is the pre-fix behavior on history restore
   }
@@ -351,6 +355,7 @@ function CollabEditor({
   contentFormat,
   initialStateB64,
   seedContent,
+  seedVersion,
   seedGranted,
   seedAuthorKind,
   seedAuthorName,
@@ -612,8 +617,8 @@ function CollabEditor({
     // someone else holds the claim — waits for the sync handshake.
     if (provider.synced || ydoc.store.clients.size > 0) {
       start()
-    } else if (seedGranted && seedContent && !seedAlreadyApplied(slug)) {
-      markSeedApplied(slug)
+    } else if (seedGranted && seedContent && !seedAlreadyApplied(slug, seedVersion)) {
+      markSeedApplied(slug, seedVersion)
       provider.seedContent = seedContent
       provider.seedFormat = contentFormat
       provider.seedAuthorKind = seedAuthorKind ?? null

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -107,6 +107,7 @@ export interface DocumentProps {
     title: string
     content_format: DocumentFormat
     seed_content: string | null
+    seed_version: string
     seed_granted: boolean
     seed_author_kind: string | null
     seed_author_name: string | null
@@ -1347,6 +1348,7 @@ export default function DocumentShow({
                       contentFormat={doc.content_format}
                       initialStateB64={doc.yjs_state_b64}
                       seedContent={doc.seed_content}
+                      seedVersion={doc.seed_version}
                       seedGranted={doc.seed_granted}
                       seedAuthorKind={doc.seed_author_kind}
                       seedAuthorName={doc.seed_author_name}

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -105,6 +105,26 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
     assert_equal "pending", @document.reload.seed_state
   end
 
+  test "seed version changes after source replacement at the same slug" do
+    get document_page_path(@document.slug), headers: browser
+    first_version = nil
+    assert_inertia_props do |props|
+      first_version = props[:document][:seed_version]
+      first_version.present?
+    end
+
+    travel 1.second do
+      @document.replace_content!(source: "# Replacement")
+    end
+
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props[:document][:seed_version].present? &&
+        props[:document][:seed_version] != first_version &&
+        props[:document][:seed_content] == "# Replacement"
+    end
+  end
+
   test "documents without seed markdown never grant the seed" do
     doc = Document.create!(title: "Blank", seed_markdown: nil)
 


### PR DESCRIPTION
## Summary

CLI replacement no longer leaves an already-open browser session with an empty editor. The server now sends a seed generation with document page props, and the editor records seed consumption per generation instead of per slug, so replacing live content at the same URL can seed the new CRDT document once while stale browser-history props still cannot duplicate old content.

This fixes the follow-up symptom from #116 where `thinkroom update` succeeded and the agent API still returned the Markdown, but the browser showed the source briefly and then went blank after the live editor mounted. Production document `KzQbftEGc2` confirmed that shape: `content_snapshot` and `yjs_state` were nil, `seed_state` had already been claimed, and the canonical Markdown was still present.

## Validation

- `env -u FORCE_COLOR npm run check`
- `bin/rails test test/integration/document_seed_claim_test.rb`
- `bin/rails test test/models/document_test.rb test/integration/agent_api_test.rb test/channels/sync_channel_test.rb`
- `bin/rails test`
- `bin/rubocop`
- Playwright local browser reproduction: opened a seeded doc, replaced its source at the same slug, reopened in the same browser context, and verified the live editor settled on the replacement text instead of going empty.

Fixes #116

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
