### PR TITLE
fix: require --force for thinkroom update on a claimed document (#121)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     commonmarker (2.8.2-x86_64-linux-musl)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -497,7 +497,7 @@ CHECKSUMS
   commonmarker (2.8.2-x86_64-linux-musl) sha256=66568dce1c6f265e85d57ea7f749a148446527c7dd599c6ded4cdc819997c43e
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -59,11 +59,14 @@ module Api
     end
 
     # PATCH/PUT /api/docs/:slug — revise a document in place. Unclaimed drafts
-    # still use the seed-stage path; authenticated account owners may also
-    # replace their own live document by resetting stale CRDT/snapshot state to
-    # the new source. Non-owners on claimed/live documents keep the suggestion
-    # workflow so a full replacement never bypasses ownership.
+    # still use the seed-stage path. An authenticated account owner may also
+    # replace their own live document, but because that discards human edits,
+    # the live CRDT/snapshot state, and pending suggestions, it requires an
+    # explicit force opt-in — a bare update is refused rather than silently
+    # destroying that work (issue #121). Non-owners on claimed/live documents
+    # keep the suggestion workflow so a full replacement never bypasses ownership.
     def update
+      force = ActiveModel::Type::Boolean.new.cast(params[:force])
       live_owner_replacement = !document.seed_stage? && owner_via_cli_token?
       return render_update_conflict unless live_owner_replacement || (document.seed_stage? && updatable_in_place?)
 
@@ -82,6 +85,13 @@ module Api
                       status: :unprocessable_entity
       end
       return if reject_oversized_content(content)
+
+      # Replacing the content of a claimed, live document destroys human browser
+      # edits, the live CRDT state, and any pending suggestions. Never do that
+      # silently: require an explicit force opt-in so a routine update can't look
+      # like success while corrupting the document (issue #121). A title-only
+      # owner update is non-destructive and stays allowed without force.
+      return render_claimed_replacement_warning if live_owner_replacement && content.present? && !force
 
       normalized = false
       warning = nil
@@ -122,7 +132,11 @@ module Api
           action: "updated_document", detail: document.title
         )
       end
-      DocumentMetaChannel.broadcast_event(document, :content_reset) if content_reset
+      if content_reset
+        DocumentMetaChannel.broadcast_event(document, :content_reset)
+        # The replacement cleared pending suggestions; tell open panels to refresh.
+        DocumentMetaChannel.broadcast_event(document, :suggestions)
+      end
 
       render json: agent_document_response(document, normalized:, warning:), status: :ok
     end
@@ -171,11 +185,28 @@ module Api
         document.owned_by?(nil, user: current_api_user)
     end
 
+    # The owner CAN replace their own document, but past the seed stage that
+    # discards human browser edits, the live CRDT state, and pending suggestions.
+    # Refuse a bare update so it can never silently destroy that work (issue
+    # #121): teach the safe suggestion path and the explicit force opt-in the
+    # owner uses when an overwrite is genuinely intended.
+    def render_claimed_replacement_warning
+      suggestions_url = "#{api_doc_url(document.slug)}/suggestions"
+      render json: {
+        error: "This document has been claimed and edited in the browser, so its live editor " \
+               "state is authoritative. Updating it would overwrite those human edits and discard " \
+               "pending suggestions.",
+        next_action: "Propose a suggestion instead (POST #{suggestions_url}), or re-run with " \
+                     "--force (force: true) to replace the live document and reset its editor state.",
+        propose_suggestion: suggestions_url,
+        force_hint: "Add --force (CLI) or force: true (API) to overwrite the claimed document."
+      }, status: :conflict
+    end
+
     # A well-formed request that conflicts with the document's current state.
-    # The owner reaches it only past the seed stage (an editor session made the
-    # live CRDT authoritative); everyone else also lands here on a claimed or
-    # collaboratively edited document. Teach the correct next action rather than
-    # failing opaquely or silently no-opping a seed write.
+    # Non-owners land here on a claimed or collaboratively edited document
+    # (owners get render_claimed_replacement_warning instead). Teach the correct
+    # next action rather than failing opaquely or silently no-opping a seed write.
     def render_update_conflict
       revision_workflow = AgentGuide.revision_workflow(document, request.base_url)
       steps = revision_workflow.fetch(:steps).index_by { |step| step.fetch(:action) }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -174,6 +174,10 @@ class Document < ApplicationRecord
         attributes[:seed_author_name] = seed_author_name
       end
       update!(attributes)
+      # A full replacement removes the text that pending suggestions target, so
+      # none of them can apply cleanly. Clear them rather than leaving an
+      # orphaned, unappliable review queue behind (issue #121).
+      suggestions.pending.destroy_all
     end
     self
   end

--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -149,12 +149,13 @@ class AgentGuide
                            rate_limits: contribution_rate_limits,
                            body: { title: "(optional) replacement title",
                                    format: "(optional) must equal this document's immutable content_format",
-                                   content: "(optional) replacement canonical #{source_name} source; send title and/or content" },
+                                   content: "(optional) replacement canonical #{source_name} source; send title and/or content",
+                                   force: "(optional) set true to replace a claimed, live document you own — discards its live editor state and pending suggestions" },
                            limits: { content_max_bytes: Document::MAX_CONTENT_BYTES },
                            returns: { slug: "Unchanged identifier", share_url: "Unchanged share URL",
                                       content: "Updated canonical source", plain_text: "Updated rendered text",
                                       normalized: "Whether source changed during normalization", warning: "Normalization detail" },
-                           purpose: "Revise the document you created in place — same slug, same share URL. An authenticated owner (CLI Bearer token) can replace their own document even after live editing has started; non-owners receive 409 and should propose a suggestion instead." }
+                           purpose: "Revise the document you created in place — same slug, same share URL. While it is still an unclaimed/seed draft it updates directly; once it is claimed and edited, only its authenticated account owner can replace their own document, and only with force: true (a bare update is refused so it cannot silently overwrite human edits). Non-owners receive 409 and should propose a suggestion instead." }
       }
     end
 
@@ -263,7 +264,7 @@ class AgentGuide
         "All your writes go through the same provenance/suggestion machinery as the human UI. There is no side channel: you propose, humans review.",
         "Text you contribute is marked kind=ai provenance (with your agent name as author) and tinted in the editor until a human advances its review state (pending -> reviewed -> endorsed).",
         "Documents you create with source content are pre-attributed as 100% unreviewed AI prose. Before any editor session opens the doc, the provenance summary is derived from the seed source and replaced by the first editor snapshot.",
-        "Updating: PATCH /api/docs/:slug rewrites your document in place — same slug, same share URL — so revisions stay at the link you already shared. An authenticated owner (a Bearer token from `thinkroom login`) can replace their own live document; non-owners get a 409 and should propose suggestions instead.",
+        "Updating: PATCH /api/docs/:slug rewrites your document in place — same slug, same share URL — so revisions stay at the link you already shared. Once it is claimed and edited in the browser a bare update is refused; its authenticated account owner (a Bearer token from `thinkroom login`) can still replace it by sending force: true, which discards the live editor state and pending suggestions. Non-owners get a 409 and should propose suggestions instead.",
         "Connected editors see your suggestions, comments, and presence live over WebSocket — no refresh needed on their side.",
         "Reading state: use plain_text as working context and content when source fidelity matters. This document expects #{source_name} suggestion bodies. State may lag if no human has the document open — the Yjs CRDT state is always authoritative.",
         "Sketches: inline Excalidraw scenes appear in content and are summarized in plain_text from their human description and text labels. Treat the scene as editable source and SVG as a derived browser export; embedded bitmap files are not supported. To author one in Markdown, embed a fenced excalidraw block following content_contract.sketches.markdown_source (formatVersion, id, description, height, and a full excalidraw scene with type/version/appState/files) — copy its example to start. A recognized sketch shows in plain_text as \"Sketch: <description> — <labels>\"; raw scene JSON in plain_text means the block was not recognized, and the create response then returns normalized: true with a warning.",
@@ -412,10 +413,13 @@ class AgentGuide
              -H "X-Agent-Name: YOUR_NAME" -H "Content-Type: application/json" \\
              -d '{"title": "Revised", "content": "..."}'
         format is immutable; omit it or send the document's existing format.
-        If you authenticate with a Bearer token (thinkroom login) and own the
-        document, you can keep updating it in place even after it is claimed or
-        after live editing has started. If you do not own the document, PATCH
-        returns 409 once it is claimed or live; propose a suggestion instead.
+        While the document is still an unclaimed seed draft this just works. Once
+        it has been claimed and edited in the browser, a bare update is refused —
+        replacing it would discard the human's edits and pending suggestions. If
+        you authenticate with a Bearer token (thinkroom login), own the document,
+        and intend a full overwrite, add "force": true (CLI: --force). If you do
+        not own the document, PATCH returns 409 once it is claimed or live;
+        propose a suggestion instead.
 
         HTML is sanitized and normalized to Thinkroom's editable schema. Create and
         suggestion responses include normalized=true plus a warning when

--- a/cli/bin/thinkroom.js
+++ b/cli/bin/thinkroom.js
@@ -45,7 +45,7 @@ class ApiError extends CliError {
 function parseArgs(argv) {
   const options = {}
   const positionals = []
-  const booleans = new Set(['json', 'help', 'version', 'no-open'])
+  const booleans = new Set(['json', 'help', 'version', 'no-open', 'force'])
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]
@@ -316,6 +316,9 @@ async function updateDocument(positionals, options) {
   if (options.title) body.title = options.title
   if (content !== undefined) body.content = content
   if (options.format) body.format = options.format
+  // Replacing a claimed/live document is destructive; the server refuses it
+  // without an explicit opt-in. --force makes that intent explicit.
+  if (options.force) body.force = true
   if (Object.keys(body).length === 0) throw new CliError('Provide a file/stdin and/or --title to update the document.')
   const result = await request(`/api/docs/${encodeURIComponent(slug)}`, options, {
     method: 'PATCH',
@@ -487,7 +490,7 @@ function help() {
   process.stdout.write(`Thinkroom CLI ${VERSION}\n\n`)
   process.stdout.write('Usage: thinkroom <command> [arguments] [options]\n\n')
   process.stdout.write('Account\n  login [--url URL] [--no-open]\n  whoami [--json]\n  logout\n\n')
-  process.stdout.write('Documents\n  new [FILE|-] [--title TITLE] [--format markdown|html] [--agent NAME] [--json]\n  show SLUG|URL [--json]\n  update SLUG|URL [FILE|-] [--title TITLE] [--agent NAME] [--json]\n  suggest SLUG|URL [FILE|-] --body TEXT --replaces TEXT --intent TEXT [--agent NAME]\n  comment SLUG|URL [FILE|-] --body TEXT [--anchor TEXT] [--agent NAME]\n  open SLUG|URL\n\n')
+  process.stdout.write('Documents\n  new [FILE|-] [--title TITLE] [--format markdown|html] [--agent NAME] [--json]\n  show SLUG|URL [--json]\n  update SLUG|URL [FILE|-] [--title TITLE] [--force] [--agent NAME] [--json]\n  suggest SLUG|URL [FILE|-] --body TEXT --replaces TEXT --intent TEXT [--agent NAME]\n  comment SLUG|URL [FILE|-] --body TEXT [--anchor TEXT] [--agent NAME]\n  open SLUG|URL\n\n')
   process.stdout.write('Agent setup\n  init [--agent agents|claude|codex|all]\n  skill install [--agent agents|claude|codex|all]\n  prime [--json]\n\n')
   process.stdout.write('Environment: THINKROOM_URL, THINKROOM_TOKEN, THINKROOM_AGENT, XDG_CONFIG_HOME\n')
 }

--- a/cli/skill/thinkroom/SKILL.md
+++ b/cli/skill/thinkroom/SKILL.md
@@ -45,7 +45,13 @@ For a document that is still an untouched seed, revise it in place:
 thinkroom update SHARE_URL revision.md --title "Updated title" --agent "Codex"
 ```
 
-If you are logged in (`thinkroom login`) and own the document, you can update it in place this way even after it is claimed or after a live editing session exists. Owner updates are full replacements of the document source at the same share URL.
+Once a document has been claimed and edited in the browser, a bare `thinkroom update` is refused — overwriting it would discard the human's edits, the live editor state, and any pending suggestions. Prefer `thinkroom suggest` for changes to a claimed document. If you are logged in (`thinkroom login`), own the document, and genuinely intend a full replacement, re-run with `--force`:
+
+```bash
+thinkroom update SHARE_URL revision.md --force --agent "Codex"
+```
+
+A forced update replaces the document source at the same share URL and clears pending suggestions, so use it only when overwriting the human's edits is intended.
 
 If you do not own the document, do not try to overwrite a claimed or live document from the CLI. Propose the smallest exact replacement and include intent:
 

--- a/cli/test/thinkroom.test.js
+++ b/cli/test/thinkroom.test.js
@@ -273,3 +273,40 @@ test('writes warn on the generic identity fallback and honor THINKROOM_AGENT', a
   assert.equal(seen[1].agent, 'Claude')
   assert.equal(fromEnv.stderr, '', 'an explicit THINKROOM_AGENT must suppress the fallback warning')
 })
+
+test('update is refused on a claimed doc and --force opts in to replacement', async (t) => {
+  const root = await temporaryDirectory('force-update')
+  const configHome = path.join(root, 'config')
+  const seen = []
+  const server = await startServer(async (request, response) => {
+    if (request.method === 'PATCH' && request.url === '/api/docs/claimed123') {
+      const body = await jsonRequest(request)
+      seen.push(body)
+      if (!body.force) {
+        return sendJson(response, 409, {
+          error: 'This document has been claimed and edited in the browser.',
+          next_action: 'Propose a suggestion instead, or re-run with --force to replace the live document.',
+        })
+      }
+      return sendJson(response, 200, { share_url: `${server.url}/d/claimed123` })
+    }
+    return sendJson(response, 404, { error: 'Unexpected request' })
+  })
+  t.after(() => server.close())
+  const env = { THINKROOM_URL: server.url }
+
+  const refused = await runCli(['update', 'claimed123', '-', '--agent', 'Codex'], {
+    cwd: root, configHome, env, input: '# Revision',
+  })
+  assert.equal(refused.code, 1)
+  assert.match(refused.stderr, /claimed/)
+  assert.match(refused.stderr, /--force/)
+  assert.equal(seen[0].force, undefined, 'a bare update must not send force')
+
+  const forced = await runCli(['update', 'claimed123', '-', '--force', '--agent', 'Codex'], {
+    cwd: root, configHome, env, input: '# Revision',
+  })
+  assert.equal(forced.code, 0, forced.stderr)
+  assert.equal(forced.stdout.trim(), `${server.url}/d/claimed123`)
+  assert.equal(seen[1].force, true, '--force sends force: true')
+})

--- a/docs/plans/2026-06-28-002-fix-block-or-warn-claimed-doc-update-plan.md
+++ b/docs/plans/2026-06-28-002-fix-block-or-warn-claimed-doc-update-plan.md
@@ -1,0 +1,158 @@
+---
+title: "fix: Block or warn thinkroom update on a claimed document"
+type: fix
+date: 2026-06-28
+origin: https://github.com/kieranklaassen/thinkroom/issues/121
+---
+
+# fix: Block or warn `thinkroom update` on a claimed document
+
+## Summary
+
+After #114/#117/#118 let an authenticated owner replace their own live document
+through `thinkroom update`, issue #121 reports that doing so on a claimed,
+human-edited document is a footgun. The update returns a share URL with exit
+code 0 (looks like success) but:
+
+1. The browser never reflects the new content (#119/#120 — separate agents).
+2. Subsequent `thinkroom suggest --replaces` calls fail with "target missing,
+   ambiguous, or empty" because the replacement shifted the underlying content.
+3. Pending suggestions are orphaned and need manual dismissal.
+
+#121 asks for the destructive overwrite to stop being silent: either return an
+error pointing at `thinkroom suggest`, or warn before proceeding.
+
+This plan reconciles #116 (owners *want* to be able to replace) with #121
+(the silent overwrite is dangerous) by gating the destructive live replacement
+behind an explicit `--force` / `force: true` opt-in — the exact mechanism the
+reporter proposed in #116 — and by clearing now-orphaned pending suggestions
+when a forced replacement happens.
+
+Scope note: the browser-reflection bugs (#119, #120) are owned by other agents.
+This change deliberately does NOT touch the editor reseed/`content_reset`
+frontend wiring; it fixes the silent-success and suggestion-corruption symptoms
+at the API/model/CLI layer.
+
+---
+
+## Problem Frame
+
+`Api::DocsController#update` currently treats an authenticated owner past the
+seed stage as `live_owner_replacement` and immediately calls
+`Document#replace_content!`, which wipes `content_snapshot`/`yjs_state` and resets
+the seed lifecycle. There is no confirmation step, so a routine `thinkroom update`
+silently discards the human's browser edits and leaves pending suggestions that
+target text which no longer exists.
+
+The fix must keep:
+- Unclaimed-draft seed updates working (anonymous + owner).
+- Owner *seed-stage* updates of their own claimed-but-not-yet-edited doc working.
+- Owner *title-only* updates of a live doc working (non-destructive rename).
+- Non-owner conflicts returning the existing 409 suggestion workflow.
+
+…while requiring an explicit opt-in for the one destructive case: replacing the
+*content* of a claimed, live document.
+
+---
+
+## Requirements
+
+- R1. A bare `thinkroom update` (no force) that would replace a claimed, live
+  document's content must NOT succeed silently. It returns a clear conflict
+  explaining the doc is claimed and how to proceed (suggest, or `--force`).
+- R2. `thinkroom update --force` (API `force: true`) lets the authenticated
+  account owner replace their own live document, preserving the #116 capability.
+- R3. A forced replacement clears the document's pending suggestions, so the
+  review queue is not corrupted and subsequent `suggest` calls match fresh content.
+- R4. Owner title-only updates and owner seed-stage updates keep working WITHOUT
+  `--force` (they are not destructive of live human edits).
+- R5. Non-owners, other accounts, guest-cookie owners, and unclaimable docs keep
+  their existing behavior; `force` never substitutes for ownership.
+- R6. CLI and agent-facing guidance describe the `--force` requirement and that
+  the default path is safe (suggest).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[PATCH /api/docs/:slug] --> B{owner & past seed stage?}
+  B -->|no| C{seed-stage & updatable?}
+  C -->|yes| S[seed update]
+  C -->|no| N[409 non-owner suggestion workflow]
+  B -->|yes| D{content present?}
+  D -->|no, title only| T[rename without reset]
+  D -->|yes| F{force?}
+  F -->|no| W[409 claimed-replacement warning]
+  F -->|yes| R[replace_content! + clear pending suggestions + broadcast]
+```
+
+---
+
+## Implementation Units
+
+### U1. Gate destructive live replacement behind `force` (API)
+
+**Files:** `app/controllers/api/docs_controller.rb`, `test/integration/agent_api_test.rb`
+
+- Parse `force = ActiveModel::Type::Boolean.new.cast(params[:force])`.
+- When `live_owner_replacement && content.present? && !force`, render a focused
+  409 warning (`error` + `next_action` + `propose_suggestion` URL) instead of
+  replacing. Keep `render_update_conflict` for non-owners.
+- When forced, proceed with the existing `replace_content!` path and broadcast
+  `:content_reset` plus `:suggestions` (so open panels clear).
+
+### U2. Clear orphaned pending suggestions on replacement (model)
+
+**Files:** `app/models/document.rb`, `test/models/document_test.rb`
+
+- In `Document#replace_content!`, after the destructive `update!`, destroy
+  `suggestions.pending` (their `replaces`/`anchor_text` targets are gone).
+
+### U3. `--force` flag (CLI)
+
+**Files:** `cli/bin/thinkroom.js`, `cli/test/thinkroom.test.js`
+
+- Add `force` to the boolean flags; when set, include `force: true` in the PATCH
+  body. The existing `ApiError` already prints `error` + `next_action`, so the
+  default warning surfaces cleanly.
+
+### U4. Guidance
+
+**Files:** `app/services/agent_guide.rb`, `cli/skill/thinkroom/SKILL.md`
+
+- Document that replacing a claimed/live owned document requires `--force` and
+  that non-owners (and owners who don't want to overwrite) should use `suggest`.
+
+---
+
+## Scope Boundaries
+
+- Does not change the browser reseed / `content_reset` rendering path (#119/#120).
+- Does not let non-owners overwrite anything.
+- Does not remove the owner replacement capability — it makes it explicit.
+
+---
+
+## Test Scenarios
+
+- Owner content replacement on a live doc WITHOUT force → 409 warning; content,
+  snapshot, yjs_state, and pending suggestions all unchanged.
+- Owner content replacement on a live doc WITH force → 200; content replaced,
+  live state reset, pending suggestions cleared, `content_reset` broadcast.
+- Owner title-only update on a live doc → 200 without force, content untouched.
+- Owner seed-stage update → 200 without force (unchanged).
+- Non-owner / other account / guest-cookie / unclaimable → 409 (unchanged); force
+  does not help.
+- `Document#replace_content!` destroys pending suggestions.
+- CLI `update --force` sends `force: true`; CLI surfaces the default warning.
+
+---
+
+## Verification
+
+- `bin/rails test` (Minitest), `bin/rubocop`, `npm run check`, `npm --prefix cli test`.
+- End-to-end with the real `thinkroom` CLI against a `bin/dev` server: claim a
+  doc in the browser, confirm bare `update` is refused with guidance, confirm
+  `--force` replaces and leaves no orphaned pending suggestions.

--- a/test/integration/agent_api_test.rb
+++ b/test/integration/agent_api_test.rb
@@ -819,7 +819,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
 
     assert_broadcast_on(DocumentMetaChannel.broadcasting_for(doc), event: "content_reset") do
       patch "/api/docs/#{doc.slug}",
-            params: { title: "Replaced", content: "# replace" },
+            params: { title: "Replaced", content: "# replace", force: true },
             headers: bearer(raw_token), as: :json
     end
 
@@ -850,7 +850,7 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     )
 
     patch "/api/docs/#{doc.slug}",
-          params: { content: "# replace" },
+          params: { content: "# replace", force: true },
           headers: bearer(raw_token), as: :json
 
     assert_response :ok
@@ -876,6 +876,87 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal "Renamed", doc.title
     assert_equal "# editor snapshot", doc.current_content
     assert_equal "binary-crdt-state", doc.yjs_state
+  end
+
+  test "owner content replacement on a claimed live document is refused without force" do
+    user = cli_user(email: "owner-live-noforce@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Live", user:, owner_name: user.name,
+      seed_content: "# Seed", content_snapshot: "# editor snapshot",
+      yjs_state: "binary-crdt-state"
+    )
+    suggestion = doc.suggestions.create!(
+      author_name: "Scout", author_kind: "agent", status: "pending",
+      body: "improved", replaces: "editor snapshot"
+    )
+
+    assert_no_broadcasts(DocumentMetaChannel.broadcasting_for(doc)) do
+      patch "/api/docs/#{doc.slug}",
+            params: { content: "# replace" },
+            headers: bearer(raw_token), as: :json
+    end
+
+    assert_response :conflict
+    body = response.parsed_body
+    assert_includes body["error"], "claimed"
+    assert_includes body["next_action"], "--force"
+    assert_includes body["propose_suggestion"], "/api/docs/#{doc.slug}/suggestions"
+
+    doc.reload
+    assert_equal "# editor snapshot", doc.current_content,
+                 "a bare update must not overwrite the live document"
+    assert_equal "binary-crdt-state", doc.yjs_state
+    assert Suggestion.exists?(suggestion.id), "pending suggestions survive a refused update"
+  end
+
+  test "forced owner replacement clears orphaned pending suggestions" do
+    user = cli_user(email: "owner-live-force@example.com")
+    _record, raw_token = CliAccessToken.issue!(user:)
+    doc = Document.create!(
+      title: "Live", user:, owner_name: user.name,
+      seed_content: "# Seed", content_snapshot: "# editor snapshot",
+      yjs_state: "binary-crdt-state"
+    )
+    orphan = doc.suggestions.create!(
+      author_name: "Scout", author_kind: "agent", status: "pending",
+      body: "improved", replaces: "editor snapshot"
+    )
+    resolved = doc.suggestions.create!(
+      author_name: "Scout", author_kind: "agent", status: "accepted",
+      body: "kept", replaces: "Seed"
+    )
+
+    assert_broadcast_on(DocumentMetaChannel.broadcasting_for(doc), event: "suggestions") do
+      patch "/api/docs/#{doc.slug}",
+            params: { content: "# replace", force: true },
+            headers: bearer(raw_token), as: :json
+    end
+
+    assert_response :ok
+    assert_equal "# replace", doc.reload.current_content
+    refute Suggestion.exists?(orphan.id), "a forced replacement clears pending suggestions"
+    assert Suggestion.exists?(resolved.id), "resolved suggestions are history and stay"
+  end
+
+  test "force does not let a non-owner overwrite a claimed live document" do
+    owner = cli_user(email: "force-owner@example.com")
+    other = cli_user(email: "force-impostor@example.com", name: "Other")
+    _record, raw_token = CliAccessToken.issue!(user: other)
+    doc = Document.create!(
+      title: "Theirs", user: owner, owner_name: owner.name,
+      seed_content: "# Seed", content_snapshot: "# Owner content",
+      yjs_state: "binary-crdt-state"
+    )
+
+    patch "/api/docs/#{doc.slug}",
+          params: { content: "# not yours", force: true },
+          headers: bearer(raw_token), as: :json
+
+    assert_response :conflict
+    assert_includes response.parsed_body["error"], "no longer an unclaimed draft"
+    assert_equal "# Owner content", doc.reload.current_content,
+                 "force from a non-owner must not overwrite the document"
   end
 
   test "an unclaimable document is not updatable even with a bearer token" do
@@ -1092,6 +1173,8 @@ class AgentApiTest < ActionDispatch::IntegrationTest
     assert_equal 409, update["conflict_status"]
     assert_includes update["url"], "/api/docs/#{response.parsed_body['slug']}"
     assert_includes update["purpose"], "replace their own document"
+    assert_includes update["purpose"], "force: true"
+    assert update.dig("body", "force").present?, "the update endpoint advertises the force opt-in"
   end
 
   test "state payload advertises the update endpoint and explains it in notes" do

--- a/test/integration/feedback_runs_test.rb
+++ b/test/integration/feedback_runs_test.rb
@@ -34,6 +34,11 @@ class FeedbackRunsTest < ActionDispatch::IntegrationTest
   end
 
   setup do
+    # sign_in posts to the authentication-rate-limited sessions endpoint, and
+    # the limiter's store is process-global. Clear it so sign-ins accumulated by
+    # parallel test workers can't flake this suite to 429 (mirrors the other
+    # auth-exercising suites, e.g. authentication_flow_test).
+    WriteRateLimited::STORE.clear
     @cursor_client = FakeCursorClient.new
     Rails.application.config.x.cursor_client = @cursor_client
   end

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -133,6 +133,26 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "Codex", doc.seed_author_name
   end
 
+  test "replace content clears pending suggestions but keeps resolved ones" do
+    doc = Document.create!(
+      title: "Live", seed_content: "# Seed", content_snapshot: "# Snapshot",
+      yjs_state: "old-crdt-state"
+    )
+    pending = doc.suggestions.create!(
+      author_name: "Codex", author_kind: "agent", status: "pending",
+      body: "new", replaces: "Snapshot"
+    )
+    accepted = doc.suggestions.create!(
+      author_name: "Codex", author_kind: "agent", status: "accepted",
+      body: "kept", replaces: "Seed"
+    )
+
+    doc.replace_content!(source: "# Replacement")
+
+    refute Suggestion.exists?(pending.id), "pending suggestions target text that is now gone"
+    assert Suggestion.exists?(accepted.id), "resolved suggestions are history and are kept"
+  end
+
   test "database rejects unknown content formats" do
     doc = Document.create!(title: "Constrained")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (#121)

After #114/#117/#118 let an authenticated owner replace their own live document through `thinkroom update`, doing so on a claimed, human-edited document became a footgun. A bare `thinkroom update` returned a share URL with exit code 0 (looks like success) but silently:

1. Wiped the human's browser edits (`replace_content!` resets snapshot/CRDT state).
2. Left **orphaned pending suggestions** whose `replaces`/`anchor_text` targets no longer existed — so later `thinkroom suggest --replaces` failed with "target missing, ambiguous, or empty," and the queue had to be dismissed by hand.

As #121 puts it: *"the current silent success is the worst outcome."*

## Fix

Reconcile #116 (owners *want* to replace) with #121 (silent overwrite is dangerous) using the exact mechanism the reporter proposed in #116 — an explicit `--force` opt-in:

- **Bare `thinkroom update` on a claimed, live document is refused** with a clear 409 that names the safe path (`thinkroom suggest`) and the explicit override (`--force`). No more silent success.
- **`thinkroom update --force` (`force: true`)** lets the account owner replace their own live document, preserving the #116 capability, and **clears the now-orphaned pending suggestions** so the review queue isn't corrupted.
- **Unchanged:** owner title-only renames and seed-stage updates (non-destructive, no force needed); non-owners still get the 409 suggestion workflow — `force` never substitutes for ownership.

## Scope

This targets #121's "block or warn" ask. It deliberately does **not** touch the editor reseed / `content_reset` frontend rendering path — the browser-staleness bugs (#119, #120) are owned by other agents. This change fixes the silent-success and suggestion-corruption symptoms at the API/model/CLI layer.

## Changes

- `app/controllers/api/docs_controller.rb` — parse `force`; refuse a bare destructive replacement with `render_claimed_replacement_warning`; broadcast a `suggestions` refresh after a forced reset.
- `app/models/document.rb` — `replace_content!` clears `suggestions.pending` (their targets are gone after a full replacement).
- `cli/bin/thinkroom.js` — add `--force` to `update`.
- `app/services/agent_guide.rb`, `cli/skill/thinkroom/SKILL.md` — document the `force` requirement and prefer `suggest` for claimed docs.

Two supporting commits keep CI green (both independent of the feature):
- `chore(security)`: bump transitive `crass` 1.0.6 → 1.0.7 (fixes the `bundler-audit` advisory GHSA-wwpr-jff3-395c that was failing `scan_ruby`).
- `test`: clear the auth rate-limit store in `FeedbackRunsTest` setup — a pre-existing parallel-execution flake (sign-ins crossing the 10/IP auth limit → 429), reproducible at `--seed 31140` with `PARALLEL_WORKERS=2`.

## Testing

- **Reproduced the footgun first** (bare owner update on a claimed/live doc → 200, content wiped, suggestion orphaned), then verified the fix.
- New/updated Minitest coverage: bare owner content update refused (409, nothing changed, suggestion survives); forced replacement clears orphaned pending suggestions + broadcasts; force from a non-owner still 409; title-only/seed-stage owner updates still work without force; `replace_content!` clears pending but keeps resolved suggestions.
- New CLI test: bare update on a claimed doc surfaces the warning; `--force` sends `force: true`.
- Full suite green: `bin/rails test` (475 runs, 0 failures), `bin/rubocop` clean, `npm run check` (tsc + CLI tests), `bin/brakeman` (0 warnings), `bin/bundler-audit` (clean after the crass bump).

### End-to-end walkthrough (real `thinkroom` CLI against a `bin/dev` server)

A document was created via the CLI, then claimed and edited in the browser (real CRDT/live state):

[Claimed, human-edited document in the Thinkroom editor](https://cursor.com/agents/bc-ac6e2a20-9aef-4cb8-bffe-fcdd86b81ca8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser_human_edited_doc.webp)

Then the CLI flow shows the bare update refused and `--force` succeeding while clearing the orphaned suggestion:

[CLI transcript: bare update refused, --force replaces and clears suggestions](https://cursor.com/agents/bc-ac6e2a20-9aef-4cb8-bffe-fcdd86b81ca8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_claimed_update_force_transcript.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac6e2a20-9aef-4cb8-bffe-fcdd86b81ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac6e2a20-9aef-4cb8-bffe-fcdd86b81ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

