### PR TITLE
feat: Ruby Native iOS app support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       # (selection stomping while a second tab is open).
       - name: Run browser regression checks
         run: |
-          for check in sync_check link_check mermaid_check rich_block_width_check suggestion_list_replace_check export_check html_document_check meta_refresh_check mobile_zoom_check; do
+          for check in sync_check link_check mermaid_check rich_block_width_check suggestion_list_replace_check export_check html_document_check meta_refresh_check mobile_zoom_check native_shell_check; do
             echo "=== script/${check}.mjs"
             node "script/${check}.mjs"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@
 # Local agent state
 /.claude/
 
+# Ruby Native
+.ruby_native/
+
 # Local feedback recordings and extracted artifacts
 /riffrec-*.zip
 /docs/brainstorms/riffrec-feedback/

--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ gem "ruby-vips", "~> 2.3"
 gem "bcrypt", "~> 3.1"
 gem "omniauth-google-oauth2", "~> 1.2"
 gem "omniauth-rails_csrf_protection", "~> 2.0"
+
+gem "ruby_native", "~> 0.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    chunky_png (1.4.0)
     commonmarker (2.8.2-aarch64-linux)
     commonmarker (2.8.2-aarch64-linux-musl)
     commonmarker (2.8.2-arm-linux)
@@ -310,6 +311,10 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    rqrcode (3.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.1.0)
     rubocop (1.87.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -342,6 +347,10 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    ruby_native (0.10.11)
+      jwt (>= 2.0, < 4)
+      rails (>= 7.1)
+      rqrcode (~> 3.0)
     securerandom (0.4.1)
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
@@ -454,6 +463,7 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rubocop-rails-omakase
   ruby-vips (~> 2.3)
+  ruby_native (~> 0.10)
   solid_cable
   sqlite3 (>= 2.1)
   thruster
@@ -488,6 +498,7 @@ CHECKSUMS
   brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
   commonmarker (2.8.2-aarch64-linux) sha256=715a5df28e5c1ec7b520e6441466062e9717b82193d2a5bd11a9c94f2f1e15f0
   commonmarker (2.8.2-aarch64-linux-musl) sha256=c7d587bd7978416978e84d0de7488906b8f29b3f67ce8424942f0ca9aa6899db
   commonmarker (2.8.2-arm-linux) sha256=da9da5c08d5133ad429ece13f2e93d3a30e1b23621ffac9040e185d7ea29bde6
@@ -585,6 +596,8 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rqrcode (3.2.0) sha256=64c1494ca6bb67d731330f38b50e3fd09eeab4f5dcd04b608e21218d1d0b9542
+  rqrcode_core (2.1.0) sha256=f303b85df89c1b8fc5ee8dc19808c9dc4330e6329b660d99d4a8cbb36ca13051
   rubocop (1.87.0) sha256=b9d9ddf55116a513f8ef2c7ae660662d8b49301f118d3f0df61865b33a5c188d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
@@ -592,6 +605,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
+  ruby_native (0.10.11) sha256=d1eb8989546b9aae3b70822f6249d28e09a8dc846eec65420e199003e8f2ae55
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
   solid_cable (4.0.0) sha256=8379680ef6bf36e195eb876a6306ea290f87d5fa10bc4a757bc2a918f83229b5

--- a/app/controllers/concerns/authenticates_user.rb
+++ b/app/controllers/concerns/authenticates_user.rb
@@ -13,10 +13,20 @@ module AuthenticatesUser
     # Ruby Native app users are always remembered (per rubynative.com/docs/
     # authentication) so the wrapped app never logs them out unexpectedly.
     # Covers password, signup, and OAuth sign-ins in one place.
-    session[:remember_me] = true if remember || native_app?
+    session[:remember_me] = true if remember || native_app? || native_oauth_flow?
     replace_owner_token!
 
     destination || root_path
+  end
+
+  # Native OAuth runs in a system-browser sheet whose UA carries no
+  # "Ruby Native" marker, so native_app? is false on the callback request.
+  # The gem's OAuthMiddleware tracks the native flow with a signed cookie
+  # instead — its presence identifies a native-initiated sign-in. Presence
+  # alone suffices: like the UA check, it only lets a client opt itself
+  # into a longer session.
+  def native_oauth_flow?
+    cookies[RubyNative::OAuthMiddleware::COOKIE_NAME].present?
   end
 
   def remember_return_to
@@ -24,6 +34,10 @@ module AuthenticatesUser
   end
 
   def render_auth_page(mode)
+    # Marks the page as a form for the Ruby Native shell (nativeForm shared
+    # prop), pairing with the NativeForm DOM signal the page renders — native
+    # back navigation skips form pages after a successful sign-in.
+    @native_form = true
     render inertia: "auth/show", props: {
       mode:,
       google_enabled: Rails.application.config.x.google_oauth_enabled,

--- a/app/controllers/concerns/authenticates_user.rb
+++ b/app/controllers/concerns/authenticates_user.rb
@@ -10,7 +10,10 @@ module AuthenticatesUser
     user.claim_documents!(anonymous_token)
     reset_session
     session[:user_id] = user.id
-    session[:remember_me] = true if remember
+    # Ruby Native app users are always remembered (per rubynative.com/docs/
+    # authentication) so the wrapped app never logs them out unexpectedly.
+    # Covers password, signup, and OAuth sign-ins in one place.
+    session[:remember_me] = true if remember || native_app?
     replace_owner_token!
 
     destination || root_path

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class InertiaController < ApplicationController
+  # Shares nativeApp/nativeForm props on every Inertia page so the frontend
+  # can adapt when running inside the Ruby Native iOS/Android shell.
+  include RubyNative::InertiaSupport
+
   # ViteRuby.digest chdirs into the project root — a process-global move.
   # Concurrent Inertia requests (two clients reloading off one broadcast,
   # or one client's simultaneous partial reloads) raced that chdir and 500'd

--- a/app/frontend/components/margin_inline_suggestions.tsx
+++ b/app/frontend/components/margin_inline_suggestions.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { nativeHaptic } from '@ruby-native/react'
 import { editorViewCtx } from '@milkdown/kit/core'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
@@ -186,6 +187,7 @@ export function MarginInlineSuggestions({ inline, handle, spans, focusMode }: Pr
                   event.stopPropagation()
                   resolve(s, true)
                 }}
+                {...nativeHaptic('success')}
               >
                 Accept
               </button>
@@ -195,6 +197,7 @@ export function MarginInlineSuggestions({ inline, handle, spans, focusMode }: Pr
                   event.stopPropagation()
                   resolve(s, false)
                 }}
+                {...nativeHaptic('warning')}
               >
                 Reject
               </button>
@@ -243,10 +246,10 @@ export function InlineSuggestionSheetList({ inline, handle }: SheetProps) {
           {s.deletedText && <del className="margin-old">{truncate(s.deletedText, 160)}</del>}
           {s.insertedText && <p className="margin-new">{truncate(s.insertedText, 400)}</p>}
           <div className="suggestion-actions">
-            <button className="btn-accept" onClick={() => resolve(s, true)}>
+            <button className="btn-accept" onClick={() => resolve(s, true)} {...nativeHaptic('success')}>
               Accept
             </button>
-            <button className="btn-reject" onClick={() => resolve(s, false)}>
+            <button className="btn-reject" onClick={() => resolve(s, false)} {...nativeHaptic('warning')}>
               Reject
             </button>
           </div>

--- a/app/frontend/components/margin_suggestions.tsx
+++ b/app/frontend/components/margin_suggestions.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { nativeHaptic } from '@ruby-native/react'
 import { editorViewCtx, parserCtx, schemaCtx } from '@milkdown/kit/core'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
@@ -261,6 +262,7 @@ export function MarginSuggestions({
                   event.stopPropagation()
                   resolve(suggestion, onAccept)
                 }}
+                {...nativeHaptic('success')}
               >
                 Accept
               </button>
@@ -271,6 +273,7 @@ export function MarginSuggestions({
                   event.stopPropagation()
                   resolve(suggestion, onReject)
                 }}
+                {...nativeHaptic('warning')}
               >
                 Reject
               </button>

--- a/app/frontend/components/mode_control.tsx
+++ b/app/frontend/components/mode_control.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { nativeHaptic } from '@ruby-native/react'
 import { useDismissable } from '../lib/use_dismissable'
 import { useMediaQuery } from '../lib/use_media_query'
 
@@ -86,6 +87,7 @@ export function ModeControl({
             onChange(value)
             setOpen(false)
           }}
+          {...nativeHaptic('selection')}
         >
           <span className="mode-control-option-check" aria-hidden="true">
             {mode === value ? '✓' : ''}

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -961,10 +961,12 @@ a:focus-visible {
   opacity: 1;
 }
 
-/* Native back affordance for the Ruby Native shell. The gem stylesheet
- * keeps .native-back-button hidden until the shell adds body.can-go-back,
- * so this never renders in regular browsers. */
+/* Native back affordance for the Ruby Native shell. Hidden by default here
+ * AND by the gem stylesheet; only the gem's body.can-go-back rule (higher
+ * specificity) reveals it, so web users never see it even if the gem
+ * stylesheet fails to load. */
 .doc-back {
+  display: none;
   border: none;
   background: none;
   padding: 0 0.25rem 0 0;
@@ -3515,6 +3517,10 @@ a:focus-visible {
 @media (max-width: 48rem) {
   .doc-header {
     padding: 0.45rem 0.75rem;
+    /* The shorthand resets the base rule's safe-area padding-top; re-apply
+     * it here or the header sits under the notch on phones — the exact
+     * viewport the native shell uses. */
+    padding-top: calc(0.45rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
     gap: 0.5rem;
   }
 
@@ -3713,7 +3719,7 @@ a:focus-visible {
   }
 
   .landing-corner {
-    top: 0.75rem;
+    top: calc(0.75rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
     right: 0.75rem;
   }
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -918,6 +918,11 @@ a:focus-visible {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.5rem 1rem;
+  /* Clears the status bar / Dynamic Island in the Ruby Native shell and
+   * installed PWAs; resolves to the base 0.5rem in regular browsers. The
+   * shell pushes real inset heights into --ruby-native-* on Android, where
+   * env() stays 0. */
+  padding-top: calc(0.5rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--line);
@@ -954,6 +959,24 @@ a:focus-visible {
 
 .doc-home:hover {
   opacity: 1;
+}
+
+/* Native back affordance for the Ruby Native shell. The gem stylesheet
+ * keeps .native-back-button hidden until the shell adds body.can-go-back,
+ * so this never renders in regular browsers. */
+.doc-back {
+  border: none;
+  background: none;
+  padding: 0 0.25rem 0 0;
+  color: var(--ink);
+  opacity: 0.85;
+  cursor: pointer;
+  line-height: 0;
+}
+
+.doc-back svg {
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .doc-title {
@@ -3218,7 +3241,8 @@ a:focus-visible {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 0.25rem;
-  padding: 0.35rem 0.6rem calc(0.35rem + env(safe-area-inset-bottom));
+  padding: 0.35rem 0.6rem
+    calc(0.35rem + var(--ruby-native-safe-area-inset-bottom, env(safe-area-inset-bottom)));
   background: color-mix(in srgb, var(--surface) 90%, transparent);
   backdrop-filter: blur(10px);
   border-top: 1px solid var(--line);
@@ -3286,7 +3310,7 @@ a:focus-visible {
   background: var(--surface-raised);
   border-radius: 16px 16px 0 0;
   box-shadow: 0 -8px 32px rgb(0 0 0 / 0.16);
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: var(--ruby-native-safe-area-inset-bottom, env(safe-area-inset-bottom));
   animation: sheet-up 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
@@ -3426,7 +3450,8 @@ a:focus-visible {
     width: auto;
     min-width: 0;
     max-width: none;
-    padding: 2rem 1.25rem calc(7rem + env(safe-area-inset-bottom));
+    padding: 2rem 1.25rem
+      calc(7rem + var(--ruby-native-safe-area-inset-bottom, env(safe-area-inset-bottom)));
   }
 
   .document-width-handle {
@@ -3525,7 +3550,7 @@ a:focus-visible {
     z-index: 80;
     border-radius: 16px 16px 0 0;
     border-bottom: none;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: var(--ruby-native-safe-area-inset-bottom, env(safe-area-inset-bottom));
     animation: sheet-up 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 
@@ -3670,7 +3695,8 @@ a:focus-visible {
 
 .landing-corner {
   position: absolute;
-  top: 1rem;
+  /* Extra offset only inside the Ruby Native shell / installed PWAs. */
+  top: calc(1rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
   right: 1rem;
   display: flex;
   align-items: center;

--- a/app/frontend/pages/auth/show.tsx
+++ b/app/frontend/pages/auth/show.tsx
@@ -1,4 +1,5 @@
 import { Form, Head, Link } from '@inertiajs/react'
+import { NativeForm, NativeNavbar, nativeHaptic } from '@ruby-native/react'
 import './show.css'
 
 interface Props {
@@ -6,6 +7,7 @@ interface Props {
   google_enabled: boolean
   csrf_token: string
   return_to: string | null
+  nativeApp: boolean
 }
 
 const errorText = (error: unknown): string | null => {
@@ -13,7 +15,7 @@ const errorText = (error: unknown): string | null => {
   return typeof error === 'string' ? error : null
 }
 
-export default function AuthShow({ mode, google_enabled, csrf_token, return_to }: Props) {
+export default function AuthShow({ mode, google_enabled, csrf_token, return_to, nativeApp }: Props) {
   const registering = mode === 'register'
   const title = registering ? 'Create your account' : 'Welcome back'
   const switchPath = registering ? '/login' : '/signup'
@@ -24,6 +26,10 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to }
   return (
     <>
       <Head title={`${title} · Thinkroom`} />
+      {/* Ruby Native chrome: navbar title plus a form marker so native back
+          navigation skips this page after a successful sign-in. */}
+      <NativeNavbar title={registering ? 'Create account' : 'Sign in'} />
+      <NativeForm />
       <main className="auth-page">
         <section className="auth-card" aria-labelledby="auth-heading">
           <Link href="/" className="auth-wordmark" aria-label="Thinkroom home">
@@ -99,7 +105,9 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to }
                     />
                   </label>
                 )}
-                {!registering && (
+                {/* Native sign-ins are always remembered server-side, so the
+                    checkbox would be a no-op inside the app. */}
+                {!registering && !nativeApp && (
                   <label className="auth-remember">
                     <input name="remember_me" type="checkbox" value="1" />
                     <span>Remember me for 30 days</span>
@@ -110,7 +118,12 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to }
                     {errorText(errors.email) || errorText(errors.form)}
                   </p>
                 )}
-                <button className="btn btn-primary auth-submit" type="submit" disabled={processing}>
+                <button
+                  className="btn btn-primary auth-submit"
+                  type="submit"
+                  disabled={processing}
+                  {...nativeHaptic('impact')}
+                >
                   {processing ? 'Working…' : registering ? 'Create account' : 'Sign in'}
                 </button>
               </div>

--- a/app/frontend/pages/auth/show.tsx
+++ b/app/frontend/pages/auth/show.tsx
@@ -48,7 +48,7 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
             <>
               <form method="post" action="/auth/google_oauth2">
                 <input type="hidden" name="authenticity_token" value={csrf_token} />
-                <button className="auth-google" type="submit">
+                <button className="auth-google" type="submit" {...nativeHaptic('impact')}>
                   <svg viewBox="0 0 24 24" aria-hidden="true">
                     <path fill="#4285f4" d="M21.6 12.2c0-.7-.1-1.4-.2-2H12v3.9h5.4a4.6 4.6 0 0 1-2 3v2.5h3.3c1.9-1.8 2.9-4.4 2.9-7.4Z" />
                     <path fill="#34a853" d="M12 22c2.7 0 5-.9 6.7-2.4l-3.3-2.5c-.9.6-2.1 1-3.4 1-2.6 0-4.8-1.8-5.6-4.1H3v2.6A10 10 0 0 0 12 22Z" />

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
+import { NativeNavbar, NativeButton, nativeHaptic } from '@ruby-native/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
 import { userIdentity } from '../../editor/identity'
@@ -292,6 +293,12 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
   return (
     <>
       <Head title="Thinkroom" />
+      {/* Ruby Native chrome: hidden signal elements the iOS/Android shell
+          reads. The plus button clicks the web "New document" button so the
+          native action reuses the exact same submission path. */}
+      <NativeNavbar title="Thinkroom">
+        <NativeButton icon="plus" click="#new-document-button" />
+      </NativeNavbar>
       <div className="landing">
         <div className="landing-corner">
           <AccountControl viewer={viewer} />
@@ -310,10 +317,12 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
             <p className="landing-byline">From the creator of Compound Engineering.</p>
             <div className="landing-actions">
               <button
+                id="new-document-button"
                 className="btn btn-primary"
                 type="button"
                 disabled={processing}
                 onClick={() => post('/documents')}
+                {...nativeHaptic('impact')}
               >
                 {processing ? 'Creating…' : 'New document'}
               </button>

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { Head, Link, router, usePoll } from '@inertiajs/react'
+import { nativeHaptic } from '@ruby-native/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import {
@@ -1233,6 +1234,24 @@ export default function DocumentShow({
       >
         <header className="doc-header">
           <div className="doc-header-left">
+            {/* Only visible inside the Ruby Native shell (body.can-go-back
+                toggles it); asks the shell to pop the native history. */}
+            <button
+              type="button"
+              className="native-back-button doc-back"
+              aria-label="Back"
+              onClick={() => window.RubyNative?.postMessage({ action: 'back' })}
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M15.75 19.5L8.25 12l7.5-7.5"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
             <Link href="/" className="doc-home" aria-label="Home">
               T.
             </Link>
@@ -1287,6 +1306,7 @@ export default function DocumentShow({
                 className="accept-all-button"
                 disabled={acceptingAll}
                 onClick={() => void acceptAllSuggestions()}
+                {...nativeHaptic('success')}
               >
                 {acceptingAll ? 'Accepting…' : `Accept all ${pendingSuggestionCount}`}
               </button>

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -3,4 +3,9 @@ export type FlashData = {
   alert?: string
 }
 
-export type SharedProps = {}
+export type SharedProps = {
+  /** True when the page is rendered inside the Ruby Native iOS/Android shell. */
+  nativeApp: boolean
+  /** True when the server marked this page as a form (native back skips it). */
+  nativeForm: boolean
+}

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -3,6 +3,8 @@
 // Only the surface Thinkroom uses is typed; extend as more features land.
 // https://rubynative.com/docs/inertia
 
+type NativeHapticFeedback = 'success' | 'warning' | 'error' | 'impact' | 'selection'
+
 declare module '@ruby-native/react' {
   import type { ReactElement, ReactNode } from 'react'
 
@@ -15,7 +17,7 @@ declare module '@ruby-native/react' {
 
   /**
    * Native navbar button. `href` navigates; `click` clicks a DOM element by
-   * CSS selector. With children (NativeMenuItem) it becomes a dropdown menu.
+   * CSS selector. With children (menu items) it becomes a dropdown menu.
    */
   export function NativeButton(props: {
     position?: 'leading' | 'trailing'
@@ -28,36 +30,15 @@ declare module '@ruby-native/react' {
     children?: ReactNode
   }): ReactElement
 
-  export function NativeMenuItem(props: {
-    title: string
-    href?: string
-    click?: string
-    icon?: string
-    icons?: { ios?: string; android?: string }
-    selected?: boolean
-  }): ReactElement
-
-  /** Opens the native share sheet (defaults to the current page URL). */
-  export function NativeShareButton(props: {
-    position?: 'leading' | 'trailing'
-    title?: string
-    icon?: string
-    icons?: { ios?: string; android?: string }
-    url?: string
-  }): ReactElement
-
   /** Marks the page as a form so native back navigation skips it. */
   export function NativeForm(): ReactElement
-
-  /** Signal element: shows the native tab bar (unused while tabs are off). */
-  export function NativeTabs(props: { enabled?: boolean }): ReactElement
 
   /**
    * Returns `data-native-haptic` attributes to spread onto a clickable
    * element. The shell vibrates when the element is tapped; inert on web.
    */
   export function nativeHaptic(
-    feedback?: 'success' | 'warning' | 'error' | 'impact' | 'selection',
+    feedback?: NativeHapticFeedback,
     data?: Record<string, string>,
   ): Record<string, string>
 }
@@ -67,7 +48,7 @@ declare module '@ruby-native/react' {
  * guard access (`window.RubyNative?.`).
  */
 interface RubyNativeBridge {
-  haptic(feedback?: 'success' | 'warning' | 'error' | 'impact' | 'selection'): void
+  haptic(feedback?: NativeHapticFeedback): void
   /** Tab-aware navigation: switches tabs when the URL belongs to another tab. */
   visit(url: string): void
   postMessage(message: { action: string } & Record<string, unknown>): void

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -1,0 +1,78 @@
+// Local typings for @ruby-native/react (the package ships untyped JS) and
+// for the RubyNative global the native shell injects into the web view.
+// Only the surface Thinkroom uses is typed; extend as more features land.
+// https://rubynative.com/docs/inertia
+
+declare module '@ruby-native/react' {
+  import type { ReactElement, ReactNode } from 'react'
+
+  /** Signal element: shows the native navbar with `title` on this page. */
+  export function NativeNavbar(props: {
+    title?: string
+    pullToRefresh?: boolean
+    children?: ReactNode
+  }): ReactElement
+
+  /**
+   * Native navbar button. `href` navigates; `click` clicks a DOM element by
+   * CSS selector. With children (NativeMenuItem) it becomes a dropdown menu.
+   */
+  export function NativeButton(props: {
+    position?: 'leading' | 'trailing'
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    title?: string
+    href?: string
+    click?: string
+    selected?: boolean
+    children?: ReactNode
+  }): ReactElement
+
+  export function NativeMenuItem(props: {
+    title: string
+    href?: string
+    click?: string
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    selected?: boolean
+  }): ReactElement
+
+  /** Opens the native share sheet (defaults to the current page URL). */
+  export function NativeShareButton(props: {
+    position?: 'leading' | 'trailing'
+    title?: string
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    url?: string
+  }): ReactElement
+
+  /** Marks the page as a form so native back navigation skips it. */
+  export function NativeForm(): ReactElement
+
+  /** Signal element: shows the native tab bar (unused while tabs are off). */
+  export function NativeTabs(props: { enabled?: boolean }): ReactElement
+
+  /**
+   * Returns `data-native-haptic` attributes to spread onto a clickable
+   * element. The shell vibrates when the element is tapped; inert on web.
+   */
+  export function nativeHaptic(
+    feedback?: 'success' | 'warning' | 'error' | 'impact' | 'selection',
+    data?: Record<string, string>,
+  ): Record<string, string>
+}
+
+/**
+ * Injected by the Ruby Native shell; absent in regular browsers. Always
+ * guard access (`window.RubyNative?.`).
+ */
+interface RubyNativeBridge {
+  haptic(feedback?: 'success' | 'warning' | 'error' | 'impact' | 'selection'): void
+  /** Tab-aware navigation: switches tabs when the URL belongs to another tab. */
+  visit(url: string): void
+  postMessage(message: { action: string } & Record<string, unknown>): void
+}
+
+interface Window {
+  RubyNative?: RubyNativeBridge
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,10 @@
 <html data-theme="<%= cookies[:proof_theme].to_s.presence_in(%w[proof whitey]) || "proof" %>">
   <head>
     <title data-inertia><%= @open_graph&.dig(:page_title) || content_for(:title) || "Thinkroom" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%# viewport-fit=cover is required by Ruby Native so env(safe-area-inset-*)
+        returns real values when the native web view extends behind the
+        status bar. Harmless on the open web. %>
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
     <% if @open_graph.present? %>
       <%= tag.meta name: "description", content: @open_graph[:description] %>
       <%= tag.link rel: "canonical", href: @open_graph[:url] %>
@@ -40,6 +43,9 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app %>
+    <%# Ruby Native utility classes: native-hidden, native-inset-*, and the
+        native-back-button visibility rules. Inert outside the native app. %>
+    <%= stylesheet_link_tag :ruby_native %>
     <%= vite_stylesheet_tag "application" %>
     <%= vite_react_refresh_tag %>
     <%= vite_client_tag %>

--- a/config/ruby_native.yml
+++ b/config/ruby_native.yml
@@ -1,0 +1,40 @@
+# Ruby Native reads this file on launch to configure the native app shell.
+# Served as JSON from GET /native/config. Edit and relaunch the native app
+# to see changes (reloaded per request in development).
+# https://rubynative.com/docs/setup
+
+app:
+  # Normal mode: no native screen transitions. Advanced Mode needs a
+  # Stimulus bridge dependency the app doesn't carry.
+  # https://rubynative.com/docs/advanced-mode
+  mode: normal
+  # No entry_path and no tabs: the app is document-centric (home list +
+  # editor), so it launches as a single stack at "/".
+
+# https://rubynative.com/docs/appearance
+appearance:
+  # Matches --accent in app/frontend/entrypoints/application.css.
+  tint_color: "#b65c3d"
+
+  # Matches --surface (warm paper). Shown during launch and as the
+  # safe-area fill, so it must match the CSS body background to avoid a
+  # white flash before content paints.
+  background_color: "#faf8f4"
+
+  # Both Thinkroom themes (proof, whitey) are light; the web app has no OS
+  # dark mode. Forcing light keeps the status bar and window background
+  # consistent with the page.
+  theme: light
+
+  # Hold the launch screen with a spinner until the web content paints.
+  splash:
+    enabled: true
+    spinner_color: "#b65c3d"
+    status_bar: dark
+
+# Native OAuth: each listed path opens in a system browser sheet
+# (ASWebAuthenticationSession) instead of the in-app web view. List only
+# authorize paths, never callbacks. https://rubynative.com/docs/oauth
+auth:
+  oauth_paths:
+    - /auth/google_oauth2

--- a/docs/plans/2026-07-02-004-feat-ruby-native-ios-app-plan.md
+++ b/docs/plans/2026-07-02-004-feat-ruby-native-ios-app-plan.md
@@ -1,0 +1,173 @@
+---
+title: "feat: Ruby Native iOS app support"
+type: feat
+date: 2026-07-02
+---
+
+# feat: Ruby Native iOS app support
+
+## Summary
+
+Integrate [Ruby Native](https://rubynative.com/docs) (gem `ruby_native` ~> 0.10, npm `@ruby-native/react`) so Thinkroom can ship as a native iOS app that wraps the existing Rails + Inertia React frontend. The integration adds native detection, safe-area layout, a native navigation bar with buttons on the home and auth pages, haptic feedback on key interactions, always-on session persistence for native users, and OAuth hand-off through the system browser.
+
+## Problem Frame
+
+Thinkroom is web-only today. Ruby Native turns an existing Rails app into an App Store iOS app (Android in beta) by pointing a native shell at the site and reading signal elements from the DOM. The repo has strong mobile web UI (mobile dock, bottom sheets, safe-area padding) but zero native-bridge infrastructure: no native detection, no signal elements, no haptics, and the session/auth flow assumes a browser.
+
+---
+
+## Requirements
+
+**Native shell wiring**
+
+- R1. The `ruby_native` gem is installed with a `config/ruby_native.yml` tailored to Thinkroom (app name, brand tint/background colors, forced light theme, no tab bar, Google OAuth path), and `GET /native/config` serves it.
+- R2. The layout carries `viewport-fit=cover` in the viewport meta tag and links the gem stylesheet so `native-hidden` and `native-inset-*` utility classes work.
+- R3. Every Inertia page receives `nativeApp` (and `nativeForm`) shared props via `RubyNative::InertiaSupport`, and requests from non-native browsers see `nativeApp: false` with no behavior change.
+
+**Native UI**
+
+- R4. The home page (`documents/index`) renders a native navigation bar titled "Thinkroom" with a trailing plus button that triggers the existing "New document" action.
+- R5. The auth page renders a native navigation bar and marks itself as a form (`NativeForm`) so native back navigation skips it; the "Remember me" checkbox is hidden in the native app.
+- R6. The document page keeps its custom web header (mode control, presence, share) and gains a native back affordance plus correct safe-area insets in the native shell.
+- R7. Key interactions carry haptic feedback data attributes: new document (impact), accept/reject suggestion actions (success/warning), Accept all (success), mode selection (selection), auth submit (impact).
+
+**Auth & sessions**
+
+- R8. Native app sign-ins (password, signup, and Google OAuth) are always remembered (30-day session), without changing web behavior where remember-me stays opt-in.
+- R9. Google OAuth works from the native shell via the gem's system-browser flow (`auth.oauth_paths` config); the web OAuth flow is untouched.
+
+**Quality**
+
+- R10. Integration tests cover native UA detection, shared props, layout tags, the config endpoint, and forced remember-me for native sign-ins. `npm run check`, `bin/rubocop`, and `bin/rails test` pass.
+
+---
+
+## Key Technical Decisions
+
+- **Use the official `ruby_native` gem + `@ruby-native/react` npm package, not hand-rolled signals:** the gem auto-includes `RubyNative::NativeDetection` into `ActionController::Base`, mounts its engine at `/native`, serves the utility stylesheet, and its data-attribute contract (`data-native-*`) is what the native shell actually reads. Hand-rolling would chase a moving contract.
+- **Share native props from `InertiaController`:** include `RubyNative::InertiaSupport` in `app/controllers/inertia_controller.rb` (the Inertia base), matching the existing `inertia_share viewer:` pattern. The concern shares `nativeApp`/`nativeForm` on every Inertia page.
+- **No tab bar:** Thinkroom is document-centric (home list + document editor); there is no second top-level destination. Omitting `tabs:` in `config/ruby_native.yml` hides the tab bar and launches at `/` (the gem's fallback entry path). A Profile/Settings tab is deferred until such a page exists.
+- **Native navbar on home and auth only; document page keeps its web header:** the doc header (`doc-header`) carries mode control, connection status, presence, Accept all, and the share popover — chrome with no native-navbar equivalent. Replicating it would fork the editor UX. Home and auth have simple headers where the liquid-glass native bar plus a plus-button shines. The doc page instead gets the gem's custom back-button pattern (`native-back-button` class + `goBack()`), which the gem stylesheet shows only when history exists inside the native shell.
+- **Haptics via data attributes, not JS calls:** `nativeHaptic(type)` from `@ruby-native/react` returns `{ "data-native-haptic": type }` spread onto buttons. Declarative, SSR-safe, zero-cost on web. A `window.RubyNative` global type is declared for future programmatic use but no runtime JS calls are added.
+- **Force remember-me inside `complete_authentication`:** `app/controllers/concerns/authenticates_user.rb` is the single funnel for password, signup, and OAuth sign-ins. `remember: remember || native_app?` there satisfies the Ruby Native auth guidance ("always remember native users") for all three flows with one change — no hidden form fields.
+- **Force `theme: light` in the native shell:** Thinkroom's two themes (`proof`, `whitey`) are both light; the web app has no OS dark mode. Forcing light prevents a dark status bar/window background mismatch. `background_color` matches `--surface` (`#faf8f4`), `tint_color` matches `--accent` (`#b65c3d`).
+- **TypeScript declaration file for `@ruby-native/react`:** the package ships plain JS with no types; strict `tsc` would fail on import. A local `.d.ts` module declaration in `app/frontend/types/` types the components used.
+
+---
+
+## Scope Boundaries
+
+Out of scope for this PR: no product behavior changes on the web (native chrome only appears under a Ruby Native user agent).
+
+### Deferred to Follow-Up Work
+
+- Push notifications (`native_push_tag`, `action_push_native`, `/native/push/devices`) — needs APNs setup.
+- App icon badges, in-app review prompts, in-app purchases, permissions, FAB.
+- App Store submission config (`ios.bundle_id`, `team_id`, linked domains / AASA) — requires Apple Developer Program enrollment values.
+- Android (private beta upstream).
+- Advanced Mode (native push/pop transitions) — requires a Stimulus bridge dependency; the app has no Stimulus.
+- App Store screenshot automation (`ruby_native_screenshot_session?` determinism).
+
+---
+
+## Implementation Units
+
+### U1. Gem install and native shell config
+
+- **Goal:** Rails side of the integration — gem, config file, ignore rules.
+- **Requirements:** R1, R9
+- **Dependencies:** none
+- **Files:** `Gemfile`, `Gemfile.lock`, `config/ruby_native.yml` (new), `.gitignore`
+- **Approach:** `bundle add ruby_native`, then create `config/ruby_native.yml` by hand (the generator's template carries placeholder tabs we don't want): `app.mode: normal`, no `entry_path` (falls back to `/`), `appearance` with `tint_color: "#b65c3d"`, `background_color: "#faf8f4"`, `theme: light`, splash enabled with dark status bar, no `tabs:` key, and `auth.oauth_paths: ["/auth/google_oauth2"]`. Add `.ruby_native/` to `.gitignore`. Dev `config.hosts` already allows `.trycloudflare.com`, so skip the generator's host edit.
+- **Patterns to follow:** template at the gem's `lib/generators/ruby_native/templates/ruby_native.yml`; option semantics per rubynative.com/docs/setup and /docs/appearance.
+- **Test scenarios:**
+  - `GET /native/config` returns JSON containing the app appearance (tint color) and no `tabs` key.
+  - `GET /` with a normal browser UA renders unchanged (no native signal elements).
+- **Verification:** engine routes respond in dev; `bin/rails test` still green.
+
+### U2. Layout and controller wiring
+
+- **Goal:** Head tags plus shared Inertia props for native detection.
+- **Requirements:** R2, R3
+- **Dependencies:** U1
+- **Files:** `app/views/layouts/application.html.erb`, `app/controllers/inertia_controller.rb`, `test/integration/ruby_native_test.rb` (new)
+- **Approach:** add `viewport-fit=cover` to the existing viewport meta tag; add `stylesheet_link_tag :ruby_native` next to the existing stylesheet tags. Include `RubyNative::InertiaSupport` at the top of `InertiaController` so `nativeApp`/`nativeForm` join the shared props alongside `viewer`.
+- **Patterns to follow:** existing `inertia_share` block in `app/controllers/inertia_controller.rb`; Inertia testing helpers from `inertia_rails/minitest` (see `test/test_helper.rb`).
+- **Test scenarios:**
+  - `GET /` with UA `Thinkroom Ruby Native iOS RubyNative/1.0` → Inertia props include `nativeApp: true`.
+  - `GET /` with a desktop Chrome UA → `nativeApp: false`.
+  - Response body includes `viewport-fit=cover` and a `ruby_native` stylesheet link.
+- **Verification:** integration tests pass; SSR pages (`/`, `/d/demo`) still render.
+
+### U3. npm package and TypeScript types
+
+- **Goal:** Frontend dependency plus type safety under strict `tsc`.
+- **Requirements:** R4, R5, R7
+- **Dependencies:** none
+- **Files:** `package.json`, `package-lock.json`, `app/frontend/types/ruby_native.d.ts` (new), `app/frontend/types/index.ts`, `app/frontend/types/globals.d.ts`
+- **Approach:** `npm install @ruby-native/react`. Write a module declaration typing `NativeNavbar`, `NativeButton`, `NativeForm`, and `nativeHaptic` (the surface this plan uses; extend later as needed). Add `nativeApp: boolean` to the shared props type so `usePage().props` picks it up, and declare an optional `window.RubyNative` global (`haptic`, `visit`, `postMessage`).
+- **Patterns to follow:** existing declarations in `app/frontend/types/globals.d.ts`; shared props shape in `app/frontend/types/index.ts`.
+- **Test scenarios:** Test expectation: none — type-only unit; covered by `npm run check`.
+- **Verification:** `npm run check` passes with the new imports in use.
+
+### U4. Native navbar and buttons (home + auth)
+
+- **Goal:** Native navigation bars with working native buttons.
+- **Requirements:** R4, R5
+- **Dependencies:** U2, U3
+- **Files:** `app/frontend/pages/documents/index.tsx`, `app/frontend/pages/auth/show.tsx`
+- **Approach:** Home: render `NativeNavbar title="Thinkroom"` with a trailing `NativeButton icon="plus"` whose `click` targets a stable id added to the existing "New document" submit button — the native button reuses the web form's submission path (owner token, Inertia redirect) untouched. Auth: render `NativeNavbar` titled "Sign in"/"Create account" plus `NativeForm`, and hide the remember-me checkbox when `nativeApp` (U6 forces it server-side). Signal elements are hidden divs; render them unconditionally (the shell ignores them on web and the components return `hidden` elements).
+- **Patterns to follow:** Inertia examples at rubynative.com/docs/navbar; `usePage().props` usage in existing pages.
+- **Test scenarios:**
+  - Home HTML (any UA) contains `data-native-navbar="Thinkroom"` and a `data-native-button` with `data-native-click` pointing at the new-document button id.
+  - Auth HTML contains `data-native-form` and `data-native-navbar`.
+  - With native UA, auth page hides the remember-me label (assert via `nativeApp` prop; visual check manual).
+- **Verification:** signals present in DOM; web rendering unchanged visually (signal divs are `hidden`).
+
+### U5. Haptics and document-page native affordances
+
+- **Goal:** Tactile feedback on the interactions that define the app, plus back/safe-area polish on the editor.
+- **Requirements:** R6, R7
+- **Dependencies:** U3
+- **Files:** `app/frontend/pages/documents/index.tsx`, `app/frontend/pages/documents/show.tsx`, `app/frontend/components/mode_control.tsx`, `app/frontend/components/margin_suggestions.tsx`, `app/frontend/components/review_popover.tsx`, `app/frontend/pages/auth/show.tsx`, `app/frontend/entrypoints/application.css`
+- **Approach:** spread `nativeHaptic(...)` data attributes: `impact` on New document and auth submit, `success` on suggestion accept and Accept all, `warning` on suggestion reject, `selection` on mode-control options. On the document page header, add a `native-back-button`-classed button (calling `window.RubyNative`-backed `goBack` semantics via the gem's postMessage contract) before the `T.` home link; the gem stylesheet keeps it hidden outside the native shell. Add `native-inset-top` to `doc-header` and `native-inset-bottom` to the mobile dock so fixed chrome clears the Dynamic Island and home indicator (classes are no-ops on web where the CSS variables/env() resolve to 0).
+- **Patterns to follow:** rubynative.com/docs/haptics and /docs/back-buttons Inertia examples; existing safe-area usage (`env(safe-area-inset-bottom)`) in `app/frontend/entrypoints/application.css`.
+- **Test scenarios:**
+  - Rendered home HTML: New document button carries `data-native-haptic="impact"`.
+  - Document page HTML: Accept all button carries `data-native-haptic="success"`; header contains a `native-back-button` element.
+  - Web view: back button not visible without the native shell (CSS default `display: none`).
+- **Verification:** DOM attribute checks via integration test or Playwright UA-override script; no visual regression on web (manual browser pass).
+
+### U6. Always-remember native sessions
+
+- **Goal:** Native users stay signed in per Ruby Native auth guidance.
+- **Requirements:** R8
+- **Dependencies:** U1
+- **Files:** `app/controllers/concerns/authenticates_user.rb`, `test/integration/ruby_native_test.rb`
+- **Approach:** in `complete_authentication`, treat `native_app?` as an implicit remember: `session[:remember_me] = true if remember || native_app?`. Covers login, signup, and OAuth callback in one place. Web behavior unchanged (checkbox still opt-in).
+- **Patterns to follow:** existing remember-me flow (`extend_remembered_session` in `app/controllers/application_controller.rb`, plan `docs/plans/2026-07-02-003-feat-remember-me-login-plan.md`).
+- **Test scenarios:**
+  - POST `/login` with native UA and no `remember_me` param → session carries `remember_me`, subsequent request gets extended cookie expiry.
+  - POST `/login` with desktop UA and no `remember_me` param → not remembered.
+  - POST `/signup` with native UA → remembered.
+- **Verification:** integration tests green.
+
+### U7. End-to-end verification
+
+- **Goal:** Prove the native contract renders and the web experience is unregressed.
+- **Requirements:** R10
+- **Dependencies:** U1–U6
+- **Files:** `test/integration/ruby_native_test.rb`
+- **Approach:** finish the integration test file started in U2/U6; run `npm run check`, `bin/rubocop`, `bin/rails test`. Manual pass with `bin/dev`: a Playwright (or curl) check with UA `Ruby Native iOS RubyNative/1.0` asserting signal elements and `nativeApp: true`, and a normal-browser pass over home, auth, and `/d/demo` confirming no visible change.
+- **Test scenarios:** covered by U1–U6 scenario lists; this unit executes them.
+- **Verification:** all checks green; screenshots/video captured from the browser pass.
+
+---
+
+## Risks & Dependencies
+
+- **Native shell contract drift:** the data-attribute contract is owned by the gem/app pair; pinning `ruby_native` ~> 0.10 and using its helpers/components (not hand-built divs where a component exists) keeps us on the supported surface.
+- **True native chrome is untestable locally:** tab bar, navbar rendering, haptics, and back gestures only exist in the Ruby Native shell (`bundle exec ruby_native preview` on a physical device). Local verification stops at the DOM/props contract, which is exactly what the shell consumes.
+- **Engine auto-mounts routes:** `/native/*` and `/.well-known/apple-app-site-association` are prepended by the engine. Route conflict risk is low (no existing `/native` routes) but the integration test asserts `/native/config` responds.
+- **`allow_browser versions: :modern`:** WKWebView's Safari-equivalent UA passes the modern gate; the native UA marker is appended, not replacing the Mozilla UA. If preview testing ever shows a 406, add a UA allowance — deferred until observed.
+- **OAuth in the shell:** the gem bridges GET → POST via `/native/auth/start` with a CSRF-protected auto-submitting form, so OmniAuth's POST-only + `omniauth-rails_csrf_protection` setup is compatible as-is. Real-device validation deferred to preview testing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@milkdown/plugin-highlight": "7.21.2",
         "@milkdown/react": "7.21.2",
         "@rails/actioncable": "^8.1.300",
+        "@ruby-native/react": "^0.10.11",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.1",
@@ -2527,6 +2528,21 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
+    },
+    "node_modules/@ruby-native/react": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@ruby-native/react/-/react-0.10.11.tgz",
+      "integrity": "sha512-u0lXRTm/8zzxso6FMlT5tOnxAWWW43pOQDf1dDDrVydAD35Ik5I7F8KjLq5UFswSj3xmnLb0MkH/nIP7XGD47A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@inertiajs/react": ">=2",
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@inertiajs/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "workspace",
+  "name": "brainstorm-riffrec-to-pr-pipeline",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,6 @@
         "@milkdown/plugin-highlight": "7.21.2",
         "@milkdown/react": "7.21.2",
         "@rails/actioncable": "^8.1.300",
-        "@ruby-native/react": "^0.10.11",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.1",
@@ -2350,6 +2349,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2365,6 +2367,9 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2382,6 +2387,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2397,6 +2405,9 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2414,6 +2425,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2429,6 +2443,9 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2510,21 +2527,6 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
-    },
-    "node_modules/@ruby-native/react": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@ruby-native/react/-/react-0.10.11.tgz",
-      "integrity": "sha512-u0lXRTm/8zzxso6FMlT5tOnxAWWW43pOQDf1dDDrVydAD35Ik5I7F8KjLq5UFswSj3xmnLb0MkH/nIP7XGD47A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@inertiajs/react": ">=2",
-        "react": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@inertiajs/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.3.0",
@@ -2763,6 +2765,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2778,6 +2783,9 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2795,6 +2803,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,6 +2821,9 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4947,6 +4961,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4966,6 +4983,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4987,6 +5007,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5006,6 +5029,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brainstorm-riffrec-to-pr-pipeline",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,6 +14,7 @@
         "@milkdown/plugin-highlight": "7.21.2",
         "@milkdown/react": "7.21.2",
         "@rails/actioncable": "^8.1.300",
+        "@ruby-native/react": "^0.10.11",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.1",
@@ -2349,9 +2350,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,9 +2365,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2387,9 +2382,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2405,9 +2397,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2425,9 +2414,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2429,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2527,6 +2510,21 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
+    },
+    "node_modules/@ruby-native/react": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@ruby-native/react/-/react-0.10.11.tgz",
+      "integrity": "sha512-u0lXRTm/8zzxso6FMlT5tOnxAWWW43pOQDf1dDDrVydAD35Ik5I7F8KjLq5UFswSj3xmnLb0MkH/nIP7XGD47A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@inertiajs/react": ">=2",
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@inertiajs/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.3.0",
@@ -2765,9 +2763,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2783,9 +2778,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2803,9 +2795,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2810,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4961,9 +4947,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4983,9 +4966,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5007,9 +4987,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5029,9 +5006,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@milkdown/plugin-highlight": "7.21.2",
     "@milkdown/react": "7.21.2",
     "@rails/actioncable": "^8.1.300",
+    "@ruby-native/react": "^0.10.11",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.1",

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -1,0 +1,111 @@
+// Ruby Native shell contract check: the iOS/Android shell reads hidden
+// data-native-* signal elements and haptic data attributes from the DOM,
+// and the server keys nativeApp/nativeForm props off the "Ruby Native" UA
+// marker. These are rendered client-side by React, so server-side tests
+// can't see them — this check loads the pages the way the shell would and
+// asserts the contract, plus that none of it leaks into the regular web UI.
+//
+//   BASE_URL=http://localhost:3000 SLUG=demo node script/native_shell_check.mjs
+//
+import { chromium } from 'playwright'
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
+const SLUG = process.env.SLUG ?? 'demo'
+
+// WKWebView UA with the Ruby Native marker appended, as the iOS shell sends.
+// The base must stay a modern Safari string so `allow_browser versions:
+// :modern` keeps accepting it.
+const NATIVE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 ' +
+  '(KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1 Ruby Native iOS RubyNative/1.0'
+
+const ok = (msg) => console.log(`✓ ${msg}`)
+const fail = (msg) => {
+  console.error(`✗ ${msg}`)
+  process.exitCode = 1
+}
+const check = (condition, msg) => (condition ? ok(msg) : fail(msg))
+
+const mounted = (page) =>
+  page.waitForFunction(() => (document.getElementById('app')?.childElementCount ?? 0) > 0)
+
+const browser = await chromium.launch()
+try {
+  const native = await browser.newContext({
+    userAgent: NATIVE_UA,
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    hasTouch: true,
+  })
+  const page = await native.newPage()
+
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check(
+    (await page.locator('[data-native-navbar="Thinkroom"]').count()) === 1,
+    'home: native navbar signal present',
+  )
+  check(
+    (await page.locator('[data-native-button][data-native-click="#new-document-button"]').count()) === 1,
+    'home: native plus button targets #new-document-button',
+  )
+  check(
+    (await page.locator('#new-document-button[data-native-haptic="impact"]').count()) === 1,
+    'home: New document button carries an impact haptic',
+  )
+
+  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check((await page.locator('[data-native-navbar="Sign in"]').count()) === 1, 'login: native navbar signal present')
+  check((await page.locator('[data-native-form]').count()) === 1, 'login: NativeForm marker present (back skips the form)')
+  check(
+    (await page.locator('input[name="remember_me"]').count()) === 0,
+    'login: remember-me checkbox hidden (native sessions are always remembered)',
+  )
+  check(
+    (await page.locator('button[type="submit"][data-native-haptic="impact"]').count()) >= 1,
+    'login: submit carries an impact haptic',
+  )
+
+  await page.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check(
+    (await page.locator('.doc-header .native-back-button').count()) === 1,
+    'doc: native back button rendered in the header',
+  )
+  check(
+    !(await page.locator('.native-back-button').isVisible()),
+    'doc: back button hidden until the shell signals history',
+  )
+  await page.evaluate(() => document.body.classList.add('can-go-back'))
+  check(
+    await page.locator('.native-back-button').isVisible(),
+    'doc: back button appears once body.can-go-back is set',
+  )
+  const headerClearsNotch = await page.evaluate(() => {
+    document.documentElement.style.setProperty('--ruby-native-safe-area-inset-top', '47px')
+    const paddingTop = parseFloat(getComputedStyle(document.querySelector('.doc-header')).paddingTop)
+    document.documentElement.style.removeProperty('--ruby-native-safe-area-inset-top')
+    return paddingTop >= 47
+  })
+  check(headerClearsNotch, 'doc: header padding-top honors the shell safe-area variable at phone width')
+  await native.close()
+
+  const web = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true })
+  const webPage = await web.newPage()
+  await webPage.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
+  await mounted(webPage)
+  check(
+    (await webPage.locator('input[name="remember_me"]').count()) === 1,
+    'web login: remember-me checkbox still present',
+  )
+  await webPage.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
+  await mounted(webPage)
+  check(
+    !(await webPage.locator('.native-back-button').isVisible()),
+    'web doc: native back button never visible',
+  )
+  await web.close()
+} finally {
+  await browser.close()
+}

--- a/test/integration/authentication_flow_test.rb
+++ b/test/integration/authentication_flow_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AuthenticationFlowTest < ActionDispatch::IntegrationTest
+  include SessionCookieAssertions
+
   setup do
     WriteRateLimited::STORE.clear
   end
@@ -192,22 +194,5 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
   def inertia_error(key)
     errors = session[:inertia_errors] || {}
     errors[key] || errors[key.to_s]
-  end
-
-  # The session cookie set by the latest response, or nil if not re-issued.
-  def session_cookie_header
-    key = Rails.application.config.session_options.fetch(:key)
-    header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
-    header.find { |value| value.start_with?("#{key}=") }
-  end
-
-  def session_cookie_reissued? = session_cookie_header.present?
-
-  # Expiry of the re-issued session cookie; nil for a browser-session cookie.
-  # Callers asserting nil should pair with session_cookie_reissued? so a
-  # missing cookie can't false-pass as "no expiry".
-  def session_cookie_expiry
-    expires = session_cookie_header&.[](/expires=([^;]+)/i, 1)
-    expires && Time.zone.parse(expires)
   end
 end

--- a/test/integration/ruby_native_test.rb
+++ b/test/integration/ruby_native_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+
+# Ruby Native shell integration: user-agent detection, shared Inertia props,
+# layout wiring, the /native/config endpoint, and always-remembered native
+# sessions. https://rubynative.com/docs
+class RubyNativeTest < ActionDispatch::IntegrationTest
+  # WKWebView UA with the Ruby Native marker appended, as the iOS shell sends.
+  NATIVE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) " \
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 " \
+    "Safari/604.1 Ruby Native iOS RubyNative/1.0".freeze
+
+  DESKTOP_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36".freeze
+
+  test "native app requests share nativeApp: true with every Inertia page" do
+    get root_path, headers: { "HTTP_USER_AGENT" => NATIVE_UA }
+
+    assert_response :success
+    assert_inertia_props do |props|
+      props[:nativeApp] == true && props[:nativeForm] == false
+    end
+  end
+
+  test "browser requests share nativeApp: false" do
+    get root_path, headers: { "HTTP_USER_AGENT" => DESKTOP_UA }
+
+    assert_response :success
+    assert_inertia_props { |props| props[:nativeApp] == false }
+  end
+
+  test "layout carries viewport-fit=cover and the ruby_native stylesheet" do
+    get root_path, headers: { "HTTP_USER_AGENT" => DESKTOP_UA }
+
+    assert_response :success
+    assert_match(/viewport-fit=cover/, response.body)
+    assert_match(/ruby_native.*\.css/, response.body)
+  end
+
+  test "/native/config serves the shell configuration without tabs" do
+    get "/native/config"
+
+    assert_response :success
+    config = response.parsed_body.deep_symbolize_keys
+    assert_equal "#b65c3d", config.dig(:appearance, :tint_color)
+    assert_equal "light", config.dig(:appearance, :theme)
+    assert_equal [ "/auth/google_oauth2" ], config.dig(:auth, :oauth_paths)
+    assert_nil config[:tabs], "tab bar must stay hidden (document-centric app)"
+    assert_equal "/", config.dig(:app, :entry_path)
+  end
+
+  test "native sign-in is always remembered, even without the checkbox" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+
+    post login_path,
+         params: { email: user.email, password: "thoughtful-passphrase" },
+         headers: { "HTTP_USER_AGENT" => NATIVE_UA }
+
+    assert_response :see_other
+    assert_equal user.id, session[:user_id]
+    expiry = session_cookie_expiry
+    assert_not_nil expiry, "native sign-in must issue a persistent session cookie"
+    assert_in_delta 30.days.from_now.to_i, expiry.to_i, 1.hour.to_i
+  end
+
+  test "native signup is always remembered" do
+    post signup_path,
+         params: {
+           name: "Kieran",
+           email: "kieran@example.com",
+           password: "thoughtful-passphrase",
+           password_confirmation: "thoughtful-passphrase"
+         },
+         headers: { "HTTP_USER_AGENT" => NATIVE_UA }
+
+    assert_response :see_other
+    assert_not_nil session_cookie_expiry, "native signup must issue a persistent session cookie"
+  end
+
+  test "browser sign-in without remember_me stays a browser-session cookie" do
+    user = User.create!(name: "Kieran", email: "kieran@example.com", password: "thoughtful-passphrase")
+
+    post login_path,
+         params: { email: user.email, password: "thoughtful-passphrase" },
+         headers: { "HTTP_USER_AGENT" => DESKTOP_UA }
+
+    assert_response :see_other
+    assert session_cookie_reissued?, "login must re-issue the session cookie"
+    assert_nil session_cookie_expiry, "web opt-out of remember_me must be preserved"
+  end
+
+  private
+
+  # The session cookie set by the latest response, or nil if not re-issued.
+  def session_cookie_header
+    key = Rails.application.config.session_options.fetch(:key)
+    header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
+    header.find { |value| value.start_with?("#{key}=") }
+  end
+
+  def session_cookie_reissued? = session_cookie_header.present?
+
+  # Expiry of the re-issued session cookie; nil for a browser-session cookie.
+  def session_cookie_expiry
+    expires = session_cookie_header&.[](/expires=([^;]+)/i, 1)
+    expires && Time.zone.parse(expires)
+  end
+end

--- a/test/integration/ruby_native_test.rb
+++ b/test/integration/ruby_native_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 # layout wiring, the /native/config endpoint, and always-remembered native
 # sessions. https://rubynative.com/docs
 class RubyNativeTest < ActionDispatch::IntegrationTest
+  include SessionCookieAssertions
+
   # WKWebView UA with the Ruby Native marker appended, as the iOS shell sends.
   NATIVE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) " \
     "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 " \
@@ -26,6 +28,13 @@ class RubyNativeTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_inertia_props { |props| props[:nativeApp] == false }
+  end
+
+  test "auth pages share nativeForm: true so native back navigation skips them" do
+    get login_path, headers: { "HTTP_USER_AGENT" => NATIVE_UA }
+
+    assert_response :success
+    assert_inertia_props { |props| props[:nativeForm] == true }
   end
 
   test "layout carries viewport-fit=cover and the ruby_native stylesheet" do
@@ -73,7 +82,60 @@ class RubyNativeTest < ActionDispatch::IntegrationTest
          headers: { "HTTP_USER_AGENT" => NATIVE_UA }
 
     assert_response :see_other
-    assert_not_nil session_cookie_expiry, "native signup must issue a persistent session cookie"
+    expiry = session_cookie_expiry
+    assert_not_nil expiry, "native signup must issue a persistent session cookie"
+    assert_in_delta 30.days.from_now.to_i, expiry.to_i, 1.hour.to_i
+  end
+
+  test "native Google OAuth sign-in is remembered via the gem's tracking cookie" do
+    # Native OAuth runs in a system-browser sheet (no Ruby Native UA); the
+    # gem's OAuthMiddleware marks the flow with a signed cookie that rides
+    # the callback request instead.
+    original_test_mode = OmniAuth.config.test_mode
+    original_mock = OmniAuth.config.mock_auth[:google_oauth2]
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "google-123",
+      info: { name: "Kieran", email: "kieran@example.com" },
+      extra: { id_info: { email_verified: true }, raw_info: { email_verified: "true" } }
+    )
+
+    cookies[RubyNative::OAuthMiddleware::COOKIE_NAME] = "signed-scheme-marker"
+    post "/auth/google_oauth2", headers: { "HTTP_USER_AGENT" => DESKTOP_UA }
+    assert_response :redirect
+    follow_redirect!(headers: { "HTTP_USER_AGENT" => DESKTOP_UA })
+
+    assert_response :see_other
+    assert_equal User.find_by!(google_uid: "google-123").id, session[:user_id]
+    assert_not_nil session_cookie_expiry,
+                   "native OAuth sign-in must issue a persistent session cookie"
+  ensure
+    OmniAuth.config.test_mode = original_test_mode
+    OmniAuth.config.mock_auth[:google_oauth2] = original_mock
+  end
+
+  test "web Google OAuth sign-in stays a browser-session cookie" do
+    original_test_mode = OmniAuth.config.test_mode
+    original_mock = OmniAuth.config.mock_auth[:google_oauth2]
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "google-456",
+      info: { name: "Kieran", email: "kieran@example.com" },
+      extra: { id_info: { email_verified: true }, raw_info: { email_verified: "true" } }
+    )
+
+    post "/auth/google_oauth2", headers: { "HTTP_USER_AGENT" => DESKTOP_UA }
+    assert_response :redirect
+    follow_redirect!(headers: { "HTTP_USER_AGENT" => DESKTOP_UA })
+
+    assert_response :see_other
+    assert session_cookie_reissued?, "OAuth sign-in must re-issue the session cookie"
+    assert_nil session_cookie_expiry, "web OAuth sign-in must stay a browser-session cookie"
+  ensure
+    OmniAuth.config.test_mode = original_test_mode
+    OmniAuth.config.mock_auth[:google_oauth2] = original_mock
   end
 
   test "browser sign-in without remember_me stays a browser-session cookie" do
@@ -86,22 +148,5 @@ class RubyNativeTest < ActionDispatch::IntegrationTest
     assert_response :see_other
     assert session_cookie_reissued?, "login must re-issue the session cookie"
     assert_nil session_cookie_expiry, "web opt-out of remember_me must be preserved"
-  end
-
-  private
-
-  # The session cookie set by the latest response, or nil if not re-issued.
-  def session_cookie_header
-    key = Rails.application.config.session_options.fetch(:key)
-    header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
-    header.find { |value| value.start_with?("#{key}=") }
-  end
-
-  def session_cookie_reissued? = session_cookie_header.present?
-
-  # Expiry of the re-issued session cookie; nil for a browser-session cookie.
-  def session_cookie_expiry
-    expires = session_cookie_header&.[](/expires=([^;]+)/i, 1)
-    expires && Time.zone.parse(expires)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "inertia_rails/minitest"
+require_relative "test_helpers/session_cookie_assertions"
 
 module ActiveSupport
   class TestCase

--- a/test/test_helpers/session_cookie_assertions.rb
+++ b/test/test_helpers/session_cookie_assertions.rb
@@ -1,0 +1,22 @@
+# Shared assertions for inspecting the session cookie re-issued by the
+# latest response — used to verify remember-me persistence behavior.
+module SessionCookieAssertions
+  private
+
+  # The session cookie set by the latest response, or nil if not re-issued.
+  def session_cookie_header
+    key = Rails.application.config.session_options.fetch(:key)
+    header = Array(response.headers["Set-Cookie"]).flat_map { |value| value.split("\n") }
+    header.find { |value| value.start_with?("#{key}=") }
+  end
+
+  def session_cookie_reissued? = session_cookie_header.present?
+
+  # Expiry of the re-issued session cookie; nil for a browser-session cookie.
+  # Callers asserting nil should pair with session_cookie_reissued? so a
+  # missing cookie can't false-pass as "no expiry".
+  def session_cookie_expiry
+    expires = session_cookie_header&.[](/expires=([^;]+)/i, 1)
+    expires && Time.zone.parse(expires)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates [Ruby Native](https://rubynative.com/docs) so Thinkroom can ship as a native iOS app (Android when it leaves beta) wrapping the existing Rails + Inertia React frontend.

<a href="https://cursor.com/agents/bc-a08c6adf-d1c5-4478-a903-16eaa62eac0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruby_native_demo_navbar_haptics_back_button.mp4"><img src="https://cursor.com/artifacts/c/art-5bdf5cce-e98e-40ee-af88-546d4c163f83" alt="ruby_native_demo_navbar_haptics_back_button.mp4" /></a>

- **Gem + shell config** — `ruby_native` (~> 0.10) with `config/ruby_native.yml`: brand tint (`#b65c3d`) and paper background (`#faf8f4`), forced light theme, splash screen, no tab bar (document-centric app), and Google OAuth via the system-browser flow (`auth.oauth_paths`). Served at `GET /native/config`.
- **Layout wiring** — `viewport-fit=cover` on the viewport meta tag and the gem stylesheet (`native-hidden`, `native-inset-*`, back-button visibility) in the layout head.
- **Inertia props** — `RubyNative::InertiaSupport` on `InertiaController` shares `nativeApp` / `nativeForm` with every page; auth pages set `@native_form` so native back skips them after sign-in.
- **Native navbar + buttons** — `@ruby-native/react` components: home gets a "Thinkroom" navbar with a native plus button that triggers the web "New document" action; the auth page gets a navbar and a `NativeForm` marker. Local `.d.ts` typings since the package ships untyped.
- **Haptics** — `data-native-haptic` attributes on the defining interactions: New document, auth submit + Google sign-in (impact), suggestion Accept / Accept all (success), Reject (warning), mode selection (selection).
- **Editor page** — keeps its custom web header (mode control, presence, share popover have no native-navbar equivalent) and gains a shell-only native back button plus safe-area insets honoring `--ruby-native-safe-area-inset-*` with `env()` fallback (no-op on the web), including inside the phone-width media queries.
- **Sessions** — native sign-ins are always remembered (30 days) per Ruby Native auth guidance: password/signup via the UA marker, Google OAuth via the gem's `_ruby_native_oauth` tracking cookie (the system-browser sheet carries no native UA). Web remember-me stays opt-in; the checkbox is hidden inside the app.
- **CI** — new `script/native_shell_check.mjs` (13 assertions on the native DOM contract + web-leak guards) wired into the `browser_checks` job.

Plan: `docs/plans/2026-07-02-004-feat-ruby-native-ios-app-plan.md`

## Review notes / residual risks

- UA-triggered always-remember is self-opt-in only (a client controls its own UA); accepted per Ruby Native auth guidance and pinned by tests.
- `viewport-fit=cover` also applies to mobile web / installed PWAs — intended; browser checks confirm no layout regression.
- Upstream gem design (pre-existing, tracked for App Store setup): the native OAuth hand-off tokenizes session cookies to a client-supplied callback scheme — prefer Universal Links (`ios.bundle_id`/`team_id`) when enrolling with Apple.
- `background_color` matches the default `proof` theme; `whitey` users may see a warm-tinted safe-area fill in the shell.
- Push notifications, badges, IAP, App Store submission config, and Advanced Mode transitions are deferred follow-ups.

## Testing

- `test/integration/ruby_native_test.rb` (10 tests): native UA detection → `nativeApp`/`nativeForm` props, layout tags, `/native/config` payload, forced remember-me for native login/signup/OAuth, unchanged web behavior.
- `script/native_shell_check.mjs`: Playwright contract check under a Ruby Native UA (signals, haptics, back-button visibility, safe-area at phone width) + web-leak guards; runs in CI.
- ✅ `bin/rails test` (516 runs) · ✅ `bin/rubocop` · ✅ `npm run check` · ✅ `node script/native_shell_check.mjs` (13/13)
- Manual browser pass (agent-browser + recorded demo): native-mode simulation and web regression on `/`, `/login`, `/signup`, `/d/demo`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a08c6adf-d1c5-4478-a903-16eaa62eac0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a08c6adf-d1c5-4478-a903-16eaa62eac0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

