### PR TITLE
fix(documents): stop stale CRDT from resurrecting old content after a CLI replacement

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -20,7 +20,17 @@ class SyncChannel < ApplicationCable::Channel
     @sequence_lock = Mutex.new
     @next_sequence = 1
     @pending_updates = {}
+    # The content generation this client loaded its page with. Fixed for the
+    # life of the page (never adopted from a reconnect handshake), so a tab
+    # holding pre-reset state keeps announcing its stale generation and its
+    # writes stay rejected. nil for clients deployed before the guard shipped.
+    @client_generation = Integer(params[:gen], exception: false)
     stream_for @document
+
+    # A client that loaded before an owner CLI replacement reconnecting here
+    # must not re-seed its stale doc. Tell it to reload (the page it loads next
+    # carries the current generation) instead of running the sync handshake.
+    return transmit({ type: "reset" }) if @document.content_stale?(@client_generation)
 
     full_state, state_vector = YjsPersistence.state_b64(@document)
     message = { type: "sync", update: full_state, sv: state_vector }
@@ -97,7 +107,8 @@ class SyncChannel < ApplicationCable::Channel
       @document,
       update,
       token: (connection.owner_token if connection.respond_to?(:owner_token)),
-      user: (connection.current_user if connection.respond_to?(:current_user))
+      user: (connection.current_user if connection.respond_to?(:current_user)),
+      generation: @client_generation
     )
     # A peer seeing an edit means the server has made it durable. This
     # ordering also prevents clients from accepting a frame that failed
@@ -105,6 +116,10 @@ class SyncChannel < ApplicationCable::Channel
     self.class.broadcast_to(@document, message)
   rescue Document::EditingLockedError
     transmit({ type: "write-denied", locked: true })
+  rescue Document::StaleContentError
+    # The doc was replaced out from under this client. Don't persist or relay
+    # its stale frame; have it reload onto the current generation.
+    transmit({ type: "reset" })
   rescue StandardError => e
     Rails.logger.warn("SyncChannel: merge failed: #{e.class}: #{e.message}")
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -97,6 +97,9 @@ class DocumentsController < InertiaController
       document: document.slice(:id, :slug, :title, :content_format).merge(
         seed_content: document.seed_content,
         seed_version: document.updated_at.iso8601(6),
+        # Announced back on every CRDT/snapshot write so the server can reject
+        # stale writes from a client that loaded before an owner replacement.
+        content_generation: document.content_generation,
         seed_granted: seed_granted,
         seed_author_kind: document.seed_author_kind,
         seed_author_name: document.seed_author_name,
@@ -315,7 +318,8 @@ class DocumentsController < InertiaController
       spans:,
       title:,
       token: owner_token,
-      user: current_user
+      user: current_user,
+      generation: client_generation
     )
     return render json: { error: "Snapshot is stale; retry from current document state." },
                   status: :conflict unless persisted
@@ -337,7 +341,8 @@ class DocumentsController < InertiaController
     decoded = Base64.strict_decode64(update)
     return head :content_too_large if decoded.bytesize > MAX_SYNC_UPDATE_BYTES
 
-    YjsPersistence.merge(document, update, token: owner_token, user: current_user)
+    YjsPersistence.merge(document, update, token: owner_token, user: current_user,
+                                           generation: client_generation)
     SyncChannel.broadcast_to(document, {
       type: "update",
       update:,
@@ -365,7 +370,8 @@ class DocumentsController < InertiaController
         spans:,
         title:,
         token: owner_token,
-        user: current_user
+        user: current_user,
+        generation: client_generation
       )
       return render json: { error: "Snapshot is stale; retry from current document state." },
                     status: :conflict unless persisted
@@ -377,12 +383,23 @@ class DocumentsController < InertiaController
     head :no_content
   rescue ArgumentError
     render json: { error: "Invalid Yjs update." }, status: :unprocessable_entity
+  rescue Document::StaleContentError
+    # The doc was replaced after this client loaded; drop the stale write
+    # rather than resurrecting the old state or relaying it to peers.
+    head :conflict
   end
 
   private
 
   def broadcast_title(document)
     DocumentMetaChannel.broadcast_event(document, :title, title: document.title)
+  end
+
+  # The content generation an editor client loaded with, echoed on its durable
+  # writes. Behind the document's current generation => the client predates a
+  # replace_content! reset, so the persistence layer drops the write.
+  def client_generation
+    Integer(params[:gen], exception: false)
   end
 
   def index_document_props(document, week_start:, current_year:)

--- a/app/frontend/editor/cable_provider.ts
+++ b/app/frontend/editor/cable_provider.ts
@@ -10,7 +10,7 @@ import {
 } from 'y-protocols/awareness'
 
 type SyncMessage = {
-  type: 'sync' | 'sync-reply' | 'update' | 'awareness' | 'awareness-query' | 'write-denied'
+  type: 'sync' | 'sync-reply' | 'update' | 'awareness' | 'awareness-query' | 'write-denied' | 'reset'
   update?: string
   sv?: string
   seed?: boolean
@@ -67,20 +67,31 @@ export class CableProvider {
   private serverStateVector: Uint8Array | null = null
   private readonly slug: string
   private readonly canWrite: boolean
+  // The content generation this page loaded with. Sent on subscribe and with
+  // every durable write so the server can drop writes from a session that
+  // predates an owner CLI replacement (a stale tab re-syncing old state).
+  // Fixed for the page's lifetime: never updated from a reconnect handshake.
+  private readonly generation: number | null
 
   constructor(
     doc: Y.Doc,
     slug: string,
-    options?: { consumer?: Consumer; canWrite?: boolean; connectionIdentity?: string },
+    options?: {
+      consumer?: Consumer
+      canWrite?: boolean
+      connectionIdentity?: string
+      generation?: number | null
+    },
   ) {
     this.doc = doc
     this.slug = slug
     this.canWrite = options?.canWrite ?? true
+    this.generation = options?.generation ?? null
     this.awareness = new Awareness(doc)
     this.consumer = options?.consumer ?? getConsumer(options?.connectionIdentity)
 
     this.subscription = this.consumer.subscriptions.create(
-      { channel: 'SyncChannel', slug },
+      { channel: 'SyncChannel', slug, gen: this.generation },
       {
         received: (data: SyncMessage) => this.handleReceived(data),
         disconnected: () => {
@@ -106,12 +117,12 @@ export class CableProvider {
     window.addEventListener('beforeunload', this.handleUnload)
   }
 
-  on(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
+  on(event: 'synced' | 'seed' | 'rejected' | 'write-denied' | 'reset', handler: () => void): void {
     if (!this.listeners.has(event)) this.listeners.set(event, new Set())
     this.listeners.get(event)!.add(handler as never)
   }
 
-  off(event: 'synced' | 'seed' | 'rejected' | 'write-denied', handler: () => void): void {
+  off(event: 'synced' | 'seed' | 'rejected' | 'write-denied' | 'reset', handler: () => void): void {
     this.listeners.get(event)?.delete(handler as never)
   }
 
@@ -159,7 +170,7 @@ export class CableProvider {
       : Y.encodeStateAsUpdate(this.doc)
     const persistedVector = Y.encodeStateVector(this.doc)
 
-    const updatePayload = { update: toBase64(update), cid: this.clientId }
+    const updatePayload = { update: toBase64(update), cid: this.clientId, gen: this.generation }
     const completePayload = { ...updatePayload, ...snapshot }
     const completeBody = JSON.stringify(completePayload)
     // Browsers cap keepalive request bodies at roughly 64 KiB. Large docs
@@ -237,6 +248,13 @@ export class CableProvider {
         break
       case 'write-denied':
         this.emit('write-denied')
+        break
+      case 'reset':
+        // The document was replaced (owner CLI update) after this page loaded.
+        // This stale session must not re-sync its old doc; reload onto the
+        // current generation. Reached when we reconnect after missing the
+        // DocumentMetaChannel content_reset broadcast.
+        this.emit('reset')
         break
     }
   }

--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -107,6 +107,10 @@ interface EditorProps {
   seedContent?: string | null
   /** Changes whenever the server-side source generation changes. */
   seedVersion?: string | null
+  /** Monotonic content generation this page loaded with. Announced to the
+   *  server on every durable write so writes from a session that predates an
+   *  owner CLI replacement are rejected instead of resurrecting old state. */
+  contentGeneration?: number | null
   /** True when documents#show atomically claimed the seed for this page
    *  load — the props-first path that skips the WebSocket round-trip. */
   seedGranted?: boolean
@@ -141,6 +145,9 @@ interface EditorProps {
   onSpans?: (spans: ProvenanceSpan[]) => void
   onSelection?: (view: EditorView) => void
   onTitleChange?: (title: string) => void
+  /** The document was replaced server-side (owner CLI update) and this session
+   *  is stale — reload onto the new content. */
+  onReset?: () => void
 }
 
 interface ActiveSketch {
@@ -238,6 +245,7 @@ function acquireSession(
   canWrite: boolean,
   connectionIdentity: string,
   initialStateB64?: string | null,
+  generation?: number | null,
 ): CollabSession {
   let session = sessions.get(slug)
   if (session && (session.canWrite !== canWrite || session.connectionIdentity !== connectionIdentity)) {
@@ -266,7 +274,7 @@ function acquireSession(
         // corrupt/stale prop — fall back to the wait-for-synced path
       }
     }
-    const provider = new CableProvider(ydoc, slug, { canWrite, connectionIdentity })
+    const provider = new CableProvider(ydoc, slug, { canWrite, connectionIdentity, generation })
     provider.awareness.setLocalStateField('user', identity)
     session = { ydoc, provider, refs: 0, destroyTimer: null, canWrite, connectionIdentity }
     sessions.set(slug, session)
@@ -356,6 +364,7 @@ function CollabEditor({
   initialStateB64,
   seedContent,
   seedVersion,
+  contentGeneration,
   seedGranted,
   seedAuthorKind,
   seedAuthorName,
@@ -369,13 +378,14 @@ function CollabEditor({
   onSpans,
   onSelection,
   onTitleChange,
+  onReset,
 }: EditorProps) {
   const [sketchDraft, setSketchDraft] = useState<ActiveSketch | undefined>(undefined)
   const insertSketchRef = useRef<() => void>(() => undefined)
   const saveSketchRef = useRef<(data: SketchData) => void>(() => undefined)
   const deleteSketchRef = useRef<(id: string) => void>(() => undefined)
-  const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection, onTitleChange })
-  callbacksRef.current = { onReady, onStatus, onSpans, onSelection, onTitleChange }
+  const callbacksRef = useRef({ onReady, onStatus, onSpans, onSelection, onTitleChange, onReset })
+  callbacksRef.current = { onReady, onStatus, onSpans, onSelection, onTitleChange, onReset }
   // Ref so the editable() closure always reads the live value; the effect
   // below nudges ProseMirror to re-read it when the mode changes.
   const editableRef = useRef(editable)
@@ -499,8 +509,11 @@ function CollabEditor({
       canWriteRef.current,
       connectionIdentity,
       initialStateB64,
+      contentGeneration,
     )
     callbacksRef.current.onStatus?.('connecting')
+    const handleReset = () => callbacksRef.current.onReset?.()
+    provider.on('reset', handleReset)
 
     let snapshotTimer: ReturnType<typeof setTimeout> | null = null
     let snapshotRetryTimer: ReturnType<typeof setTimeout> | null = null
@@ -508,7 +521,10 @@ function CollabEditor({
     const pushSnapshot = (attempt = 0) => {
       if (!canWriteRef.current) return
       editor.action((ctx) => {
-        void postJSON(`/d/${slug}/snapshot`, buildSnapshotPayload(ctx, ydoc, contentFormat))
+        void postJSON(`/d/${slug}/snapshot`, {
+          ...buildSnapshotPayload(ctx, ydoc, contentFormat),
+          gen: contentGeneration,
+        })
           .then((response) => {
             if (response.status === 409 && attempt < 3 && !cancelled) {
               if (snapshotRetryTimer) clearTimeout(snapshotRetryTimer)
@@ -631,6 +647,7 @@ function CollabEditor({
     return () => {
       cancelled = true
       provider.off('synced', start)
+      provider.off('reset', handleReset)
       if (snapshotTimer) clearTimeout(snapshotTimer)
       if (snapshotRetryTimer) clearTimeout(snapshotRetryTimer)
       try {

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -108,6 +108,7 @@ export interface DocumentProps {
     content_format: DocumentFormat
     seed_content: string | null
     seed_version: string
+    content_generation: number
     seed_granted: boolean
     seed_author_kind: string | null
     seed_author_name: string | null
@@ -1349,6 +1350,7 @@ export default function DocumentShow({
                       initialStateB64={doc.yjs_state_b64}
                       seedContent={doc.seed_content}
                       seedVersion={doc.seed_version}
+                      contentGeneration={doc.content_generation}
                       seedGranted={doc.seed_granted}
                       seedAuthorKind={doc.seed_author_kind}
                       seedAuthorName={doc.seed_author_name}
@@ -1369,6 +1371,7 @@ export default function DocumentShow({
                       onSpans={setSpans}
                       onSelection={isReading ? undefined : handleSelection}
                       onTitleChange={setDocumentTitle}
+                      onReset={reloadAfterContentReset}
                     />
                   )}
                 </div>

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,6 +27,12 @@ class Document < ApplicationRecord
   # as "already claimed".
   class ClaimRaceError < StandardError; end
 
+  # Raised when a CRDT/snapshot write originates from a client whose document
+  # state predates a replace_content! reset (an older content_generation). The
+  # write is dropped so it can't resurrect the replaced state; the caller signals
+  # the stale client to reload.
+  class StaleContentError < StandardError; end
+
   attr_readonly :slug, :content_format
 
   has_many :suggestions, dependent: :destroy
@@ -166,7 +172,10 @@ class Document < ApplicationRecord
         provenance_spans: [],
         yjs_state: nil,
         seed_state: "pending",
-        seed_claimed_at: nil
+        seed_claimed_at: nil,
+        # Bump the generation so any client still holding the pre-reset CRDT
+        # is rejected when it tries to re-sync stale state (see content_stale?).
+        content_generation: content_generation + 1
       }
       attributes[:title] = title if title.present?
       if seed_author_kind.present?
@@ -176,6 +185,16 @@ class Document < ApplicationRecord
       update!(attributes)
     end
     self
+  end
+
+  # True when a write announces a generation older than this document's
+  # current one — i.e. it originates from a client whose document state
+  # predates a replace_content! reset. Such a write must never persist: it
+  # would resurrect the old CRDT/snapshot and permanently shadow the new seed
+  # (seed_stage? flips false the moment yjs_state/content_snapshot is set).
+  # A nil generation (clients deployed before the guard shipped) is not stale.
+  def content_stale?(generation)
+    generation.present? && generation < content_generation
   end
 
   def with_comment_access(token: nil, user: nil)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -13,12 +13,16 @@ class YjsPersistence
 
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
-    def merge(document, base64_update, token: nil, user: nil)
+    # `generation` is the content generation the writing client loaded; a write
+    # behind the current generation predates a replace_content! reset and is
+    # rejected so it can't resurrect the replaced CRDT state.
+    def merge(document, base64_update, token: nil, user: nil, generation: nil)
       update = decode(base64_update)
       lock_for(document.id).synchronize do
         document.with_lock do
           document.reload
           raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+          raise Document::StaleContentError, "This document was replaced." if document.content_stale?(generation)
 
           ydoc = load_ydoc(document)
           before = ydoc.state
@@ -51,13 +55,17 @@ class YjsPersistence
     # A client may be ahead (its own cable frame is still in flight), but it
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
-                         token: nil, user: nil)
+                         token: nil, user: nil, generation: nil)
       client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
       lock_for(document.id).synchronize do
         document.with_lock do
           document.reload
           raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
+          # A snapshot from a pre-reset client would resurrect the replaced
+          # source (content_snapshot shadows the new seed). Drop it like a
+          # stale state vector.
+          return false if document.content_stale?(generation)
 
           if client_state && document.yjs_state.present?
             server_state = decode_state_vector(load_ydoc(document).state)

--- a/db/migrate/20260628120000_add_content_generation_to_documents.rb
+++ b/db/migrate/20260628120000_add_content_generation_to_documents.rb
@@ -1,0 +1,10 @@
+class AddContentGenerationToDocuments < ActiveRecord::Migration[8.1]
+  # Monotonic counter bumped each time an owner replaces a live document's
+  # source from the CLI (Document#replace_content!). Editor clients announce
+  # the generation they loaded; the server drops CRDT/snapshot writes from a
+  # client behind the current generation so a pre-reset session can never
+  # resurrect the old document state.
+  def change
+    add_column :documents, :content_generation, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_133000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_120000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -118,6 +118,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_133000) do
   create_table "documents", force: :cascade do |t|
     t.datetime "claimed_at"
     t.string "content_format", default: "markdown", null: false
+    t.integer "content_generation", default: 0, null: false
     t.text "content_markdown"
     t.datetime "created_at", null: false
     t.boolean "editing_locked", default: false, null: false

--- a/docs/plans/2026-06-28-002-fix-stale-crdt-resurrection-plan.md
+++ b/docs/plans/2026-06-28-002-fix-stale-crdt-resurrection-plan.md
@@ -1,0 +1,122 @@
+---
+title: "fix: Stale CRDT resurrects old content after CLI replacement"
+type: fix
+date: 2026-06-28
+origin: "PR: Hard refresh does not fix stale browser after thinkroom update on claimed doc"
+---
+
+# fix: Stale CRDT resurrects old content after CLI replacement
+
+## Summary
+
+After `thinkroom update` replaces a claimed/live document, the browser keeps
+showing the **old** content even after a hard refresh or in an incognito
+window, while `thinkroom show --json` correctly returns the **new** content.
+
+The CLI owner-replacement path (`Document#replace_content!`, added in #117/#118)
+resets the live editor state — it sets `yjs_state` and `content_snapshot` to
+`nil`, bumps the seed lifecycle back to `pending`, and stores the new source as
+`seed_content` — so fresh page loads reseed the new source. It also broadcasts
+`content_reset` so **connected** editors reload. That works for the clean
+single-tab case.
+
+The bug is the residual case: a browser session that still holds the
+**pre-reset** Yjs document (a tab that was offline/backgrounded when the
+`content_reset` broadcast fired, then reconnects; or any lingering session)
+re-merges its old CRDT state into the server through the normal sync write
+paths. Once `yjs_state` is non-`nil` again, `seed_stage?` is `false`, so every
+later load — including incognito — hydrates the resurrected old CRDT instead of
+reseeding the new source. `current_content` still reads `seed_content` (new),
+which is why the API looks correct while the browser is stale.
+
+## Reproduction (deterministic)
+
+```ruby
+doc = Document.create!(title: "Repro", seed_markdown: "# Seed", user: User.first)
+old = Y::Doc.new; old.get_text("t") << "OLD LIVE CONTENT"
+YjsPersistence.merge(doc, Base64.strict_encode64(old.full_diff.pack("C*"))) # live, yjs_state = OLD
+
+doc.replace_content!(source: "# NEW FROM CLI")           # reset: yjs_state nil, seed_content NEW
+YjsPersistence.merge(doc, Base64.strict_encode64(old.full_diff.pack("C*"))) # stale client re-syncs OLD
+
+doc.reload
+doc.current_content            # => "# NEW FROM CLI"   (API / thinkroom show)
+ydoc_text_of(doc.yjs_state)    # => "OLD LIVE CONTENT"  (what the browser hydrates)
+doc.seed_stage?                # => false               (so no reseed on refresh/incognito)
+```
+
+## Root cause
+
+The Yjs persistence layer (`YjsPersistence.merge` / `persist_snapshot`, reached
+via `SyncChannel` `sync-reply`/`update`, the `sync_update` keepalive, and the
+`snapshot` push) has no concept of "this client's state predates a reset." A
+client computes "everything the server is missing" relative to the server's
+(now-empty) state vector and ships its **entire** old document; the server
+cannot distinguish legitimately-missing new content from resurrected old
+content, so it persists it.
+
+## Fix
+
+Add a monotonic **content generation** counter to `Document`, bumped on every
+`replace_content!`. Editor clients learn the generation at page-load time
+(Inertia prop), announce it when they connect (`SyncChannel` subscribe param)
+and on the HTTP persistence requests (`snapshot`, `sync_update`). The server
+**drops any CRDT/snapshot write whose announced generation is older than the
+document's current generation**, so a pre-reset client can never resurrect the
+stale state.
+
+- The generation a client uses is fixed at page load and is **not** adopted
+  from reconnect handshakes — a stale tab keeps announcing its old generation
+  even after reconnecting, so its writes are reliably rejected.
+- A stale client is told to reload: on a stale `SyncChannel` handshake (or a
+  dropped stale write) the server transmits a `reset` signal that triggers the
+  same `window.location.reload()` the `content_reset` broadcast uses. This
+  self-heals the tab that missed the original broadcast.
+- Absent generation (clients deployed before this change during a rollout) is
+  treated as "no guard" so behavior is unchanged for them — matching the
+  existing `seq`/rollout-compatibility conventions in `SyncChannel`.
+
+## Implementation units
+
+### U1. `content_generation` column + model bump
+- `db/migrate/*_add_content_generation_to_documents.rb`: `integer, null: false, default: 0`.
+- `Document#replace_content!`: bump `content_generation` inside the existing lock.
+- `Document#content_stale?(generation)`: predicate used by the guard.
+- Tests: `test/models/document_test.rb`.
+
+### U2. Server-side generation guard (the data-integrity fix)
+- `YjsPersistence.merge(..., generation:)` raises `Document::StaleContentError`
+  when the caller's generation is behind the reloaded document.
+- `YjsPersistence.persist_snapshot(..., generation:)` returns `false` when stale.
+- `SyncChannel`: capture the client generation from subscribe params; pass it to
+  `merge`; on a stale handshake or a dropped write, transmit `{ type: "reset" }`
+  and never relay the stale frame.
+- `documents#snapshot` / `documents#sync_update`: read `params[:gen]`, thread it
+  to the persistence calls, and reject stale writes without broadcasting.
+- Tests: `test/services/yjs_persistence_test.rb`, `test/channels/sync_channel_test.rb`.
+
+### U3. Client threading + reset handling
+- `documents#show` props: add `content_generation`.
+- `documents/show.tsx`: pass `contentGeneration` into `DocumentEditor`.
+- `milkdown_editor.tsx`: forward to `CableProvider`; include `gen` on the
+  snapshot push.
+- `cable_provider.ts`: send `gen` in the subscribe params and the `sync_update`
+  body; handle an incoming `{ type: "reset" }` by emitting `reset`, wired to a
+  full reload.
+
+## Scope boundaries
+
+- No change to non-owner conflict semantics or to how `replace_content!`
+  computes the new source/attribution.
+- No attempt to merge old and new content — replacement stays destructive by
+  design.
+- The guard is defense-in-depth at the single persistence chokepoint; it does
+  not replace the `content_reset` broadcast (which remains the primary,
+  immediate reload path for connected clients).
+
+## Verification
+
+- Deterministic persistence/channel tests prove a stale generation can no longer
+  resurrect `yjs_state`/`content_snapshot`.
+- Browser end-to-end: a live doc replaced via the CLI shows the new content on
+  hard refresh and in incognito; a stale tab reloads to the new content.

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -266,6 +266,49 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "a client reconnecting behind the content generation is told to reset" do
+    doc = Document.create!(title: "Replaced", seed_markdown: "# Seed")
+    YjsPersistence.merge(doc, build_update_b64("old"), generation: 0)
+    doc.replace_content!(source: "# new source") # content_generation -> 1
+
+    subscribe slug: doc.slug, gen: 0
+
+    assert subscription.confirmed?
+    message = transmissions.last
+    assert_equal "reset", message["type"],
+                 "a stale reconnecting client must be told to reload, not handed the sync handshake"
+  end
+
+  test "a stale update frame is dropped, not persisted or relayed, and triggers reset" do
+    doc = Document.create!(title: "Replaced", seed_markdown: "# Seed")
+    YjsPersistence.merge(doc, build_update_b64("old"), generation: 0)
+    doc.replace_content!(source: "# new source")
+    subscribe slug: doc.slug, gen: 0
+    stale = build_update_b64("resurrected old content")
+
+    assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
+      perform :receive, { "type" => "sync-reply", "update" => stale, "cid" => "stale", "seq" => 1 }
+    end
+
+    assert_not doc.reload.yjs_state.present?, "a stale sync-reply must not resurrect yjs_state"
+    assert doc.seed_stage?, "doc must remain seed-stage after dropping the stale frame"
+    assert_equal "reset", transmissions.last["type"]
+  end
+
+  test "a current-generation update still persists after a reset" do
+    doc = Document.create!(title: "Replaced", seed_markdown: "# Seed")
+    YjsPersistence.merge(doc, build_update_b64("old"), generation: 0)
+    doc.replace_content!(source: "# new source")
+    subscribe slug: doc.slug, gen: doc.content_generation
+    update = build_update_b64("fresh content")
+
+    assert_broadcast_on(SyncChannel.broadcasting_for(doc), type: "update", update: update, cid: "fresh") do
+      perform :receive, { "type" => "update", "update" => update, "cid" => "fresh", "seq" => 1 }
+    end
+
+    assert doc.reload.yjs_state.present?
+  end
+
   test "awareness messages relay without persisting" do
     doc = Document.create!(title: "Presence")
     subscribe slug: doc.slug

--- a/test/integration/document_seed_claim_test.rb
+++ b/test/integration/document_seed_claim_test.rb
@@ -125,6 +125,40 @@ class DocumentSeedClaimTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "page render exposes the content generation for the editor to announce" do
+    get document_page_path(@document.slug), headers: browser
+
+    assert_inertia_props do |props|
+      props[:document][:content_generation] == @document.reload.content_generation
+    end
+  end
+
+  # The reported bug: after `thinkroom update` replaces a live document, a stale
+  # browser session re-syncs its old CRDT, which used to resurrect yjs_state and
+  # stop every later load (incognito included) from reseeding the new source.
+  test "a stale re-sync after replacement cannot stop a fresh load from reseeding the new source" do
+    old = Y::Doc.new
+    old.get_text("t") << "OLD LIVE CONTENT"
+    old_full = Base64.strict_encode64(old.full_diff.pack("C*"))
+    YjsPersistence.merge(@document, old_full, generation: 0)
+    assert_not @document.reload.seed_stage?, "doc is now live"
+
+    @document.replace_content!(source: "# Brand New")
+
+    # A stale tab (still at generation 0) re-syncing its old doc is rejected.
+    assert_raises(Document::StaleContentError) do
+      YjsPersistence.merge(@document, old_full, generation: 0)
+    end
+
+    # A brand-new (e.g. incognito) page load still reseeds the new source.
+    get document_page_path(@document.slug), headers: browser
+    assert_inertia_props do |props|
+      props[:document][:seed_granted] == true &&
+        props[:document][:seed_content] == "# Brand New" &&
+        props[:document][:has_state] == false
+    end
+  end
+
   test "documents without seed markdown never grant the seed" do
     doc = Document.create!(title: "Blank", seed_markdown: nil)
 

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -133,6 +133,27 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "Codex", doc.seed_author_name
   end
 
+  test "replace content bumps the content generation each time" do
+    doc = Document.create!(title: "Live", seed_content: "# Seed")
+    assert_equal 0, doc.content_generation
+
+    doc.replace_content!(source: "# First")
+    assert_equal 1, doc.reload.content_generation
+
+    doc.replace_content!(source: "# Second")
+    assert_equal 2, doc.reload.content_generation
+  end
+
+  test "content_stale? flags only writes behind the current generation" do
+    doc = Document.create!(title: "Live", seed_content: "# Seed")
+    doc.replace_content!(source: "# New") # content_generation -> 1
+
+    assert doc.content_stale?(0), "a write from before the reset is stale"
+    assert_not doc.content_stale?(1), "a write at the current generation is current"
+    assert_not doc.content_stale?(2), "a write ahead of the server is not stale"
+    assert_not doc.content_stale?(nil), "a write without a generation is not guarded"
+  end
+
   test "database rejects unknown content formats" do
     doc = Document.create!(title: "Constrained")
 

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -67,6 +67,62 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_not doc.yjs_state.present?, "no-op merge must not persist state"
   end
 
+  test "merge rejects a write from a client behind the current content generation" do
+    doc = Document.create!(title: "Replaced")
+    old = b64_update_for("old live content")
+    YjsPersistence.merge(doc, old, generation: 0)
+    doc.replace_content!(source: "# new source") # bumps content_generation to 1
+
+    assert_raises(Document::StaleContentError) do
+      # A stale tab (still at generation 0) re-syncing its old doc must not
+      # resurrect the replaced state.
+      YjsPersistence.merge(doc, old, generation: 0)
+    end
+
+    doc.reload
+    assert_not doc.yjs_state.present?, "stale re-sync must not repopulate yjs_state"
+    assert doc.seed_stage?, "doc must stay seed-stage so fresh loads reseed the new source"
+    assert_equal "# new source", doc.current_content
+  end
+
+  test "merge accepts a write at the current content generation after a reset" do
+    doc = Document.create!(title: "Replaced")
+    YjsPersistence.merge(doc, b64_update_for("old"), generation: 0)
+    doc.replace_content!(source: "# new source")
+
+    YjsPersistence.merge(doc, b64_update_for("fresh edit"), generation: doc.content_generation)
+
+    assert doc.reload.yjs_state.present?
+    assert_includes text_of(doc), "fresh edit"
+  end
+
+  test "merge without a generation is not guarded (rollout compatibility)" do
+    doc = Document.create!(title: "Legacy")
+    doc.replace_content!(source: "# new source")
+
+    YjsPersistence.merge(doc, b64_update_for("from a pre-guard client"))
+
+    assert doc.reload.yjs_state.present?
+  end
+
+  test "persist_snapshot rejects a client behind the current content generation" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"), generation: 0)
+    doc.replace_content!(source: "# new source")
+    client_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc,
+      state_vector_b64: client_vector,
+      content: "stale snapshot",
+      spans: [],
+      generation: 0
+    )
+
+    assert_not persisted, "a snapshot from a pre-reset client must be rejected"
+    assert_nil doc.reload.content_snapshot, "stale snapshot must not shadow the new seed"
+  end
+
   test "corrupt base64 raises and leaves the document untouched" do
     doc = Document.create!(title: "Corrupt")
     YjsPersistence.merge(doc, b64_update_for("good content"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

After `thinkroom update` replaces a claimed/live document, the browser keeps showing the **old** content even after a hard refresh or in an incognito window, while `thinkroom show --json` correctly returns the **new** content.

## Root cause

The owner CLI replacement path (`Document#replace_content!`, from #114/#117/#118) resets the live editor state — it clears `yjs_state`/`content_snapshot`, bumps the seed lifecycle back to `pending`, stores the new source as `seed_content`, and broadcasts `content_reset` so connected editors reload. That works for the clean single-tab case.

But the Yjs persistence layer (`YjsPersistence.merge` / `persist_snapshot`, reached via `SyncChannel` `sync-reply`/`update`, the `sync_update` keepalive, and the `snapshot` push) had **no notion of a content generation**. A browser session that still held the pre‑reset CRDT — a tab that was offline/backgrounded when the `content_reset` broadcast fired and then reconnects — re‑merges its old document back (a reconnect `sync-reply` dumps the client's *entire* old doc because the server's state vector is now empty). That repopulates `yjs_state` with the OLD content and flips `seed_state` back to `"seeded"`.

Once `yjs_state` is present again, `seed_stage?` is `false`, so `try_claim_seed` returns `false` forever and the editor never re‑seeds — which is exactly why a hard refresh (and incognito) keep showing the old content while `current_content`/the API read the new `seed_content`.

Reproduced deterministically:

```ruby
old = Y::Doc.new; old.get_text("t") << "OLD LIVE CONTENT"
YjsPersistence.merge(doc, Base64.strict_encode64(old.full_diff.pack("C*"))) # live, yjs_state = OLD
doc.replace_content!(source: "# NEW FROM CLI")           # reset: yjs_state nil, seed_content NEW
YjsPersistence.merge(doc, Base64.strict_encode64(old.full_diff.pack("C*"))) # stale client re-syncs OLD
doc.current_content   # => "# NEW FROM CLI"   (API / thinkroom show)
# browser hydrates yjs_state => "OLD LIVE CONTENT"; seed_stage? => false
```

## Fix — a content-generation guard

Add a monotonic `content_generation` counter bumped by `replace_content!`. Editor clients learn the generation at page load (Inertia prop), announce it on the `SyncChannel` subscribe params and on every durable HTTP write (`snapshot`, `sync_update`), and the server **drops any CRDT/snapshot write whose announced generation is behind the document's current one**. A pre‑reset session can no longer resurrect the replaced state.

- The generation is fixed at page load and is **not** adopted from a reconnect handshake, so a stale tab keeps announcing its old generation and its writes stay rejected.
- A stale client is told to reload: a stale `SyncChannel` handshake (or a dropped stale write) transmits a `reset` signal that triggers the same `window.location.reload()` the `content_reset` broadcast uses. This self-heals a tab that missed the original broadcast.
- A missing generation (clients deployed before this change) is treated as "no guard", matching the existing `seq`/rollout-compatibility conventions in `SyncChannel`.

## Changes

- `Document`: `content_generation` column; `replace_content!` bumps it; `content_stale?` predicate; `StaleContentError`.
- `YjsPersistence.merge` / `persist_snapshot`: drop writes behind the current generation.
- `SyncChannel`: capture the client generation, reject stale frames, and tell stale clients to `reset`.
- `documents#show` props expose `content_generation`; `documents#snapshot` / `#sync_update` thread and enforce it.
- Editor (`cable_provider.ts`, `milkdown_editor.tsx`, `documents/show.tsx`): announce the generation and reload on `reset`.

## Testing

- Deterministic regression tests: `test/models/document_test.rb` (generation bump + `content_stale?`), `test/services/yjs_persistence_test.rb` (stale merge/snapshot dropped, current/absent generation accepted), `test/channels/sync_channel_test.rb` (handshake `reset`, stale frame dropped/not relayed, current frame persists after reset), `test/integration/document_seed_claim_test.rb` (a stale re‑sync can't stop a fresh load from reseeding the new source).
- Full suite green (482 runs, 0 failures), RuboCop clean, `npm run check` (tsc + CLI tests) clean.
- Manual end-to-end: with a live doc opened in the browser, replacing it via the CLI while the tab is stale, the tab **automatically reloads to the new content** and the old CRDT is never resurrected; a fresh incognito window shows the new content.

**Stale tab self-heals to the new content (was: stuck on old content):**

[stale_tab_self_heals_to_new_content.mp4](https://cursor.com/agents/bc-dca7f02b-9687-4014-b9d1-56d76f1b64b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstale_tab_self_heals_to_new_content.mp4)

**A fresh incognito window shows the new content (reported symptom fixed):**

[Incognito window showing the new content after a CLI update](https://cursor.com/agents/bc-dca7f02b-9687-4014-b9d1-56d76f1b64b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincognito_shows_new_content_after_update.webp)

## CI note (pre-existing, unrelated)

The `scan_ruby` check fails on `bundler-audit`, which flags `crass 1.0.6` (a transitive dependency via `loofah`) for advisories published to ruby-advisory-db on 2026-06-28. This PR changes no gems — `Gemfile`/`Gemfile.lock` are untouched — and the same `scan_ruby` failure appears on other open branches, so it is pre-existing and repo-wide, not introduced here. `lint`, `test`, and `scan_javascript` pass. Resolving it (bump `crass` to `>= 1.0.7`) is a separate dependency-maintenance change best applied repo-wide rather than bundled into this bug fix.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dca7f02b-9687-4014-b9d1-56d76f1b64b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dca7f02b-9687-4014-b9d1-56d76f1b64b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

