### PR TITLE
fix(mobile): stop iOS input auto-zoom · feat(auth): remember me for 30 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       # (selection stomping while a second tab is open).
       - name: Run browser regression checks
         run: |
-          for check in sync_check link_check mermaid_check rich_block_width_check suggestion_list_replace_check export_check html_document_check meta_refresh_check; do
+          for check in sync_check link_check mermaid_check rich_block_width_check suggestion_list_replace_check export_check html_document_check meta_refresh_check mobile_zoom_check; do
             echo "=== script/${check}.mjs"
             node "script/${check}.mjs"
           done

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,24 @@ class ApplicationController < ActionController::Base
   # complements CSRF protection on the claim/delete POSTs.
   before_action :ensure_owner_token
 
+  # Runs after the action so login (flag just set) upgrades to a persistent
+  # cookie and logout (reset_session just cleared it) reverts to a
+  # browser-session cookie. Re-applied every request: any session write
+  # re-issues the cookie, and without expire_after that reissue would
+  # silently downgrade a remembered session. Also slides the 30-day window.
+  after_action :extend_remembered_session
+
   helper_method :current_user
 
+  REMEMBER_ME_DURATION = 30.days
+
   private
+
+  def extend_remembered_session
+    return unless session[:remember_me]
+
+    request.session_options[:expire_after] = REMEMBER_ME_DURATION
+  end
 
   def render_write_rate_limit
     render plain: "Too many requests. Try again later.", status: :too_many_requests

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,14 @@ class ApplicationController < ActionController::Base
   # complements CSRF protection on the claim/delete POSTs.
   before_action :ensure_owner_token
 
-  # Runs after the action so login (flag just set) upgrades to a persistent
+  # Runs around the action so login (flag just set) upgrades to a persistent
   # cookie and logout (reset_session just cleared it) reverts to a
   # browser-session cookie. Re-applied every request: any session write
   # re-issues the cookie, and without expire_after that reissue would
   # silently downgrade a remembered session. Also slides the 30-day window.
-  after_action :extend_remembered_session
+  # around_action + ensure (not after_action) so rescue_from-handled requests
+  # — which still commit the session — keep the expiry too.
+  around_action :extend_remembered_session
 
   helper_method :current_user
 
@@ -26,9 +28,9 @@ class ApplicationController < ActionController::Base
   private
 
   def extend_remembered_session
-    return unless session[:remember_me]
-
-    request.session_options[:expire_after] = REMEMBER_ME_DURATION
+    yield
+  ensure
+    request.session_options[:expire_after] = REMEMBER_ME_DURATION if session[:remember_me]
   end
 
   def render_write_rate_limit

--- a/app/controllers/concerns/authenticates_user.rb
+++ b/app/controllers/concerns/authenticates_user.rb
@@ -3,13 +3,14 @@ module AuthenticatesUser
 
   private
 
-  def complete_authentication(user)
+  def complete_authentication(user, remember: false)
     destination = safe_return_to(session[:return_to])
     anonymous_token = owner_token
 
     user.claim_documents!(anonymous_token)
     reset_session
     session[:user_id] = user.id
+    session[:remember_me] = true if remember
     replace_owner_token!
 
     destination || root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < InertiaController
     password_matches = BCrypt::Password.new(digest).is_password?(params[:password].to_s)
 
     if user&.password_account? && password_matches
-      redirect_to complete_authentication(user), status: :see_other
+      redirect_to complete_authentication(user, remember: params[:remember_me].present?), status: :see_other
     else
       redirect_to auth_path_with_return(login_path),
                   inertia: { errors: { email: "Invalid email or password" } }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -4268,7 +4268,8 @@ a:focus-visible {
      on focus. Desktop keeps the compact chrome sizes. */
   .document-tag-editor input,
   .comment-input,
-  .identity-input {
+  .identity-input,
+  .thinkroom-sketch-title {
     font-size: 1rem;
   }
 
@@ -4277,6 +4278,8 @@ a:focus-visible {
     height: 2.75rem;
   }
 
+  /* 36px, not the 44px convention: the input sits inside the sticky doc
+     header, which a 44px field would visibly inflate. */
   .identity-input {
     min-height: 2.25rem;
   }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -3379,7 +3379,8 @@ a:focus-visible {
 
 .sheet-body .comment-input {
   min-height: 44px;
-  font-size: 0.9rem;
+  /* 16px minimum so iOS Safari doesn't zoom in when the composer focuses. */
+  font-size: 1rem;
 }
 
 .sheet-body .comment-resolve,
@@ -4261,6 +4262,23 @@ a:focus-visible {
     min-height: 44px;
     opacity: 1;
     pointer-events: auto;
+  }
+
+  /* 16px minimum on text inputs: anything smaller makes iOS Safari zoom in
+     on focus. Desktop keeps the compact chrome sizes. */
+  .document-tag-editor input,
+  .comment-input,
+  .identity-input {
+    font-size: 1rem;
+  }
+
+  .document-tag-editor input,
+  .document-tag-save {
+    height: 2.75rem;
+  }
+
+  .identity-input {
+    min-height: 2.25rem;
   }
 }
 

--- a/app/frontend/pages/auth/show.css
+++ b/app/frontend/pages/auth/show.css
@@ -1,6 +1,8 @@
 .auth-page {
   display: grid;
   min-height: 100vh;
+  /* iOS Safari over-measures 100vh behind the dynamic toolbar. */
+  min-height: 100dvh;
   place-items: center;
   padding: 2rem 1rem;
 }
@@ -106,7 +108,8 @@
   background: var(--surface-raised);
   color: var(--ink);
   padding: 0.65rem 0.75rem;
-  font-size: 0.9rem;
+  /* 16px minimum: anything smaller makes iOS Safari zoom in on focus. */
+  font-size: 1rem;
   box-shadow: none;
 }
 

--- a/app/frontend/pages/auth/show.css
+++ b/app/frontend/pages/auth/show.css
@@ -123,6 +123,27 @@
   border-color: color-mix(in srgb, #b3261e 45%, var(--line));
 }
 
+/* Row layout + compact box: overrides the grid label and full-width input
+   rules that style the text fields. */
+.auth-fields .auth-remember {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 450;
+}
+
+.auth-fields .auth-remember input {
+  width: 1.05rem;
+  height: 1.05rem;
+  min-height: 0;
+  padding: 0;
+  border-radius: 4px;
+  /* @tailwindcss/forms paints the checked box with currentColor. */
+  color: var(--ink);
+}
+
 .auth-error {
   color: #9a2f28;
   font-size: 0.76rem;

--- a/app/frontend/pages/auth/show.css
+++ b/app/frontend/pages/auth/show.css
@@ -127,6 +127,7 @@
    rules that style the text fields. */
 .auth-fields .auth-remember {
   display: flex;
+  min-height: 2.75rem;
   align-items: center;
   gap: 0.55rem;
   cursor: pointer;

--- a/app/frontend/pages/auth/show.tsx
+++ b/app/frontend/pages/auth/show.tsx
@@ -99,6 +99,12 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to }
                     />
                   </label>
                 )}
+                {!registering && (
+                  <label className="auth-remember">
+                    <input name="remember_me" type="checkbox" value="1" />
+                    <span>Remember me for 30 days</span>
+                  </label>
+                )}
                 {(errorText(errors.email) || errorText(errors.form)) && (
                   <p className="auth-error" role="alert">
                     {errorText(errors.email) || errorText(errors.form)}

--- a/docs/plans/2026-07-02-002-fix-mobile-input-zoom-audit-plan.md
+++ b/docs/plans/2026-07-02-002-fix-mobile-input-zoom-audit-plan.md
@@ -1,0 +1,127 @@
+---
+title: "fix: Stop iOS input auto-zoom and harden mobile input sizing"
+date: 2026-07-02
+type: fix
+depth: standard
+origin: user report (mobile audit request)
+---
+
+# fix: Stop iOS input auto-zoom and harden mobile input sizing
+
+## Summary
+
+Logging in on iOS zooms the page because the auth form inputs render at 0.9rem (≈14.4px) — iOS Safari auto-zooms any focused `input`/`textarea`/contenteditable whose font-size is below 16px. The same sub-16px pattern exists on every other native text input in the app (home tag editor, comment composers, identity chip). Fix the auth inputs unconditionally, enforce a 16px minimum on all other inputs for touch devices via the repo's existing coarse-pointer media-query pattern, and add an automated browser check so the regression can't return.
+
+---
+
+## Problem Frame
+
+- **Report:** "if I log in on mobile it kind of zooms in" + a general request to audit mobile font sizes / layout.
+- **Root cause (verified in code):** `.auth-fields input { font-size: 0.9rem; }` in `app/frontend/pages/auth/show.css`. 0.9rem ≈ 14.4px < 16px → iOS Safari zooms the viewport on focus and does not zoom back out on blur.
+- **Audit findings (all native text inputs, computed at the 16px browser default):**
+  - `.auth-fields input` — 14.4px (`app/frontend/pages/auth/show.css`) — login/signup email, password, name fields. **The reported bug.**
+  - `.document-tag-editor input` — 12.5px (`app/frontend/entrypoints/application.css` ~line 558) — home page tag editor.
+  - `.comment-input` — 12.8px (`application.css` ~line 2023) — comment composer textarea.
+  - `.sheet-body .comment-input` — 14.4px (`application.css` ~line 3380) — mobile comment sheet composer.
+  - `.identity-input` — 11.8px (`application.css` ~line 2872) — guest-name edit in the header.
+- **Not affected:** the Milkdown editor surface (contenteditable) is already 1rem on mobile; buttons/links don't trigger zoom; the viewport meta tag is correct (`width=device-width,initial-scale=1`, no `maximum-scale` hack — keep it that way for accessibility).
+- **Auth page also uses `min-height: 100vh`**, which over-measures under iOS Safari's dynamic toolbar; `100dvh` is the modern fix with `100vh` as fallback.
+- Touch-target audit: auth inputs/buttons are already 2.75rem (44px) tall — good. The tag editor input and identity input are shorter (34px / ~28px) and should get a touch-height bump alongside their font bump.
+
+## Requirements
+
+- R1: Focusing any input on the login/signup page on iOS must not zoom the viewport (all auth inputs ≥16px computed).
+- R2: All other native text inputs must compute to ≥16px on touch devices, without changing the compact desktop chrome.
+- R3: No horizontal overflow on the auth pages or home page at iPhone-class widths (390px).
+- R4: Regression coverage via the repo's existing Playwright check-script convention, wired into the CI `browser_checks` job.
+
+---
+
+## Key Technical Decisions
+
+1. **Fix auth inputs unconditionally (1rem everywhere), not just on touch.** The auth card is a simple centered form; 16px inputs are standard form sizing on desktop too, and an unconditional rule is simpler than a fork. Labels/help text stay as-is (they are not zoom triggers).
+2. **Gate the other input bumps behind `@media (hover: none), (pointer: coarse)`.** This matches the repo's existing touch-target pattern (44px rules in `application.css` ~line 4248) and leaves the intentionally-compact desktop chrome (12–14px inputs in rails/popovers) untouched. Narrow *desktop* windows keep the compact look; real touch devices — the only place auto-zoom happens — get 16px.
+3. **Do not add `maximum-scale=1` / `user-scalable=no` to the viewport meta.** That suppresses the symptom by disabling user zoom — an accessibility regression. Font-size is the correct fix.
+4. **New check script follows `script/*_check.mjs` conventions** (Playwright chromium, `BASE_URL` env, `✓`/`✗` output, non-zero exit on failure) and is appended to the CI `browser_checks` loop.
+
+## Scope Boundaries
+
+- **In scope:** input font-size/touch-height fixes listed above, auth `100dvh`, the new browser check, CI wiring.
+- **Out of scope (audited, no change needed):** viewport meta tag, Milkdown editor font sizes (already ≥16px mobile), mobile dock/sheets (already 44px targets + safe-area insets), secondary text sizes (labels, hints — small but readable and not zoom triggers).
+- **Deferred to follow-up work:** a broader typographic pass on sub-13px UI chrome text if the user wants larger secondary text on mobile; auth-page-specific responsive polish beyond the zoom fix.
+
+---
+
+## Implementation Units
+
+### U1. Fix auth page inputs and viewport height
+
+**Goal:** Login/signup no longer triggers iOS auto-zoom; auth card centers correctly under dynamic toolbars.
+
+**Requirements:** R1, R3
+
+**Dependencies:** none
+
+**Files:**
+- `app/frontend/pages/auth/show.css`
+
+**Approach:** Change `.auth-fields input` `font-size` from `0.9rem` to `1rem`. Change `.auth-page` `min-height` to `100vh` fallback + `100dvh` override. No markup changes; `app/frontend/pages/auth/show.tsx` stays untouched.
+
+**Test scenarios:** Covered by U3's browser check (computed font-size ≥16px on every auth input at an iPhone-class touch viewport; no horizontal overflow). No Ruby-side behavior change.
+
+**Verification:** On a 390px touch viewport, `getComputedStyle` of email/password/name inputs reports ≥16px; the page has no horizontal scrollbar; desktop rendering still looks correct.
+
+### U2. Enforce 16px minimum on remaining inputs for touch devices
+
+**Goal:** No native text input anywhere in the app triggers iOS auto-zoom.
+
+**Requirements:** R2
+
+**Dependencies:** none
+
+**Files:**
+- `app/frontend/entrypoints/application.css`
+
+**Approach:** In the existing touch-target section (or adjacent to it), add rules under `@media (hover: none), (pointer: coarse)` bumping `.document-tag-editor input`, `.comment-input` (covers the sheet variant via inheritance of the same class), and `.identity-input` to `font-size: 1rem`. Give `.document-tag-editor input` and `.identity-input` a `min-height: 2.75rem` touch height in the same block (matching the repo's 44px convention); let the tag-save button grow with the row if needed. Desktop rules stay untouched.
+
+**Patterns to follow:** the existing `@media (hover: none), (pointer: coarse)` block in `application.css` (~line 4248) that sets 44px menu targets.
+
+**Test scenarios:** Touch-context computed-style assertions in U3's check for the home tag editor input. Comment composer and identity input live behind auth/interaction state; verify manually via device-emulated browser testing (focus each, confirm ≥16px computed size and no zoom).
+
+**Verification:** With Playwright device emulation (hasTouch/isMobile), computed font-size of each listed input is ≥16px; with a plain desktop context they keep their compact sizes.
+
+### U3. Mobile zoom browser check + CI wiring
+
+**Goal:** Automated regression coverage for R1–R3.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `script/mobile_zoom_check.mjs` (new)
+- `.github/workflows/ci.yml` (append check to the `browser_checks` loop)
+
+**Approach:** Playwright chromium with an iPhone-class emulated context (390×844, `isMobile`, `hasTouch` — so `(hover: none), (pointer: coarse)` matches). Visit `/login` and `/signup`: assert every rendered `input`/`textarea` computes to ≥16px font-size and the document has no horizontal overflow (`document.documentElement.scrollWidth <= window.innerWidth`). Visit `/` (home): assert the same input sweep (tag editor input is auth-gated; sweep whatever inputs render anonymously) and no horizontal overflow. Follow `script/meta_refresh_check.mjs` conventions for structure, env vars, and output.
+
+**Patterns to follow:** `script/meta_refresh_check.mjs` (script shape), `.github/workflows/ci.yml` `browser_checks` job (the `for check in …` loop).
+
+**Test scenarios:**
+- Happy path: all inputs on `/login`, `/signup` ≥16px → check passes.
+- Regression: any input under 16px → `✗` line and exit code 1.
+- Layout: horizontal overflow at 390px on any checked page → failure.
+
+**Verification:** `node script/mobile_zoom_check.mjs` passes locally against `bin/dev`; the CI loop includes the new script name.
+
+---
+
+## Risks & Dependencies
+
+- **Larger input text can change control heights/layout.** Auth inputs have a fixed 2.75rem min-height with modest padding, so 16px text fits; the tag-editor row wraps at ≤40rem already. Verify visually at 390px.
+- **`100dvh` support:** all evergreen browsers ship it; keep the `100vh` line first as fallback.
+- **The coarse-pointer media query also matches touch laptops.** Acceptable — 16px inputs on a touch-enabled laptop are fine, and this matches how the repo already gates 44px targets.
+
+## Deferred Implementation Notes
+
+- Exact placement of the new media-query block inside `application.css` (near the existing touch-target section) is an implementation-time choice.
+- Whether the anonymous home page renders any input at all determines how much U3's home sweep asserts; the sweep is written generically so it holds either way.

--- a/docs/plans/2026-07-02-003-feat-remember-me-login-plan.md
+++ b/docs/plans/2026-07-02-003-feat-remember-me-login-plan.md
@@ -1,0 +1,124 @@
+---
+title: "feat: Remember me for 30 days on login"
+date: 2026-07-02
+type: feat
+depth: standard
+origin: user request (follow-up on mobile audit branch)
+---
+
+# feat: Remember me for 30 days on login
+
+## Summary
+
+Login sessions currently die when the browser closes: the app uses Rails' encrypted cookie session store with no `expire_after`, so `session[:user_id]` lives in a browser-session cookie. Add a "Remember me" checkbox to the login form that, when checked, makes the session cookie persist for 30 days (sliding — activity extends the window). Implemented as a session flag plus a per-request `expire_after`, with no database migration and no separate token: the encrypted session cookie itself becomes persistent, which keeps Action Cable's session-cookie auth working unchanged.
+
+---
+
+## Problem Frame
+
+- `SessionsController#create` → `complete_authentication` (in `app/controllers/concerns/authenticates_user.rb`) does `reset_session` then `session[:user_id] = user.id`. No expiry is configured anywhere, so the `_proof_session`-style cookie is a browser-session cookie.
+- Rails only re-sends the session cookie when session data changes. The classic pitfall: setting `expire_after` only at login means any later session write (e.g. `session[:recent_slugs]` on document visits, `session[:display_name]`) re-issues the cookie *without* an expiry, silently downgrading it back to browser-session. The fix must therefore set `expire_after` on **every** request where the remembered flag is present, not just at login.
+- Action Cable (`app/channels/application_cable/connection.rb`) resolves the user straight from the encrypted session cookie — a persistent session cookie means realtime auth survives browser restarts with zero cable changes. A token-based design would have needed an HTTP-first re-auth hop.
+
+## Requirements
+
+- R1: The login form shows a "Remember me for 30 days" checkbox (login mode only, unchecked by default).
+- R2: Logging in with the box checked issues a session cookie that expires 30 days out; subsequent session-writing requests re-issue it with a fresh 30-day expiry (sliding window).
+- R3: Logging in without the box keeps today's browser-session behavior.
+- R4: Logout (`reset_session`) fully clears the remembered state; the next session cookie is a browser-session cookie again.
+- R5: The checkbox renders correctly on mobile (390px) and does not regress the iOS-zoom browser check.
+
+---
+
+## Key Technical Decisions
+
+1. **Session flag + per-request `expire_after`, not a DB remember token.** `complete_authentication` sets `session[:remember_me] = true` (after `reset_session`, so fixation rotation is preserved), and an `ApplicationController` after-action sets `request.session_options[:expire_after] = 30.days` whenever the flag is present. Running after the action means login (flag just set) gets a persistent cookie and logout (`reset_session` just cleared the flag) reverts to a browser-session cookie, with a single hook. No migration, no new cookie, no revocation surface beyond what logout already provides, and Action Cable keeps working. A DB token (Devise-style rememberable) adds server-side revocation but is disproportionate for this app's single-session cookie architecture.
+2. **Sliding 30-day window.** Each session-writing request while remembered re-issues the cookie with a fresh 30 days. This is the standard "remember me" contract; a hard cap would log out active users mid-session.
+3. **Login only.** Signup and Google OAuth keep browser-session behavior — the user asked for login, and OAuth has no form to carry the preference. Deferred below.
+4. **Checkbox is absent-when-unchecked.** Inertia's `Form` uses FormData semantics, so the server reads `params[:remember_me].present?` — no hidden-field dance.
+5. **Mobile zoom check learns to skip non-keyboard inputs.** The 390px sweep asserts all `input` elements ≥16px; checkboxes/radios never trigger iOS zoom (no keyboard), so the sweep filter excludes them rather than forcing a meaningless 16px font on a checkbox.
+
+## Scope Boundaries
+
+- **In scope:** login checkbox UI + styles, session persistence plumbing, logout clearing, integration tests, mobile-check filter fix.
+- **Out of scope:** server-side session revocation ("log out other devices"), remember-me on signup, remember-me for Google OAuth (would need the preference stashed pre-redirect), configurable duration.
+- **Deferred to follow-up work:** extending remember-me to signup and the OAuth callback if users ask for it.
+
+---
+
+## Implementation Units
+
+### U1. Session persistence plumbing
+
+**Goal:** A remembered login stays signed in for 30 sliding days; plain login and logout behave exactly as today.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** none
+
+**Files:**
+- `app/controllers/concerns/authenticates_user.rb`
+- `app/controllers/application_controller.rb`
+- `app/controllers/sessions_controller.rb`
+- `test/integration/authentication_flow_test.rb`
+
+**Approach:** `complete_authentication(user, remember: false)` sets `session[:remember_me] = true` when remembering. `ApplicationController` gains a `REMEMBER_ME_DURATION = 30.days` constant and an after-action that applies `request.session_options[:expire_after]` whenever `session[:remember_me]` is set — this is what keeps later session writes from downgrading the cookie, and because it runs after the action it naturally covers login (flag just set) and logout (flag just cleared by `reset_session`). `SessionsController#create` passes `remember: params[:remember_me].present?`. `destroy` needs no change.
+
+**Patterns to follow:** existing `complete_authentication` structure and its call sites (registrations and oauth callbacks pass no `remember:` and keep default behavior).
+
+**Test scenarios:**
+- Happy path: `post login_path` with `remember_me: "1"` → response session cookie carries an `expires` attribute ~30 days out; `session[:user_id]` set.
+- Sliding: after a remembered login, a session-writing request (`post identity_path`) re-issues the session cookie with an `expires` attribute.
+- Negative: login without `remember_me` → session cookie has no `expires` attribute.
+- Logout: `delete logout_path` after a remembered login → `session[:user_id]` nil; a subsequent session-writing request issues a cookie without `expires`.
+- Regression: existing login/logout/registration tests keep passing (flag defaults off everywhere else).
+
+**Verification:** New integration tests pass; full `bin/rails test` green.
+
+### U2. Login form checkbox
+
+**Goal:** Login page offers "Remember me for 30 days"; signup does not.
+
+**Requirements:** R1, R5
+
+**Dependencies:** U1
+
+**Files:**
+- `app/frontend/pages/auth/show.tsx`
+- `app/frontend/pages/auth/show.css`
+
+**Approach:** In login mode only, render a checkbox row between the password field and the submit button: `<input type="checkbox" name="remember_me" value="1" />` inside a horizontal label. New `.auth-remember` styles follow the existing `.auth-fields` vocabulary (ink-soft text, small-but-readable size; the checkbox styled by `@tailwindcss/forms` base with an accent that matches the focus ring).
+
+**Test scenarios:** Test expectation: UI covered by the browser check and manual walkthrough; the server behavior is covered by U1's integration tests.
+
+**Verification:** Checkbox renders on `/login` and not `/signup`; checked state posts `remember_me=1`; mobile rendering verified at 390px.
+
+### U3. Mobile check filter fix
+
+**Goal:** The zoom regression check doesn't false-positive on the new checkbox (or future radios).
+
+**Requirements:** R5
+
+**Dependencies:** U2
+
+**Files:**
+- `script/mobile_zoom_check.mjs`
+
+**Approach:** Extend the sweep's filter to skip input types that never summon the iOS keyboard (`checkbox`, `radio`) alongside the existing `hidden` exclusion.
+
+**Test scenarios:** Check passes with the checkbox present; a sub-16px *text* input still fails (unchanged assertion logic).
+
+**Verification:** `node script/mobile_zoom_check.mjs` passes against the running dev server with the checkbox rendered.
+
+---
+
+## Risks & Dependencies
+
+- **Session-cookie assertions in integration tests** depend on reading `Set-Cookie` response headers; Rack 3 may return an array. The test helper must handle both shapes.
+- **Silent downgrade regression risk** is the core risk this design addresses; the sliding test in U1 pins it.
+- **30-day encrypted cookie** slightly widens the replay window for a stolen cookie; acceptable and standard (cookie is encrypted, httponly, SameSite=Lax, Secure in production), and logout still invalidates by rotation... note: cookie-store logout does not server-side-invalidate old cookies — that's true today for browser-session cookies too and out of scope.
+
+## Deferred Implementation Notes
+
+- Exact `Set-Cookie` parsing helper shape is implementation-time.
+- Checkbox visual (native accent-color vs custom) decided against the rendered result on both themes.

--- a/script/mobile_zoom_check.mjs
+++ b/script/mobile_zoom_check.mjs
@@ -27,12 +27,14 @@ const auditPage = async (page, path, { expectFields }) => {
   await page.waitForFunction(() => (document.getElementById('app')?.childElementCount ?? 0) > 0)
   if (expectFields) await page.waitForSelector('input:not([type=hidden])')
 
+  // contenteditable focuses zoom on iOS too — the Milkdown editor surface
+  // on document pages must hold the same floor as native fields.
   const inputs = await page.evaluate(() => {
-    const fields = [...document.querySelectorAll('input, textarea, select')]
+    const fields = [...document.querySelectorAll('input, textarea, select, [contenteditable="true"]')]
     return fields
       .filter((field) => field.type !== 'hidden' && field.getClientRects().length > 0)
       .map((field) => ({
-        label: `${field.tagName.toLowerCase()}[name=${field.name || field.className || '?'}]`,
+        label: `${field.tagName.toLowerCase()}[name=${field.name || field.className.split(' ')[0] || '?'}]`,
         fontPx: parseFloat(getComputedStyle(field).fontSize),
       }))
   })
@@ -57,6 +59,41 @@ const auditPage = async (page, path, { expectFields }) => {
   }
 }
 
+// The page sweeps only see fields that render at load. The composer, tag
+// editor, identity, and sketch-caption inputs mount behind interactions, so
+// probe them with synthetic elements — this also proves the emulated context
+// really matches the coarse-pointer media query the 16px rules live in.
+const assertTouchRules = async (page) => {
+  const probe = await page.evaluate((min) => {
+    if (!window.matchMedia('(hover: none), (pointer: coarse)').matches) {
+      return ['emulated context does not match the coarse-pointer media query']
+    }
+    const failures = []
+    const host = document.createElement('div')
+    document.body.append(host)
+    const probes = [
+      ['comment composer', '<textarea class="comment-input"></textarea>'],
+      ['tag editor', '<div class="document-tag-editor"><input></div>'],
+      ['identity chip', '<input class="identity-input">'],
+      ['sketch caption', '<figcaption class="thinkroom-sketch-caption"><input class="thinkroom-sketch-title"></figcaption>'],
+    ]
+    for (const [name, html] of probes) {
+      host.innerHTML = html
+      const field = host.querySelector('input, textarea')
+      const fontPx = parseFloat(getComputedStyle(field).fontSize)
+      if (fontPx < min) failures.push(`${name} input is ${fontPx}px on touch — below ${min}px`)
+    }
+    host.remove()
+    return failures
+  }, MIN_FONT_PX)
+
+  if (probe.length > 0) {
+    for (const message of probe) fail(message)
+  } else {
+    ok('interaction-gated inputs hold the 16px floor under the coarse-pointer rules')
+  }
+}
+
 const browser = await chromium.launch()
 try {
   // No Safari userAgent spoof: Rails `allow_browser versions: :modern`
@@ -71,6 +108,7 @@ try {
   const page = await context.newPage()
 
   await auditPage(page, '/login', { expectFields: true })
+  await assertTouchRules(page)
   await auditPage(page, '/signup', { expectFields: true })
   await auditPage(page, '/', { expectFields: false })
   await auditPage(page, `/d/${SLUG}`, { expectFields: false })

--- a/script/mobile_zoom_check.mjs
+++ b/script/mobile_zoom_check.mjs
@@ -27,18 +27,17 @@ const auditPage = async (page, path, { expectFields }) => {
   await page.waitForFunction(() => (document.getElementById('app')?.childElementCount ?? 0) > 0)
   if (expectFields) await page.waitForSelector('input:not([type=hidden])')
 
-  const inputs = await page.evaluate((min) => {
+  const inputs = await page.evaluate(() => {
     const fields = [...document.querySelectorAll('input, textarea, select')]
     return fields
       .filter((field) => field.type !== 'hidden' && field.getClientRects().length > 0)
       .map((field) => ({
         label: `${field.tagName.toLowerCase()}[name=${field.name || field.className || '?'}]`,
         fontPx: parseFloat(getComputedStyle(field).fontSize),
-        zooms: parseFloat(getComputedStyle(field).fontSize) < min,
       }))
-  }, MIN_FONT_PX)
+  })
 
-  const zoomers = inputs.filter((input) => input.zooms)
+  const zoomers = inputs.filter((input) => input.fontPx < MIN_FONT_PX)
   if (zoomers.length > 0) {
     for (const input of zoomers) {
       fail(`${path}: ${input.label} is ${input.fontPx}px — below the ${MIN_FONT_PX}px iOS zoom threshold`)

--- a/script/mobile_zoom_check.mjs
+++ b/script/mobile_zoom_check.mjs
@@ -28,11 +28,13 @@ const auditPage = async (page, path, { expectFields }) => {
   if (expectFields) await page.waitForSelector('input:not([type=hidden])')
 
   // contenteditable focuses zoom on iOS too — the Milkdown editor surface
-  // on document pages must hold the same floor as native fields.
+  // on document pages must hold the same floor as native fields. Inputs that
+  // never summon the keyboard (checkboxes, radios, buttons) never zoom.
   const inputs = await page.evaluate(() => {
+    const NO_KEYBOARD = ['hidden', 'checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'file', 'color', 'image']
     const fields = [...document.querySelectorAll('input, textarea, select, [contenteditable="true"]')]
     return fields
-      .filter((field) => field.type !== 'hidden' && field.getClientRects().length > 0)
+      .filter((field) => !NO_KEYBOARD.includes(field.type) && field.getClientRects().length > 0)
       .map((field) => ({
         label: `${field.tagName.toLowerCase()}[name=${field.name || field.className.split(' ')[0] || '?'}]`,
         fontPx: parseFloat(getComputedStyle(field).fontSize),

--- a/script/mobile_zoom_check.mjs
+++ b/script/mobile_zoom_check.mjs
@@ -1,0 +1,80 @@
+// Mobile audit check: iOS Safari zooms the whole page when a focused
+// input/textarea computes to a font-size below 16px. The login form shipped
+// at 0.9rem (14.4px), so signing in on a phone zoomed in and never zoomed
+// back out. Every native text input must compute to >=16px on touch devices,
+// and no audited page may overflow an iPhone-class viewport horizontally.
+//
+// Runs an emulated touch context (390x844, coarse pointer) so the
+// `(hover: none), (pointer: coarse)` input rules apply. Usage:
+//
+//   BASE_URL=http://localhost:3000 SLUG=demo node script/mobile_zoom_check.mjs
+//
+import { chromium } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
+const SLUG = process.env.SLUG ?? 'demo'
+const MIN_FONT_PX = 16
+
+const ok = (msg) => console.log(`✓ ${msg}`)
+const fail = (msg) => {
+  console.error(`✗ ${msg}`)
+  process.exitCode = 1
+}
+
+const auditPage = async (page, path, { expectFields }) => {
+  await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle' })
+  // Wait for Inertia/React to mount; auth pages must render their form.
+  await page.waitForFunction(() => (document.getElementById('app')?.childElementCount ?? 0) > 0)
+  if (expectFields) await page.waitForSelector('input:not([type=hidden])')
+
+  const inputs = await page.evaluate((min) => {
+    const fields = [...document.querySelectorAll('input, textarea, select')]
+    return fields
+      .filter((field) => field.type !== 'hidden' && field.getClientRects().length > 0)
+      .map((field) => ({
+        label: `${field.tagName.toLowerCase()}[name=${field.name || field.className || '?'}]`,
+        fontPx: parseFloat(getComputedStyle(field).fontSize),
+        zooms: parseFloat(getComputedStyle(field).fontSize) < min,
+      }))
+  }, MIN_FONT_PX)
+
+  const zoomers = inputs.filter((input) => input.zooms)
+  if (zoomers.length > 0) {
+    for (const input of zoomers) {
+      fail(`${path}: ${input.label} is ${input.fontPx}px — below the ${MIN_FONT_PX}px iOS zoom threshold`)
+    }
+  } else {
+    ok(`${path}: ${inputs.length} visible field(s), all >=${MIN_FONT_PX}px`)
+  }
+
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }))
+  if (overflow.scrollWidth > overflow.innerWidth) {
+    fail(`${path}: horizontal overflow (${overflow.scrollWidth}px content in ${overflow.innerWidth}px viewport)`)
+  } else {
+    ok(`${path}: no horizontal overflow at ${overflow.innerWidth}px`)
+  }
+}
+
+const browser = await chromium.launch()
+try {
+  // No Safari userAgent spoof: Rails `allow_browser versions: :modern`
+  // rejects unrecognized/old UA strings, and the touch media queries key on
+  // hasTouch/isMobile emulation rather than the UA.
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+  })
+  const page = await context.newPage()
+
+  await auditPage(page, '/login', { expectFields: true })
+  await auditPage(page, '/signup', { expectFields: true })
+  await auditPage(page, '/', { expectFields: false })
+  await auditPage(page, `/d/${SLUG}`, { expectFields: false })
+} finally {
+  await browser.close()
+}

--- a/test/integration/authentication_flow_test.rb
+++ b/test/integration/authentication_flow_test.rb
@@ -105,6 +105,7 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :see_other
     assert_equal user.id, session[:user_id]
+    assert session_cookie_reissued?, "login must re-issue the session cookie"
     assert_nil session_cookie_expiry, "login without remember_me must not set a cookie expiry"
   end
 
@@ -116,7 +117,23 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
 
     assert_nil session[:user_id]
     post identity_path, params: { name: "Guest again" }
+    assert_response :see_other
+    assert session_cookie_reissued?, "identity update must re-issue the session cookie"
     assert_nil session_cookie_expiry, "session cookies after logout must revert to browser-session"
+  end
+
+  test "remembered session keeps its expiry on rescue_from-handled requests" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+    document = Document.create!(title: "View only", link_access: "view")
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase", remember_me: "1" }
+
+    # CommentingLockedError → rescue_from handler that writes inertia errors
+    # into the session; the reissued cookie must stay persistent.
+    post document_comments_path(document.slug), params: { body: "Hello" }
+
+    assert_response :redirect
+    assert_not_nil session_cookie_expiry,
+                   "a rescued request must not downgrade the remembered session cookie"
   end
 
   test "logout removes account ownership from the guest session" do
@@ -177,15 +194,20 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
     errors[key] || errors[key.to_s]
   end
 
-  # Expiry of the session cookie set by the latest response, or nil when the
-  # cookie is a browser-session cookie (or was not re-issued).
-  def session_cookie_expiry
+  # The session cookie set by the latest response, or nil if not re-issued.
+  def session_cookie_header
     key = Rails.application.config.session_options.fetch(:key)
     header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
-    cookie = header.find { |value| value.start_with?("#{key}=") }
-    return nil unless cookie
+    header.find { |value| value.start_with?("#{key}=") }
+  end
 
-    expires = cookie[/expires=([^;]+)/i, 1]
+  def session_cookie_reissued? = session_cookie_header.present?
+
+  # Expiry of the re-issued session cookie; nil for a browser-session cookie.
+  # Callers asserting nil should pair with session_cookie_reissued? so a
+  # missing cookie can't false-pass as "no expiry".
+  def session_cookie_expiry
+    expires = session_cookie_header&.[](/expires=([^;]+)/i, 1)
     expires && Time.zone.parse(expires)
   end
 end

--- a/test/integration/authentication_flow_test.rb
+++ b/test/integration/authentication_flow_test.rb
@@ -77,6 +77,48 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to document_page_path(document.slug)
   end
 
+  test "remembered login issues a session cookie that persists for 30 days" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase", remember_me: "1" }
+
+    assert_response :see_other
+    assert_equal user.id, session[:user_id]
+    expiry = session_cookie_expiry
+    assert_not_nil expiry, "remembered login must set an expiry on the session cookie"
+    assert_in_delta 30.days.from_now.to_i, expiry.to_i, 1.hour.to_i
+  end
+
+  test "remembered session slides the expiry window on later requests" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase", remember_me: "1" }
+
+    get root_path
+
+    assert_not_nil session_cookie_expiry, "later requests must keep re-issuing the persistent cookie"
+  end
+
+  test "plain login keeps a browser-session cookie" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase" }
+
+    assert_response :see_other
+    assert_equal user.id, session[:user_id]
+    assert_nil session_cookie_expiry, "login without remember_me must not set a cookie expiry"
+  end
+
+  test "logout clears the remembered session persistence" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+    post login_path, params: { email: user.email, password: "thoughtful-passphrase", remember_me: "1" }
+
+    delete logout_path
+
+    assert_nil session[:user_id]
+    post identity_path, params: { name: "Guest again" }
+    assert_nil session_cookie_expiry, "session cookies after logout must revert to browser-session"
+  end
+
   test "logout removes account ownership from the guest session" do
     user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
     document = Document.create!(title: "Private to account", user:, owner_name: user.name)
@@ -133,5 +175,17 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
   def inertia_error(key)
     errors = session[:inertia_errors] || {}
     errors[key] || errors[key.to_s]
+  end
+
+  # Expiry of the session cookie set by the latest response, or nil when the
+  # cookie is a browser-session cookie (or was not re-issued).
+  def session_cookie_expiry
+    key = Rails.application.config.session_options.fetch(:key)
+    header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
+    cookie = header.find { |value| value.start_with?("#{key}=") }
+    return nil unless cookie
+
+    expires = cookie[/expires=([^;]+)/i, 1]
+    expires && Time.zone.parse(expires)
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# fix(mobile): stop iOS input auto-zoom · feat(auth): remember me for 30 days

Two changes on this branch: the mobile audit fix (iOS zoomed in on login because inputs were under 16px) and a follow-up "Remember me for 30 days" option on the login form.

## 1. Mobile audit: 16px input floor

Logging in on an iPhone zoomed the page in (and left it zoomed) because iOS Safari auto-zooms any focused field whose font-size computes below 16px — the auth inputs shipped at 0.9rem (14.4px).

- **Auth pages** (`app/frontend/pages/auth/show.css`): inputs go from 0.9rem to 1rem unconditionally, and the page is sized with `100dvh` (with a `100vh` fallback) so the card centers correctly under iOS Safari's dynamic toolbar.
- **Touch-device 16px floor** (`app/frontend/entrypoints/application.css`): the home tag editor input, comment composer, identity chip input, and sketch caption title — all 11.8–14.4px today — get `font-size: 1rem` under the existing `(hover: none), (pointer: coarse)` media query, keeping desktop's compact chrome untouched. The mobile comment sheet composer moves from 0.9rem to 1rem, and the tag editor row gets a 44px touch height.
- **Regression check** (`script/mobile_zoom_check.mjs`, wired into the CI `browser_checks` loop): an emulated iPhone-class touch context (390×844, coarse pointer) sweeps `/login`, `/signup`, `/`, and `/d/demo` asserting every visible keyboard-summoning field (including contenteditable) computes to ≥16px and no page overflows horizontally. Interaction-gated inputs are probed with synthetic elements so the media-query rules themselves have coverage.

Audited but deliberately unchanged: the viewport meta tag (no `maximum-scale` hack — that would break user zoom), the Milkdown editor surface (already 16px on mobile), the mobile dock/sheets (already 44px targets with safe-area insets), and secondary label/hint text (small but not zoom triggers). Plan: `docs/plans/2026-07-02-002-fix-mobile-input-zoom-audit-plan.md`.

<a href="https://cursor.com/agents/bc-019f20b4-c377-7a38-b586-caf21267f863/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_auth_flow_iphone_390px.mp4"><img src="https://cursor.com/artifacts/c/art-04a5e0c0-cbe5-40a2-af43-27e47d712144" alt="mobile_auth_flow_iphone_390px.mp4" /></a>

Login → signup → account creation → home, all at 390px iPhone emulation with 16px inputs and no overflow.

![Login at 390px with 16px inputs](https://cursor.com/artifacts/c/art-581a055e-a97f-44c6-8843-e2bba80b8773)

## 2. Remember me for 30 days

Sessions were browser-session cookies (the app sets no `expire_after`), so closing the browser always signed users out.

- **Login form** gains a "Remember me for 30 days" checkbox (login only; signup and Google OAuth keep today's behavior).
- **Session plumbing:** `complete_authentication` sets `session[:remember_me]` when opted in, and an `ApplicationController` `around_action` re-applies `expire_after = 30.days` on every request. Re-applying per request matters: any later session write re-issues the cookie, and without the hook that reissue would silently downgrade the remembered session back to browser-session. It also makes the 30-day window sliding, and logout reverts naturally because `reset_session` drops the flag. `around_action` + `ensure` (not `after_action`) so `rescue_from`-handled requests — which still commit the session — keep the expiry too; that failure mode is pinned by a regression test that was verified failing under the `after_action` variant.
- **No DB migration, no separate token:** the encrypted session cookie itself becomes persistent, which keeps Action Cable's session-cookie auth working unchanged.
- The mobile zoom check now skips keyboard-less input types (checkbox, radio, …), which never trigger iOS zoom.

Plan: `docs/plans/2026-07-02-003-feat-remember-me-login-plan.md`.

<a href="https://cursor.com/agents/bc-019f20b4-c377-7a38-b586-caf21267f863/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fremember_me_login_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5ccd3b0b-c7bb-4b86-84c6-cca25a4c2c2c" alt="remember_me_login_demo.mp4" /></a>

Checking "Remember me for 30 days" and signing in issues a `_proof_session` cookie expiring `2026-08-01` (~30 days out) instead of "Session"; visible in the DevTools cookie panel at the end.

![Login at 390px with the remember-me checkbox](https://cursor.com/artifacts/c/art-9f91e0e5-8eac-4c61-bee3-de6460671184)

## Testing

- ✅ `bin/rails test` — 506 runs, 0 failures (new: remembered-login expiry ~30 days, sliding window, plain login stays browser-session, logout reverts, rescued-request regression)
- ✅ `node script/mobile_zoom_check.mjs` — passes post-fix; verified it fails with exit 1 against the pre-fix CSS
- ✅ `npm run check`
- ✅ `bin/rubocop`
- ✅ Playwright cookie verification: remembered login → `_proof_session` expires in 30.00 days and stays persistent across navigation; plain login → `expires=-1` (browser-session)
- ✅ Manual iPhone-emulated walkthroughs of both flows (videos above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f20b4-c377-7a38-b586-caf21267f863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f20b4-c377-7a38-b586-caf21267f863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

