### PR TITLE
fix(editor): reject stale CRDT frames after owner content replacement

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -23,7 +23,11 @@ class SyncChannel < ApplicationCable::Channel
     stream_for @document
 
     full_state, state_vector = YjsPersistence.state_b64(@document)
-    message = { type: "sync", update: full_state, sv: state_vector }
+    # The content generation this client is syncing from. It stamps every frame
+    # the client sends back; frames from a superseded generation (after an owner
+    # replace_content!) are dropped server-side instead of resurrecting the old
+    # CRDT state. Absent for pre-rollout clients — treated as generation 0.
+    message = { type: "sync", update: full_state, sv: state_vector, epoch: @document.crdt_epoch }
     if claim_seed?
       message[:seed] = true
       message[:content_format] = @document.content_format
@@ -55,14 +59,15 @@ class SyncChannel < ApplicationCable::Channel
         return
       end
 
+      epoch = data["epoch"]
       if data.key?("seq")
         sequence = Integer(data["seq"], exception: false)
         return unless sequence&.positive?
 
-        enqueue_update(sequence, message, update)
+        enqueue_update(sequence, message, update, epoch)
       else
         # Rollout compatibility for clients deployed before ordered frames.
-        persist_and_broadcast(message, update)
+        persist_and_broadcast(message, update, epoch)
       end
     when "awareness", "awareness-query"
       self.class.broadcast_to(@document, message)
@@ -76,7 +81,7 @@ class SyncChannel < ApplicationCable::Channel
   # one of those updates in isolation leaves pending structs that y-rb's
   # full_diff does not serialize. Sequence and drain each subscription's
   # frames in client order before persisting them.
-  def enqueue_update(sequence, message, update)
+  def enqueue_update(sequence, message, update, epoch)
     @sequence_lock.synchronize do
       return if sequence < @next_sequence
       if sequence > @next_sequence + MAX_SEQUENCE_GAP
@@ -84,7 +89,7 @@ class SyncChannel < ApplicationCable::Channel
         return
       end
 
-      @pending_updates[sequence] ||= [ message, update ]
+      @pending_updates[sequence] ||= [ message, update, epoch ]
       while (frame = @pending_updates.delete(@next_sequence))
         persist_and_broadcast(*frame)
         @next_sequence += 1
@@ -92,13 +97,19 @@ class SyncChannel < ApplicationCable::Channel
     end
   end
 
-  def persist_and_broadcast(message, update)
-    YjsPersistence.merge(
+  def persist_and_broadcast(message, update, epoch)
+    relayable = YjsPersistence.merge(
       @document,
       update,
       token: (connection.owner_token if connection.respond_to?(:owner_token)),
-      user: (connection.current_user if connection.respond_to?(:current_user))
+      user: (connection.current_user if connection.respond_to?(:current_user)),
+      epoch: epoch
     )
+    # A stale-generation frame (produced before an owner replace_content!) is
+    # neither persisted nor relayed — broadcasting it would let peers merge the
+    # superseded content back into their freshly reset docs.
+    return unless relayable
+
     # A peer seeing an edit means the server has made it durable. This
     # ordering also prevents clients from accepting a frame that failed
     # persistence and would disappear on reload.

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -320,7 +320,8 @@ class DocumentsController < InertiaController
       spans:,
       title:,
       token: owner_token,
-      user: current_user
+      user: current_user,
+      epoch: params[:epoch]
     )
     return render json: { error: "Snapshot is stale; retry from current document state." },
                   status: :conflict unless persisted
@@ -375,7 +376,8 @@ class DocumentsController < InertiaController
         spans:,
         title:,
         token: owner_token,
-        user: current_user
+        user: current_user,
+        epoch: params[:epoch]
       )
       return render json: { error: "Snapshot is stale; retry from current document state." },
                     status: :conflict unless persisted

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -284,6 +284,11 @@ class DocumentsController < InertiaController
     document = Document.find_by!(slug: params[:slug])
     @write_document = document
     document.assert_write_access!(token: owner_token, user: current_user)
+    # A snapshot derived before an owner replace_content! reset would write the
+    # superseded source into the read model. Drop it silently — the client
+    # reloads into the new generation via content_reset — instead of letting
+    # current_content diverge from the live editor state.
+    return head :no_content if document.crdt_epoch > params[:epoch].to_i
     if params.key?(:content) && params.key?(:markdown)
       return render json: { error: "Send content or legacy markdown, not both." },
                     status: :unprocessable_entity

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -337,7 +337,12 @@ class DocumentsController < InertiaController
     decoded = Base64.strict_decode64(update)
     return head :content_too_large if decoded.bytesize > MAX_SYNC_UPDATE_BYTES
 
-    YjsPersistence.merge(document, update, token: owner_token, user: current_user)
+    relayable = YjsPersistence.merge(document, update, token: owner_token, user: current_user, epoch: params[:epoch])
+    # A stale-generation keepalive frame (the source was replaced out from under
+    # this client via replace_content!) must neither relay nor re-persist the
+    # superseded content/snapshot. The client recovers through content_reset.
+    return head :no_content unless relayable
+
     SyncChannel.broadcast_to(document, {
       type: "update",
       update:,

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -125,6 +125,12 @@ export class CableProvider {
     this.listeners.get(event)?.delete(handler as never)
   }
 
+  // The generation derived snapshots must be stamped with, so the server drops
+  // a snapshot produced before an owner replace_content! reset.
+  get contentEpoch(): number {
+    return this.serverEpoch
+  }
+
   destroy(): void {
     if (this.destroyed) return
     this.destroyed = true

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -13,6 +13,9 @@ type SyncMessage = {
   type: 'sync' | 'sync-reply' | 'update' | 'awareness' | 'awareness-query' | 'write-denied'
   update?: string
   sv?: string
+  /** Server content generation. Bumped by an owner replace_content!; echoed on
+   *  outgoing frames so the server can drop ones from a superseded generation. */
+  epoch?: number
   seed?: boolean
   content_format?: 'markdown' | 'html'
   seed_content?: string
@@ -51,6 +54,13 @@ export class CableProvider {
   readonly awareness: Awareness
   readonly clientId = crypto.randomUUID()
   synced = false
+  // The server content generation this client last synced at. Stamped on every
+  // outgoing frame so the server drops frames produced before an owner
+  // replace_content! reset (which would otherwise resurrect the old CRDT state).
+  private serverEpoch = 0
+  // True once any sync has landed; unlike `synced` it survives disconnects, so a
+  // reconnect can tell "first handshake" from "re-handshake at a new generation".
+  private hasSynced = false
   seedContent: string | null = null
   seedFormat: 'markdown' | 'html' = 'markdown'
   // Seed authorship rides alongside seedContent with the same one-shot
@@ -106,12 +116,12 @@ export class CableProvider {
     window.addEventListener('beforeunload', this.handleUnload)
   }
 
-  on(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
+  on(event: 'synced' | 'seed' | 'rejected' | 'write-denied' | 'superseded', handler: () => void): void {
     if (!this.listeners.has(event)) this.listeners.set(event, new Set())
     this.listeners.get(event)!.add(handler as never)
   }
 
-  off(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
+  off(event: 'synced' | 'seed' | 'rejected' | 'write-denied' | 'superseded', handler: () => void): void {
     this.listeners.get(event)?.delete(handler as never)
   }
 
@@ -144,7 +154,7 @@ export class CableProvider {
 
   private sendUpdate(type: 'sync-reply' | 'update', update: Uint8Array): void {
     this.updateSequence += 1
-    this.send({ type, update: toBase64(update), seq: this.updateSequence })
+    this.send({ type, update: toBase64(update), seq: this.updateSequence, epoch: this.serverEpoch })
   }
 
   /**
@@ -159,7 +169,7 @@ export class CableProvider {
       : Y.encodeStateAsUpdate(this.doc)
     const persistedVector = Y.encodeStateVector(this.doc)
 
-    const updatePayload = { update: toBase64(update), cid: this.clientId }
+    const updatePayload = { update: toBase64(update), cid: this.clientId, epoch: this.serverEpoch }
     const completePayload = { ...updatePayload, ...snapshot }
     const completeBody = JSON.stringify(completePayload)
     // Browsers cap keepalive request bodies at roughly 64 KiB. Large docs
@@ -191,6 +201,19 @@ export class CableProvider {
 
     switch (data.type) {
       case 'sync': {
+        const incomingEpoch = data.epoch ?? 0
+        // A reconnect that lands on a newer generation means the source was
+        // replaced (replace_content!) while we held the old one — possibly
+        // while we were offline and missed the content_reset signal. Replying
+        // with our stale state would resurrect the replaced content, so skip the
+        // handshake and recover by reloading into the new generation.
+        if (this.hasSynced && incomingEpoch > this.serverEpoch) {
+          this.serverEpoch = incomingEpoch
+          this.emit('superseded')
+          break
+        }
+        this.serverEpoch = incomingEpoch
+        this.hasSynced = true
         // Server's full state, then reply with what it's missing (sync step 2).
         Y.applyUpdate(this.doc, fromBase64(data.update!), this)
         const serverVector = fromBase64(data.sv!)

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -212,9 +212,11 @@ export class CableProvider {
         // replaced (replace_content!) while we held the old one — possibly
         // while we were offline and missed the content_reset signal. Replying
         // with our stale state would resurrect the replaced content, so skip the
-        // handshake and recover by reloading into the new generation.
+        // handshake and recover by reloading into the new generation. Keep
+        // serverEpoch at the superseded value on purpose: a keepalive/snapshot
+        // that fires before the reload tears us down is then stamped stale and
+        // dropped server-side, rather than re-stamped current and accepted.
         if (this.hasSynced && incomingEpoch > this.serverEpoch) {
-          this.serverEpoch = incomingEpoch
           this.emit('superseded')
           break
         }

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -141,6 +141,10 @@ interface EditorProps {
   onSpans?: (spans: ProvenanceSpan[]) => void
   onSelection?: (view: EditorView) => void
   onTitleChange?: (title: string) => void
+  /** The synced document generation was superseded by an owner replacement
+   *  (replace_content!) while this client held an older one — recover by
+   *  reloading so the new source is applied instead of the stale local doc. */
+  onSuperseded?: () => void
 }
 
 interface ActiveSketch {
@@ -369,13 +373,14 @@ function CollabEditor({
   onSpans,
   onSelection,
   onTitleChange,
+  onSuperseded,
 }: EditorProps) {
   const [sketchDraft, setSketchDraft] = useState<ActiveSketch | undefined>(undefined)
   const insertSketchRef = useRef<() => void>(() => undefined)
   const saveSketchRef = useRef<(data: SketchData) => void>(() => undefined)
   const deleteSketchRef = useRef<(id: string) => void>(() => undefined)
-  const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection, onTitleChange })
-  callbacksRef.current = { onReady, onStatus, onSpans, onSelection, onTitleChange }
+  const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection, onTitleChange, onSuperseded })
+  callbacksRef.current = { onReady, onStatus, onSpans, onSelection, onTitleChange, onSuperseded }
   // Ref so the editable() closure always reads the live value; the effect
   // below nudges ProseMirror to re-read it when the mode changes.
   const editableRef = useRef(editable)
@@ -501,6 +506,11 @@ function CollabEditor({
       initialStateB64,
     )
     callbacksRef.current.onStatus?.('connecting')
+
+    // Reconnecting onto a newer content generation (an owner replaced the
+    // source) means our local doc is stale; let the page reload into it.
+    const handleSuperseded = () => callbacksRef.current.onSuperseded?.()
+    provider.on('superseded', handleSuperseded)
 
     let snapshotTimer: ReturnType<typeof setTimeout> | null = null
     let snapshotRetryTimer: ReturnType<typeof setTimeout> | null = null
@@ -631,6 +641,7 @@ function CollabEditor({
     return () => {
       cancelled = true
       provider.off('synced', start)
+      provider.off('superseded', handleSuperseded)
       if (snapshotTimer) clearTimeout(snapshotTimer)
       if (snapshotRetryTimer) clearTimeout(snapshotRetryTimer)
       try {

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -518,7 +518,10 @@ function CollabEditor({
     const pushSnapshot = (attempt = 0) => {
       if (!canWriteRef.current) return
       editor.action((ctx) => {
-        void postJSON(`/d/${slug}/snapshot`, buildSnapshotPayload(ctx, ydoc, contentFormat))
+        void postJSON(`/d/${slug}/snapshot`, {
+          ...buildSnapshotPayload(ctx, ydoc, contentFormat),
+          epoch: provider.contentEpoch,
+        })
           .then((response) => {
             if (response.status === 409 && attempt < 3 && !cancelled) {
               if (snapshotRetryTimer) clearTimeout(snapshotRetryTimer)

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1369,6 +1369,7 @@ export default function DocumentShow({
                       onSpans={setSpans}
                       onSelection={isReading ? undefined : handleSelection}
                       onTitleChange={setDocumentTitle}
+                      onSuperseded={reloadAfterContentReset}
                     />
                   )}
                 </div>

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -166,7 +166,13 @@ class Document < ApplicationRecord
         provenance_spans: [],
         yjs_state: nil,
         seed_state: "pending",
-        seed_claimed_at: nil
+        seed_claimed_at: nil,
+        # Supersede the prior CRDT generation. A still-connected or reconnecting
+        # editor holding the pre-reset Yjs state would otherwise merge it back
+        # (a reconnect sync-reply dumps the client's whole old document), which
+        # resurrects the old content and re-shadows the new seed. The relay
+        # layer drops frames stamped with an older epoch — see YjsPersistence.merge.
+        crdt_epoch: crdt_epoch + 1
       }
       attributes[:title] = title if title.present?
       if seed_author_kind.present?

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -13,13 +13,30 @@ class YjsPersistence
 
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
-    def merge(document, base64_update, token: nil, user: nil)
+    # Returns true when the frame belongs to the current content generation
+    # (and was therefore relayable), false when it was dropped as stale.
+    #
+    # `epoch` is the document generation the sending client last synced at.
+    # When the source was replaced (replace_content! bumps crdt_epoch), frames
+    # produced from the superseded generation must not resurrect the old CRDT
+    # state — a reconnecting client's sync-reply would otherwise dump its entire
+    # pre-reset document back into the freshly reset doc. A nil epoch is treated
+    # as generation 0 (legacy/rollout clients): harmless on never-reset docs,
+    # correctly dropped on docs that have since been replaced.
+    def merge(document, base64_update, token: nil, user: nil, epoch: nil)
       update = decode(base64_update)
+      relayable = false
       lock_for(document.id).synchronize do
         document.with_lock do
           document.reload
           raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+          # A frame stamped with a generation older than the document's current
+          # one was produced before a replace_content! reset; dropping it keeps
+          # the old CRDT state from coming back. nil/absent stamps count as
+          # generation 0, so never-reset docs (crdt_epoch 0) accept everything.
+          next if document.crdt_epoch > epoch.to_i
 
+          relayable = true
           ydoc = load_ydoc(document)
           before = ydoc.state
           ydoc.sync(update)
@@ -35,6 +52,7 @@ class YjsPersistence
           )
         end
       end
+      relayable
     end
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -69,13 +69,19 @@ class YjsPersistence
     # A client may be ahead (its own cable frame is still in flight), but it
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
-                         token: nil, user: nil)
+                         token: nil, user: nil, epoch: nil)
       client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
       lock_for(document.id).synchronize do
         document.with_lock do
           document.reload
           raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+          # Re-check the generation under the write lock, not just in the
+          # controller: a replace_content! can commit between the unlocked read
+          # and this write, and the currency check below is skipped once the
+          # reset nils yjs_state — without this a stale snapshot would overwrite
+          # the read model after the reset. nil epoch counts as generation 0.
+          return false if document.crdt_epoch > epoch.to_i
 
           if client_state && document.yjs_state.present?
             server_state = decode_state_vector(load_ydoc(document).state)

--- a/db/migrate/20260628201938_add_crdt_epoch_to_documents.rb
+++ b/db/migrate/20260628201938_add_crdt_epoch_to_documents.rb
@@ -1,0 +1,8 @@
+# Monotonic content generation. Bumped only when replace_content! resets the
+# document's CRDT/source state, so the relay layer can reject frames produced
+# from a superseded generation instead of letting them resurrect old content.
+class AddCrdtEpochToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :crdt_epoch, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_133000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_201938) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -119,6 +119,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_133000) do
     t.datetime "claimed_at"
     t.string "content_format", default: "markdown", null: false
     t.text "content_markdown"
+    t.integer "crdt_epoch", default: 0, null: false
     t.datetime "created_at", null: false
     t.boolean "editing_locked", default: false, null: false
     t.string "link_access", default: "edit", null: false

--- a/docs/plans/2026-06-28-002-fix-stale-crdt-frames-after-reset-plan.md
+++ b/docs/plans/2026-06-28-002-fix-stale-crdt-frames-after-reset-plan.md
@@ -1,0 +1,193 @@
+---
+title: "fix: Reject stale CRDT frames after owner content replacement"
+type: fix
+date: 2026-06-28
+origin: thinkroom update on claimed doc not reflected in browser UI
+---
+
+# fix: Reject stale CRDT frames after owner content replacement
+
+## Summary
+
+`thinkroom update` on a live (claimed/edited) document succeeds — `thinkroom show`
+returns the new content — but the browser editor keeps showing the old content,
+even after a full reload. This is the residual half of the "Stale client
+re-persistence" risk documented in `2026-06-28-001-fix-owner-live-cli-replacement-plan.md`.
+
+`Document#replace_content!` correctly resets the document (`yjs_state: nil`,
+`seed_state: "pending"`, new `seed_content`) and broadcasts `content_reset`, which
+makes the *same* open tab reload and re-seed (the #118 fix). But the CRDT relay
+layer — `YjsPersistence.merge`, called by `SyncChannel#receive` (`update` /
+`sync-reply`) and by `documents#sync_update` — has **no notion of a content
+generation**. A still-connected or reconnecting editor that holds the pre-reset
+CRDT state can merge it back in (a reconnect `sync-reply` dumps the client's
+entire old document because the server's state vector is now empty). That
+repopulates `yjs_state` with the OLD content and flips `seed_state` back to
+`"seeded"`.
+
+The result is a split-brain that matches the bug report exactly:
+- `seed_content` / `current_content` (what `thinkroom show` and agents read) = NEW
+- `yjs_state` (what the browser editor binds to) = OLD
+
+Because `yjs_state` is now present, `Document#try_claim_seed` returns `false`
+forever, so the editor never re-seeds and the stale content sticks.
+
+---
+
+## Reproduction (confirmed)
+
+1. `thinkroom new` → account-owned doc (seed stage).
+2. Open `/d/:slug/edit`, type an edit → creates `yjs_state` (doc becomes live).
+3. `thinkroom update <url> <file> --agent "Claude"` → `replace_content!`
+   resets the doc and broadcasts `content_reset`.
+4. A single stale CRDT frame from the still-connected/reconnecting tab is merged
+   via `YjsPersistence.merge` → `yjs_state` = OLD content, `seed_state = "seeded"`.
+5. `thinkroom show` → NEW content; browser (even after reload) → OLD content.
+
+Verified deterministically with a `rails runner` script (replace, then replay the
+captured pre-reset state through `YjsPersistence.merge`) and visually in the
+browser (editor shows the stale heading/body after a full reload).
+
+---
+
+## Problem Frame
+
+CRDT updates are designed to merge commutatively and idempotently — the server
+"blindly merges binary updates" (per `YjsPersistence`). That is exactly why a
+destructive *reset* cannot be expressed as "clear the blob": any client still
+holding the pre-reset state can re-introduce it, and the server cannot tell an
+old-content frame from a new-content frame by bytes alone.
+
+To make a reset durable against late frames, the server needs an explicit
+**generation epoch** that increments on reset, and it must reject CRDT frames
+produced from an older epoch.
+
+---
+
+## Requirements
+
+- R1. After an owner `replace_content!`, CRDT frames produced from the pre-reset
+  document state must not repopulate `yjs_state` or flip `seed_state` back to
+  `"seeded"`.
+- R2. Frames from a client that synced at the current generation (including the
+  reloaded tab that applies the new seed) must still be accepted and broadcast.
+- R3. Normal collaborative editing on a document that was never reset is
+  unchanged (no regression to relay, persistence, ordering, or broadcast).
+- R4. A client whose live session spans a reset (transient reconnect, not a
+  reload) must not dump its stale document back; it should recover by reloading.
+- R5. Backwards/rollout compatible: a frame without a generation is treated as
+  generation 0, so never-reset documents keep working and only post-reset stale
+  frames are dropped.
+
+---
+
+## Key Technical Decisions
+
+- **KTD-1 — Add a monotonic `crdt_epoch` integer on `documents`.** No existing
+  column is monotonic-and-only-bumped-on-reset (`updated_at` changes on every
+  edit; `seed_state` is not monotonic). `replace_content!` increments it.
+- **KTD-2 — Clients echo the epoch they synced at; the server drops older
+  frames.** The `SyncChannel` sends `epoch` in its `sync` message. `CableProvider`
+  stores it and includes it on every `update` / `sync-reply` frame and on the
+  `sync_update` keepalive body. `YjsPersistence.merge` skips (and the channel does
+  not broadcast) any frame whose epoch is below the document's current epoch.
+- **KTD-3 — Reload on epoch advance instead of replying with stale state.** If a
+  reconnecting client receives a `sync` whose epoch is higher than the one it had,
+  its local doc is superseded; it reloads (the existing `content_reset` recovery)
+  rather than sending a `sync-reply` that would carry old content at the new epoch.
+- **KTD-4 — Keep the destructive reset on the server.** This builds on the
+  existing `replace_content!` + `content_reset` design; it does not make CRDT
+  merging "smarter" or rebuild Yjs state server-side.
+
+---
+
+## Implementation Units
+
+### U1. Add the `crdt_epoch` generation column and bump it on reset
+
+**Files:** `db/migrate/*_add_crdt_epoch_to_documents.rb`, `db/schema.rb`,
+`app/models/document.rb`, `test/models/document_test.rb`
+
+**Approach:** Migration adds `crdt_epoch` (integer, default 0, null: false).
+`replace_content!` sets `crdt_epoch: crdt_epoch + 1` inside its existing locked
+transition.
+
+**Test scenarios:** `replace_content!` increments `crdt_epoch`; a never-reset doc
+stays at 0.
+
+### U2. Reject stale frames in `YjsPersistence.merge`
+
+**Files:** `app/services/yjs_persistence.rb`, `test/services/yjs_persistence_test.rb`
+
+**Approach:** Add an `epoch:` keyword. After reload-under-lock, if `epoch` is
+present and `document.crdt_epoch > epoch`, skip the merge. Return a boolean so
+callers know whether the frame was applied (and therefore whether to broadcast).
+Current-epoch no-op frames still return "accepted" to preserve relay behavior.
+
+**Test scenarios:** a frame at an older epoch does not change `yjs_state` /
+`seed_state`; a frame at the current epoch persists as before; missing epoch behaves
+as epoch 0.
+
+### U3. Thread the epoch through the channel and the keepalive endpoint
+
+**Files:** `app/channels/sync_channel.rb`, `app/controllers/documents_controller.rb`,
+`test/channels/sync_channel_test.rb`, `test/integration/*`
+
+**Approach:** `SyncChannel#subscribed` includes `epoch: @document.crdt_epoch` in the
+`sync` message. `#receive` reads `data["epoch"]`, passes it to `merge`, and only
+broadcasts the frame when the merge accepted it (stale frames are dropped entirely,
+not relayed). `documents#sync_update` reads `params[:epoch]`, passes it to `merge`,
+and skips the derived snapshot persist when the frame was stale.
+
+### U4. Echo the epoch from the client and reload on epoch advance
+
+**Files:** `app/frontend/editor/cable_provider.ts`,
+`app/frontend/editor/milkdown_editor.tsx` (only if a hook is needed)
+
+**Approach:** `CableProvider` stores `serverEpoch` from the `sync` message and
+includes `epoch` on `sendUpdate` and on the `persistCurrentState` keepalive body.
+If a later `sync` carries a higher epoch than the one already seen (reconnect
+across a reset), the provider triggers a reload instead of replying with its stale
+state, reusing the existing content-reset recovery.
+
+### U5. Regression coverage end to end
+
+**Files:** `test/integration/agent_api_test.rb` (or a focused integration test)
+
+**Approach:** Assert the full sequence: live doc → owner replace → replay a
+pre-reset frame at the old epoch → `yjs_state` stays empty / `seed_state` stays
+`pending`, and a fresh page load still grants the seed (`seed_granted: true`) and
+serves the NEW content.
+
+---
+
+## Scope Boundaries
+
+- Does not change CRDT merge semantics for same-generation edits.
+- Does not rebuild Milkdown/y-prosemirror state server-side.
+- Does not alter ownership/authorization for `replace_content!` (covered by
+  `2026-06-28-001`).
+
+---
+
+## Risks & Dependencies
+
+- **Rollout overlap:** during a deploy, an old client sends no epoch (treated as 0).
+  On a never-reset doc that is fine; on a just-reset doc its frames are correctly
+  dropped (its state is genuinely stale). Acceptable, and the brief window is
+  bounded by a manual Kamal deploy.
+- **Lost edits on a superseded tab:** a tab that edited stale content after a reset
+  will have those frames dropped. This is correct — the content was replaced — and
+  the reload recovery shows the new content.
+
+---
+
+## Sources & Research
+
+- Prior plan / documented risk: `docs/plans/2026-06-28-001-fix-owner-live-cli-replacement-plan.md`
+- Reset transition: `app/models/document.rb` (`replace_content!`, `try_claim_seed`)
+- CRDT relay/persistence: `app/services/yjs_persistence.rb`, `app/channels/sync_channel.rb`
+- Keepalive path: `app/controllers/documents_controller.rb#sync_update`
+- Client provider + seed application: `app/frontend/editor/cable_provider.ts`,
+  `app/frontend/editor/milkdown_editor.tsx`
+- Seed grant on reload: `app/controllers/documents_controller.rb#show`, #118

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "workspace",
+  "name": "brainstorm-riffrec-to-pr-pipeline",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -2349,6 +2349,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,6 +2367,9 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2381,6 +2387,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2396,6 +2405,9 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2413,6 +2425,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,6 +2443,9 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2747,6 +2765,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2762,6 +2783,9 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2779,6 +2803,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2794,6 +2821,9 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4931,6 +4961,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4950,6 +4983,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4971,6 +5007,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4990,6 +5029,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brainstorm-riffrec-to-pr-pipeline",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -2349,9 +2349,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,9 +2364,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2387,9 +2381,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2405,9 +2396,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2425,9 +2413,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2428,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2765,9 +2747,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2783,9 +2762,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2803,9 +2779,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2794,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4961,9 +4931,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4983,9 +4950,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5007,9 +4971,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5029,9 +4990,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -141,6 +141,48 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert doc.reload.yjs_state.present?
   end
 
+  test "the sync handshake carries the document content generation" do
+    doc = Document.create!(title: "Generation")
+
+    subscribe slug: doc.slug
+    assert_equal 0, transmissions.last["epoch"], "a never-reset doc is generation 0"
+
+    doc.replace_content!(source: "# Replacement")
+    unsubscribe
+    subscribe slug: doc.slug
+    assert_equal 1, transmissions.last["epoch"], "a reset advances the generation"
+  end
+
+  test "an update from a superseded generation is dropped without relay or persistence" do
+    doc = Document.create!(title: "Reset", seed_markdown: "# Old")
+    doc.replace_content!(source: "# New source") # crdt_epoch -> 1
+    subscribe slug: doc.slug
+    stale = build_update_b64("stale browser content")
+
+    # A still-connected client replays its pre-reset state at the old generation.
+    assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
+      perform :receive, { "type" => "update", "update" => stale, "cid" => "stale", "epoch" => 0 }
+    end
+
+    doc.reload
+    assert_nil doc.yjs_state, "a stale frame must not resurrect the old CRDT state"
+    assert_not_equal "seeded", doc.seed_state,
+                     "a stale frame must not flip the doc to seeded and block re-seeding"
+  end
+
+  test "an update stamped with the current generation relays after a reset" do
+    doc = Document.create!(title: "Reset", seed_markdown: "# Old")
+    doc.replace_content!(source: "# New source") # crdt_epoch -> 1
+    subscribe slug: doc.slug
+    fresh = build_update_b64("# New source applied")
+
+    assert_broadcast_on(SyncChannel.broadcasting_for(doc), type: "update", update: fresh, cid: "fresh") do
+      perform :receive, { "type" => "update", "update" => fresh, "cid" => "fresh", "epoch" => 1 }
+    end
+
+    assert doc.reload.yjs_state.present?
+  end
+
   test "locked non-owner updates are rejected without persistence or relay" do
     doc = Document.create!(
       title: "Locked",

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -125,6 +125,30 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "a stale CRDT frame after a content reset cannot block the new seed grant" do
+    # The browser made the document live with its (soon to be old) content.
+    YjsPersistence.merge(@document, live_update("old browser content"))
+    old_frame = Base64.strict_encode64(@document.reload.yjs_state)
+    assert @document.yjs_state.present?
+
+    # Owner replaces the source out of band (the `thinkroom update` path).
+    @document.replace_content!(source: "# Replacement source")
+
+    # A still-connected or reconnecting editor replays its pre-reset state at the
+    # superseded generation. It must be dropped, not merged back in.
+    relayed = YjsPersistence.merge(@document, old_frame, epoch: 0)
+    assert_not relayed, "a stale-generation frame must not be relayed"
+
+    # A fresh browser load therefore re-seeds the replacement rather than binding
+    # the resurrected stale CRDT state — the exact symptom of the reported bug.
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == true &&
+        props[:document][:has_state] == false &&
+        props[:document][:seed_content] == "# Replacement source"
+    end
+  end
+
   test "documents without seed markdown never grant the seed" do
     doc = Document.create!(title: "Blank", seed_markdown: nil)
 
@@ -171,5 +195,11 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
 
   def browser
     { "User-Agent" => "Mozilla/5.0" }
+  end
+
+  def live_update(text)
+    ydoc = Y::Doc.new
+    ydoc.get_text("t") << text
+    Base64.strict_encode64(ydoc.diff.pack("C*"))
   end
 end

--- a/test/integration/snapshot_test.rb
+++ b/test/integration/snapshot_test.rb
@@ -223,6 +223,45 @@ class SnapshotTest < ActionDispatch::IntegrationTest
     assert_equal 1, @document.reload.provenance_spans.length
   end
 
+  test "a snapshot from a superseded generation is dropped without mutating content" do
+    @document.replace_content!(source: "# New source") # crdt_epoch -> 1, content_snapshot nil
+    assert_equal 1, @document.reload.crdt_epoch
+
+    post document_snapshot_path(@document.slug),
+         params: { markdown: "stale browser content", spans: [], epoch: 0 },
+         as: :json
+
+    assert_response :no_content
+    assert_nil @document.reload.content_snapshot,
+               "a snapshot from before the reset must not write the read model"
+  end
+
+  test "a snapshot stamped with the current generation persists after a reset" do
+    @document.replace_content!(source: "# New source") # crdt_epoch -> 1
+    post document_snapshot_path(@document.slug),
+         params: { markdown: "# New source typed", spans: [], epoch: 1 },
+         as: :json
+
+    assert_response :ok
+    assert_equal "# New source typed", @document.reload.content_snapshot
+  end
+
+  test "a durable sync update from a superseded generation is dropped" do
+    @document.replace_content!(source: "# New source") # crdt_epoch -> 1
+    ydoc = Y::Doc.new
+    ydoc.get_text("t") << "stale content"
+    update = Base64.strict_encode64(ydoc.diff.pack("C*"))
+
+    assert_no_broadcasts(SyncChannel.broadcasting_for(@document)) do
+      post document_sync_update_path(@document.slug),
+           params: { update:, cid: "stale", epoch: 0 },
+           as: :json
+    end
+
+    assert_response :no_content
+    assert_nil @document.reload.yjs_state, "a stale sync update must not resurrect old state"
+  end
+
   test "durable sync update persists and broadcasts the Yjs diff" do
     ydoc = Y::Doc.new
     ydoc.get_text("task") << "checked"

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -133,6 +133,17 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "Codex", doc.seed_author_name
   end
 
+  test "replace content advances the CRDT generation so stale frames can be dropped" do
+    doc = Document.create!(title: "Live", seed_content: "# Seed")
+    assert_equal 0, doc.crdt_epoch, "a never-replaced document stays at generation 0"
+
+    doc.replace_content!(source: "# First replacement")
+    assert_equal 1, doc.reload.crdt_epoch
+
+    doc.replace_content!(source: "# Second replacement")
+    assert_equal 2, doc.reload.crdt_epoch, "each replacement supersedes the prior generation"
+  end
+
   test "database rejects unknown content formats" do
     doc = Document.create!(title: "Constrained")
 

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -67,6 +67,48 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_not doc.yjs_state.present?, "no-op merge must not persist state"
   end
 
+  test "merge drops a frame produced before a content reset" do
+    doc = Document.create!(title: "Reset", seed_markdown: "# Old")
+    assert YjsPersistence.merge(doc, b64_update_for("old browser content"))
+    assert doc.reload.yjs_state.present?
+
+    # Owner replacement advances the generation and clears the CRDT state.
+    doc.replace_content!(source: "# New source")
+    doc.reload
+    assert_nil doc.yjs_state
+    assert_equal "pending", doc.seed_state
+
+    # A still-connected (or reconnecting) client replays its pre-reset state,
+    # stamped with the old generation. It must not resurrect the old content.
+    relayed = YjsPersistence.merge(doc, b64_update_for("old browser content"), epoch: 0)
+
+    assert_not relayed, "a stale-generation frame must not be relayed"
+    doc.reload
+    assert_nil doc.yjs_state, "a stale frame must not resurrect the old CRDT state"
+    assert_equal "pending", doc.seed_state, "a stale frame must not re-seed the doc"
+  end
+
+  test "merge accepts a frame stamped with the current generation after a reset" do
+    doc = Document.create!(title: "Reset", seed_markdown: "# Old")
+    doc.replace_content!(source: "# New source")
+    assert_equal 1, doc.reload.crdt_epoch
+
+    # The reloaded editor synced at the new generation and applies the new seed.
+    relayed = YjsPersistence.merge(doc, b64_update_for("new seed content"), epoch: doc.crdt_epoch)
+
+    assert relayed
+    doc.reload
+    assert doc.yjs_state.present?
+    assert_equal "seeded", doc.seed_state
+    assert_equal "new seed content", text_of(doc)
+  end
+
+  test "merge relays a current-generation frame on a never-reset document" do
+    doc = Document.create!(title: "Live")
+    assert YjsPersistence.merge(doc, b64_update_for("content"), epoch: 0),
+           "an epoch-0 frame on an epoch-0 document is current and relays"
+  end
+
   test "corrupt base64 raises and leaves the document untouched" do
     doc = Document.create!(title: "Corrupt")
     YjsPersistence.merge(doc, b64_update_for("good content"))

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -130,6 +130,32 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "server content", client.get_text("t").to_s
   end
 
+  test "persist_snapshot drops a snapshot from a superseded generation" do
+    doc = Document.create!(title: "Snap", content_snapshot: "current")
+    doc.replace_content!(source: "# New source") # crdt_epoch -> 1, content_snapshot nil
+    assert_equal 1, doc.reload.crdt_epoch
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc, state_vector_b64: nil, content: "stale snapshot", spans: [], epoch: 0
+    )
+
+    assert_not persisted
+    assert_nil doc.reload.content_snapshot,
+               "a stale-generation snapshot must not write the read model"
+  end
+
+  test "persist_snapshot accepts a snapshot stamped with the current generation" do
+    doc = Document.create!(title: "Snap")
+    doc.replace_content!(source: "# New source") # crdt_epoch -> 1
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc, state_vector_b64: nil, content: "new typed", spans: [], epoch: doc.crdt_epoch
+    )
+
+    assert persisted
+    assert_equal "new typed", doc.reload.content_snapshot
+  end
+
   test "snapshot persistence rejects a client behind the current Yjs state" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

`thinkroom update` on a live (claimed/edited) document succeeds — `thinkroom show` returns the new content — but the browser editor keeps showing the **old** content, even after a hard refresh.

Fixes #119 and #120.

## Root cause

`Document#replace_content!` (the owner CLI replacement from #116/#117/#118) correctly resets the document: `yjs_state: nil`, `seed_state: "pending"`, new `seed_content`, and broadcasts `content_reset`. #118 made the *same tab* reload and re-seed.

But the CRDT relay layer — `YjsPersistence.merge`, used by `SyncChannel#receive` (`update` / `sync-reply`) and by `documents#sync_update` — had **no notion of a content generation**. A still‑connected or reconnecting editor that holds the pre‑reset CRDT state merges it back (a reconnect `sync-reply` dumps the client's *entire* old document because the server's state vector is now empty). That repopulates `yjs_state` with the OLD content and flips `seed_state` back to `"seeded"`.

The result is a split‑brain that matches the report exactly:

- `seed_content` / `current_content` (what `thinkroom show` and agents read) = **NEW**
- `yjs_state` (what the browser editor binds to) = **OLD**

Because `yjs_state` is now present, `Document#try_claim_seed` returns `false` forever, so the editor never re‑seeds — which is why a **hard refresh doesn't fix it** (#120).

This is the "Stale client re-persistence" risk called out (but not closed) in `docs/plans/2026-06-28-001-fix-owner-live-cli-replacement-plan.md`.

## Fix — a content-generation epoch

CRDT updates merge commutatively, so a destructive reset can't be expressed as "clear the blob"; the server needs an explicit epoch and must drop frames from a superseded generation.

- Add a monotonic `crdt_epoch` column; `replace_content!` increments it.
- `SyncChannel` sends `epoch` on the `sync` handshake; the client (`CableProvider`) stores it and echoes it on every `update` / `sync-reply` frame, the `sync_update` keepalive, and snapshot pushes.
- `YjsPersistence.merge` and `persist_snapshot` drop (and the channel does not relay) any frame/snapshot whose epoch is below the document's current `crdt_epoch`. The generation re‑check happens **inside the write lock**, so a reset committing mid‑request can't slip a stale write through. A missing epoch counts as generation 0, so never‑reset docs are unaffected.
- A client that reconnects onto a newer generation reloads instead of replying with its stale state (closes the offline‑during‑reset window where the `content_reset` broadcast was missed), and keeps its stale epoch so any in‑flight keepalive is dropped rather than re‑stamped current.

## Verification

**Deterministic repro:** a live doc → owner `replace_content!` (resets, epoch→N) → replay one captured pre‑reset frame through `YjsPersistence.merge`. *Before:* the frame resurrected old content (`yjs_state` present, `seed_state: "seeded"`); `thinkroom show` = NEW, browser (even after reload) = OLD. *After:* the stale frame is rejected (`relayed=false`), `yjs_state` stays nil, `seed_state` stays `pending`, `try_claim_seed` is `true`, so a fresh load re‑seeds the NEW content.

**Browser, before the fix** — the editor stays on the stale content after a full reload while the server's authoritative content differs:

[Before fix: browser shows stale content after reload](https://cursor.com/agents/bc-9db3d01a-c899-4496-ac2f-3f6af26beb17/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_before_fix_browser_shows_stale_content.webp)

**Browser, after the fix** — an open tab auto‑reflects a `thinkroom update` (no manual interaction):

[thinkroom_update_reflected_in_browser_after_fix.mp4](https://cursor.com/agents/bc-9db3d01a-c899-4496-ac2f-3f6af26beb17/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthinkroom_update_reflected_in_browser_after_fix.mp4)

[After fix: browser reflects the CLI update](https://cursor.com/agents/bc-9db3d01a-c899-4496-ac2f-3f6af26beb17/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_after_fix_browser_reflects_update.webp)

A smoke test confirmed normal editing still persists (current‑generation snapshots are accepted; only stale ones are dropped).

## Tests

- `test/models/document_test.rb` — `replace_content!` advances `crdt_epoch`.
- `test/services/yjs_persistence_test.rb` — stale‑generation frames and snapshots are dropped; current‑generation ones persist.
- `test/channels/sync_channel_test.rb` — handshake carries the epoch; stale frames are not broadcast/persisted; current frames relay after a reset.
- `test/integration/snapshot_test.rb` — stale snapshot / sync_update frames are dropped; current ones persist.
- `test/integration/document_seed_claim_test.rb` — end‑to‑end: a stale frame after a reset cannot block the new seed grant.

Full suite (484 runs) green, RuboCop clean, `npm run check` (tsc + CLI tests) clean.

## CI status

`test`, `lint`, and `scan_javascript` pass. `scan_ruby` (`bundler-audit`) fails on a **pre‑existing, unrelated** advisory for the transitive gem `crass 1.0.6` (4 advisories published 2026‑06‑28, fixed by `>= 1.0.7`). This `Gemfile.lock` is byte‑identical to `main`; the failure is repo‑wide (it also fails on #123 and would fail on a re‑run of `main`) and is best resolved by a separate `bundle update crass`, not bundled into this editor fix.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db3d01a-c899-4496-ac2f-3f6af26beb17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db3d01a-c899-4496-ac2f-3f6af26beb17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

