### PR TITLE
feat: auto-copy the agent prompt when revealing it on home

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     commonmarker (2.8.2-x86_64-linux-musl)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -497,7 +497,7 @@ CHECKSUMS
   commonmarker (2.8.2-x86_64-linux-musl) sha256=66568dce1c6f265e85d57ea7f749a148446527c7dd599c6ded4cdc819997c43e
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -680,6 +680,15 @@ a:focus-visible {
   margin-bottom: 0.5rem;
 }
 
+.landing-agent-hint.is-copied {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.landing-agent-hint.is-copied::before {
+  content: '✓ ';
+}
+
 .landing-agent-block {
   position: relative;
   background: var(--surface-raised);

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -244,6 +244,16 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     })
   }, [agentInstruction])
 
+  // Revealing the prompt also copies it: the agent-start action is "give me the
+  // prompt", so a single click both shows it and puts it on the clipboard.
+  const revealAgentInstructions = useCallback(() => {
+    const willOpen = !agentInstructionsOpen
+    setAgentInstructionsOpen(willOpen)
+    if (willOpen) {
+      copyInstruction()
+    }
+  }, [agentInstructionsOpen, copyInstruction])
+
   const availableTags = yours.reduce<string[]>((tags, document) => {
     document.tags.forEach((tag) => {
       if (!tags.some((existingTag) => existingTag.toLowerCase() === tag.toLowerCase())) {
@@ -299,7 +309,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
                 type="button"
                 aria-expanded={agentInstructionsOpen}
                 aria-controls="agent-start-instructions"
-                onClick={() => setAgentInstructionsOpen((open) => !open)}
+                onClick={revealAgentInstructions}
               >
                 Have an agent start one
               </button>

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -240,7 +240,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
   const copyInstruction = useCallback(() => {
     void navigator.clipboard.writeText(agentInstruction).then(() => {
       setCopied(true)
-      setTimeout(() => setCopied(false), 1600)
+      setTimeout(() => setCopied(false), 2400)
     })
   }, [agentInstruction])
 
@@ -327,8 +327,13 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
               className="landing-agent"
               aria-labelledby="agent-start-trigger"
             >
-              <p className="landing-agent-hint">
-                Paste this to any agent that can make HTTP requests:
+              <p
+                className={`landing-agent-hint${copied ? ' is-copied' : ''}`}
+                aria-live="polite"
+              >
+                {copied
+                  ? 'Copied to clipboard — paste it into any agent that can make HTTP requests:'
+                  : 'Paste this to any agent that can make HTTP requests:'}
               </p>
               <div className="landing-agent-block">
                 <code>{agentInstruction}</code>

--- a/docs/plans/2026-06-29-001-feat-agent-start-auto-copy-plan.md
+++ b/docs/plans/2026-06-29-001-feat-agent-start-auto-copy-plan.md
@@ -1,0 +1,116 @@
+---
+title: "feat: Auto-copy the agent prompt when starting an agent doc"
+type: feat
+date: 2026-06-29
+origin: Riffrec feedback recording (thinkroom.kieranklaassen.com, 2026-06-29 15:47Z, 15.8s)
+---
+
+# feat: Auto-copy the agent prompt when starting an agent doc
+
+## Summary
+
+On the home page, clicking **"Have an agent start one"** should copy the agent HTTP
+prompt to the clipboard at the same time it reveals it, instead of requiring a second
+click on the panel's **Copy** button.
+
+## Problem Frame
+
+A Riffrec product-feedback recording captured the product owner on the Thinkroom home
+page clicking **"Have an agent start one"** repeatedly and saying:
+
+> "Okay, when I click 'Have an agent start one', I want it to just automatically copy —
+> so when you click this, it should send copy."
+
+The recording's event stream confirms repeated clicks on `#agent-start-trigger`
+(t≈4.7s, 7.5s, 8.3s) with no copy occurring — the user had to find and click the
+separate **Copy** button inside the revealed panel. The expectation is that the primary
+agent-start action also puts the prompt on the clipboard so it can be pasted straight
+into an agent.
+
+This intentionally revises the earlier decision in
+`docs/plans/2026-06-26-019-feat-prominent-agent-start-plan.md` (KTD4 / R3 / AE3:
+"reveal before copying; clipboard writes remain an explicit second action"). The new
+recorded owner feedback supersedes that choice: the reveal click should now also copy.
+Copying inside a click handler is a user gesture, so it stays permission-safe on the
+production HTTPS origin.
+
+## Requirements
+
+- R1. Activating `#agent-start-trigger` reveals the HTTP instruction (unchanged) **and**
+  copies that instruction to the clipboard in the same action.
+- R2. The copy produces visible confirmation (the existing "Copied" state) so the user
+  knows the prompt is on the clipboard.
+- R3. The panel's manual **Copy** button continues to work for re-copying and as a
+  fallback if the automatic copy is unavailable.
+- R4. Collapsing the panel (toggling closed) does not copy; keyboard activation and the
+  existing `aria-expanded` / `aria-controls` disclosure semantics are preserved.
+- R5. No change to the prompt text, the agent API contract, manual "New document"
+  creation, or the rest of the document library.
+
+## Key Technical Decisions
+
+- KTD1. Reuse the existing `copyInstruction` callback and `copied` state; trigger the
+  copy when the disclosure transitions to open. No new clipboard plumbing, matching the
+  convention in `app/frontend/components/share_popover.tsx`.
+- KTD2. Copy on open only (not on close). Computing the next open-state outside the
+  state updater keeps the copy a single, predictable side effect (no double-fire under
+  React StrictMode).
+- KTD3. Keep the in-panel **Copy** button. It is the fallback path and the re-copy
+  affordance, so the feature degrades gracefully if `navigator.clipboard` rejects.
+
+## Implementation Units
+
+### U1. Copy the agent prompt when the trigger reveals it
+
+- **Files:** `app/frontend/pages/documents/index.tsx`
+- **Approach:** Add a click handler for `#agent-start-trigger` that toggles
+  `agentInstructionsOpen` and, when the next state is open, calls the existing
+  `copyInstruction()`. Leave the prompt generation, the `copied` feedback, and the
+  in-panel **Copy** button untouched.
+- **Verification:** Clicking the trigger opens the panel and the in-panel **Copy** button
+  reads "Copied" without a second click; the prompt is on the clipboard; toggling closed
+  does not copy; keyboard activation works and `aria-expanded` still flips.
+
+### U2. Update landing regression coverage
+
+- **Files:** `script/browser_check.mjs`
+- **Approach:** In the landing smoke section, replace the "explicit second Copy click"
+  assertion with one that verifies the **Copy** button shows "Copied" immediately after
+  the trigger click (auto-copy), keeping the existing expand-state assertion.
+- **Test scenarios:**
+  - Happy path: after `agentStart.click()`, `.landing-agent-block .share-copy` reaches
+    text "Copied" without an explicit copy click.
+  - Preserved: `aria-expanded` flips to `true` and the instruction panel becomes visible.
+- **Verification:** `node script/browser_check.mjs` passes against a running `bin/dev`,
+  alongside `npm run check`.
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given the home page, when "Have an agent start one" is clicked,
+  then the HTTP prompt appears and is on the clipboard with a "Copied" confirmation.
+- AE2. **Covers R3.** Given the panel is open, when the **Copy** button is clicked, then
+  the prompt is (re)written to the clipboard with confirmation.
+- AE3. **Covers R4.** Given the panel is open, when the trigger is clicked again, then the
+  panel collapses and no copy occurs; the trigger reports `aria-expanded="false"`.
+
+## Scope Boundaries
+
+- In scope: copy-on-reveal behavior for the home agent-start trigger and its regression
+  coverage.
+- Out of scope: changing the prompt text or agent API, adding a toast system, restyling
+  the hero, or altering `share_popover.tsx`.
+
+### Deferred to Follow-Up Work
+
+- Hardening `copyInstruction` with an explicit `navigator.clipboard` guard / `.catch`.
+  The sibling `share_popover.tsx` omits it too; production is HTTPS (secure context) and
+  the manual button is the fallback, so this is a separate, optional cleanup.
+
+## Sources
+
+- Riffrec feedback recording (transcript + click events + frames) — the spoken request to
+  auto-copy on click, with repeated `#agent-start-trigger` clicks as corroboration.
+- `docs/plans/2026-06-26-019-feat-prominent-agent-start-plan.md` — the prior decision this
+  plan intentionally revises (KTD4 "reveal before copying").
+- `app/frontend/components/share_popover.tsx` — existing `navigator.clipboard.writeText`
+  + `copied` convention to mirror.

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -27,6 +27,11 @@ const makePage = async (label) => {
 
 try {
   const landing = await browser.newPage()
+  // Headless shell denies clipboard writes by default; real browsers allow them
+  // under a user gesture. Grant them so the agent-start copy path is testable.
+  await landing
+    .context()
+    .grantPermissions(['clipboard-read', 'clipboard-write'], { origin: BASE })
   await landing.goto(BASE)
   await landing.waitForSelector('.landing-wordmark')
   if ((await landing.locator('.landing-wordmark').innerText()) === 'Thinkroom') {
@@ -65,9 +70,10 @@ try {
   } else {
     fail('agent creation action does not report its expanded state')
   }
-  await landing.locator('.landing-agent-block .share-copy').click()
+  // Activating the trigger should copy the prompt automatically — the in-panel Copy
+  // button confirms with "Copied" without requiring a separate copy click.
   await landing.locator('.landing-agent-block .share-copy', { hasText: 'Copied' }).waitFor()
-  ok('agent creation instructions provide explicit copy confirmation')
+  ok('activating the agent action copies the instruction automatically')
   if ((await landing.locator('.format-label').count()) === 0) {
     ok('landing page organizes documents without format labels')
   } else {

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -74,6 +74,11 @@ try {
   // button confirms with "Copied" without requiring a separate copy click.
   await landing.locator('.landing-agent-block .share-copy', { hasText: 'Copied' }).waitFor()
   ok('activating the agent action copies the instruction automatically')
+  // And a clear, prominent confirmation message appears (not just the small button).
+  await landing
+    .locator('.landing-agent-hint.is-copied', { hasText: 'Copied to clipboard' })
+    .waitFor()
+  ok('a clear "Copied to clipboard" confirmation is shown on copy')
   if ((await landing.locator('.format-label').count()) === 0) {
     ok('landing page organizes documents without format labels')
   } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

From a Riffrec product-feedback recording on the Thinkroom home page, the product owner clicked **"Have an agent start one"** repeatedly and said:

> "Okay, when I click 'Have an agent start one', I want it to just automatically copy — so when you click this, it should send copy."

Today that trigger only *reveals* the HTTP agent prompt; copying requires a second click on the panel's **Copy** button. This PR makes the reveal click also copy the prompt, and adds a clear confirmation that it copied.

This intentionally revises the earlier decision in `docs/plans/2026-06-26-019-feat-prominent-agent-start-plan.md` (KTD4 "reveal before copying; clipboard writes remain an explicit second action"). The new recorded owner feedback supersedes it. Copying happens inside the click handler (a user gesture), so it stays permission-safe on the production HTTPS origin.

## Changes

- `app/frontend/pages/documents/index.tsx` — clicking `#agent-start-trigger` now toggles the disclosure and, when it opens, calls the existing `copyInstruction()`. On copy, the panel's hint line becomes a prominent **"✓ Copied to clipboard — paste it into any agent that can make HTTP requests:"** (accent-colored, `aria-live` for screen readers), reverting after 2.4s. Copy fires on open only, not on close; `aria-expanded`/`aria-controls` and keyboard activation are unchanged. The manual **Copy** button stays as a re-copy/fallback.
- `app/frontend/entrypoints/application.css` — `.landing-agent-hint.is-copied` accent/bold styling with a decorative `✓`.
- `script/browser_check.mjs` — the landing smoke check asserts auto-copy (the Copy button reads "Copied" after the trigger click) **and** that the clear "Copied to clipboard" confirmation appears; it also grants the landing context clipboard permission so the path is testable under Playwright's headless shell.
- `docs/plans/2026-06-29-001-feat-agent-start-auto-copy-plan.md` — the plan, citing the recording as origin.
- `Gemfile.lock` — **unrelated** conservative bump of the transitive gem `crass` 1.0.6 → 1.0.7 (see note below).

## Testing

- `npm run check` (TypeScript) — pass
- `bin/rubocop` — pass (146 files, no offenses)
- `bin/rails db:test:prepare test` (Minitest) — pass (471 runs, 0 failures), re-run after the gem bump
- `bin/vite build --mode test` — pass
- `node script/browser_check.mjs` — landing section passes, including **"activating the agent action copies the instruction automatically"** and **"a clear 'Copied to clipboard' confirmation is shown on copy"**. A Playwright clipboard read-back confirmed the clipboard holds the exact prompt.
- Manual GUI test (real Chrome) + videos below.

### Demo

Clear "Copied to clipboard" confirmation on a single click:

[agent_start_copied_message_demo.mp4](https://cursor.com/agents/bc-a9ef6f98-ab91-4904-b2a1-8a14d04cd57a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_start_copied_message_demo.mp4)

[Prominent Copied to clipboard confirmation at the top of the panel](https://cursor.com/agents/bc-a9ef6f98-ab91-4904-b2a1-8a14d04cd57a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_start_copied_message.webp)

Clipboard actually holds the prompt (pasted into the address bar, no Copy click):

[Auto-copied agent prompt pasted into the address bar](https://cursor.com/agents/bc-a9ef6f98-ab91-4904-b2a1-8a14d04cd57a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_start_clipboard_pasted.webp)

## Notes for reviewers

- **Unrelated dependency fix:** CI's `scan_ruby` (bundler-audit) failed on `crass` 1.0.6 for four advisories disclosed 2026-06-29 (GHSA-6jxj-px6v-747w, GHSA-6wmf-3r64-vcwv, GHSA-8vfg-2r28-hvhj, GHSA-wwpr-jff3-395c), all resolved by `>= 1.0.7`. `crass` is transitive via `loofah (~> 1.0.2)`; the conservative bump touches only `crass` and is isolated in its own commit. This is repo-wide (would fail on `main`), not introduced here.
- **Pre-existing smoke failure:** `script/browser_check.mjs` (local-only; not run in CI) fails later at an unrelated collaborative-editor step (`.selection-toolbar` "Comment"). I confirmed this reproduces on unmodified `main` (baseline run with only the clipboard-permission grant), so it is pre-existing and unrelated to this change.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ef6f98-ab91-4904-b2a1-8a14d04cd57a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ef6f98-ab91-4904-b2a1-8a14d04cd57a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

