### PR TITLE
feat(yjs): materialize the state vector at merge time

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -64,7 +64,7 @@ class SyncChannel < ApplicationCable::Channel
         Base64.strict_decode64(update)
       rescue ArgumentError
         ActiveSupport::Notifications.instrument(
-          "frame_dropped.yjs", document_id: @document.id, reason: "malformed"
+          "frame_dropped.yjs", document_id: @document.id, outcome: "dropped_malformed"
         )
         return
       end
@@ -103,7 +103,7 @@ class SyncChannel < ApplicationCable::Channel
       if sequence > @next_sequence + MAX_SEQUENCE_GAP
         ActiveSupport::Notifications.instrument(
           "frame_dropped.yjs",
-          document_id: @document.id, reason: "gap",
+          document_id: @document.id, outcome: "dropped_gap",
           sequence: sequence, expected_sequence: @next_sequence
         )
         return

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -63,7 +63,9 @@ class SyncChannel < ApplicationCable::Channel
       begin
         Base64.strict_decode64(update)
       rescue ArgumentError
-        Rails.logger.warn("SyncChannel: dropped malformed update frame")
+        ActiveSupport::Notifications.instrument(
+          "frame_dropped.yjs", document_id: @document.id, reason: "malformed"
+        )
         return
       end
 
@@ -99,7 +101,11 @@ class SyncChannel < ApplicationCable::Channel
     @sequence_lock.synchronize do
       return if sequence < @next_sequence
       if sequence > @next_sequence + MAX_SEQUENCE_GAP
-        Rails.logger.warn("SyncChannel: dropped update with excessive sequence gap")
+        ActiveSupport::Notifications.instrument(
+          "frame_dropped.yjs",
+          document_id: @document.id, reason: "gap",
+          sequence: sequence, expected_sequence: @next_sequence
+        )
         return
       end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -180,6 +180,7 @@ class Document < ApplicationRecord
         content_snapshot: nil,
         provenance_spans: [],
         yjs_state: nil,
+        yjs_state_vector: nil,
         seed_state: "pending",
         seed_claimed_at: nil,
         # Advances the generation so any SyncChannel client still holding a

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -58,6 +58,7 @@ class YjsPersistence
             payload[:blob_bytes_after] = blob.bytesize
             document.update_columns(
               yjs_state: blob,
+              yjs_state_vector: ydoc.state.pack("C*"),
               seed_state: "seeded",
               updated_at: Time.current
             )
@@ -69,14 +70,30 @@ class YjsPersistence
     end
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
+    #
+    # The stored blob is exactly the previous merge's full_diff output and
+    # the stored vector its state, so when both columns are present the
+    # handshake is served from them directly — no Y::Doc instantiation.
+    # Documents written before yjs_state_vector existed (blob present,
+    # vector nil) fall back to rebuilding; their next merge heals them.
     def state_b64(document)
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
-        ydoc = load_ydoc(document)
-        encoded = [
-          Base64.strict_encode64(ydoc.full_diff.pack("C*")),
-          Base64.strict_encode64(ydoc.state.pack("C*"))
-        ]
+        encoded =
+          if document.yjs_state.present? && document.yjs_state_vector.present?
+            payload[:served_from] = "columns"
+            [
+              Base64.strict_encode64(document.yjs_state),
+              Base64.strict_encode64(document.yjs_state_vector)
+            ]
+          else
+            payload[:served_from] = "rebuild"
+            ydoc = load_ydoc(document)
+            [
+              Base64.strict_encode64(ydoc.full_diff.pack("C*")),
+              Base64.strict_encode64(ydoc.state.pack("C*"))
+            ]
+          end
         # Outcome is assigned last so an exception leaves it unset and the
         # log subscriber's exception fallback classifies the event as a
         # failure rather than a success.
@@ -103,7 +120,7 @@ class YjsPersistence
             end
 
             if client_state && document.yjs_state.present?
-              server_state = decode_state_vector(load_ydoc(document).state)
+              server_state = decode_state_vector(server_state_vector(document))
               current = server_state.all? do |client_id, clock|
                 client_state.fetch(client_id, 0) >= clock
               end
@@ -139,6 +156,15 @@ class YjsPersistence
       ydoc = Y::Doc.new
       ydoc.sync(document.yjs_state.unpack("C*")) if document.yjs_state.present?
       ydoc
+    end
+
+    # The server-side state vector for staleness gating: the merge-time
+    # column when present, else derived from the blob (legacy rows written
+    # before yjs_state_vector existed).
+    def server_state_vector(document)
+      return document.yjs_state_vector.unpack("C*") if document.yjs_state_vector.present?
+
+      load_ydoc(document).state
     end
 
     def decode(base64_update)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -24,39 +24,57 @@ class YjsPersistence
     # rather than persisted.
     def merge(document, base64_update, generation: nil, token: nil, user: nil)
       update = decode(base64_update)
-      lock_for(document.id).synchronize do
-        document.with_lock do
-          document.reload
-          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
-          if generation && generation != document.content_generation
-            raise Document::StaleGenerationError,
-                  "Client generation #{generation} is behind document generation #{document.content_generation}."
+      instrument("merge.yjs", document_id: document.id, update_bytes: update.length) do |payload|
+        entered_at = monotonic_ms
+        lock_for(document.id).synchronize do
+          document.with_lock do
+            payload[:lock_wait_ms] = (monotonic_ms - entered_at).round(1)
+            document.reload
+            unless document.writable_by?(token, user:)
+              payload[:outcome] = "rejected_locked"
+              raise Document::EditingLockedError, "This document is read-only."
+            end
+            if generation && generation != document.content_generation
+              payload[:outcome] = "rejected_stale"
+              raise Document::StaleGenerationError,
+                    "Client generation #{generation} is behind document generation #{document.content_generation}."
+            end
+
+            ydoc = load_ydoc(document)
+            before = ydoc.state
+            ydoc.sync(update)
+            # A no-op update (e.g. the empty sync-reply a client joining an
+            # empty doc sends) must not persist — flipping seed_state to
+            # "seeded" without content would permanently block the seed claim.
+            if ydoc.state == before
+              payload[:outcome] = "noop"
+              next
+            end
+
+            payload[:blob_bytes_before] = document.yjs_state&.bytesize || 0
+            blob = ydoc.full_diff.pack("C*")
+            payload[:blob_bytes_after] = blob.bytesize
+            document.update_columns(
+              yjs_state: blob,
+              seed_state: "seeded",
+              updated_at: Time.current
+            )
+            payload[:outcome] = "merged"
           end
-
-          ydoc = load_ydoc(document)
-          before = ydoc.state
-          ydoc.sync(update)
-          # A no-op update (e.g. the empty sync-reply a client joining an
-          # empty doc sends) must not persist — flipping seed_state to
-          # "seeded" without content would permanently block the seed claim.
-          next if ydoc.state == before
-
-          document.update_columns(
-            yjs_state: ydoc.full_diff.pack("C*"),
-            seed_state: "seeded",
-            updated_at: Time.current
-          )
         end
       end
     end
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
     def state_b64(document)
-      ydoc = load_ydoc(document)
-      [
-        Base64.strict_encode64(ydoc.full_diff.pack("C*")),
-        Base64.strict_encode64(ydoc.state.pack("C*"))
-      ]
+      instrument("state.yjs", document_id: document.id) do |payload|
+        payload[:blob_bytes] = document.yjs_state&.bytesize || 0
+        ydoc = load_ydoc(document)
+        [
+          Base64.strict_encode64(ydoc.full_diff.pack("C*")),
+          Base64.strict_encode64(ydoc.state.pack("C*"))
+        ]
+      end
     end
 
     # Persist a derived source/provenance snapshot only when the submitting
@@ -65,30 +83,54 @@ class YjsPersistence
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
                          token: nil, user: nil)
-      client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
+      instrument("snapshot.yjs", document_id: document.id) do |payload|
+        client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
-      lock_for(document.id).synchronize do
-        document.with_lock do
-          document.reload
-          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
-
-          if client_state && document.yjs_state.present?
-            server_state = decode_state_vector(load_ydoc(document).state)
-            current = server_state.all? do |client_id, clock|
-              client_state.fetch(client_id, 0) >= clock
+        lock_for(document.id).synchronize do
+          document.with_lock do
+            document.reload
+            unless document.writable_by?(token, user:)
+              payload[:outcome] = "rejected_locked"
+              raise Document::EditingLockedError, "This document is read-only."
             end
-            return false unless current
-          end
 
-          document.update!(title:, content_snapshot: content, provenance_spans: spans)
+            if client_state && document.yjs_state.present?
+              server_state = decode_state_vector(load_ydoc(document).state)
+              current = server_state.all? do |client_id, clock|
+                client_state.fetch(client_id, 0) >= clock
+              end
+              unless current
+                payload[:outcome] = "rejected_stale_vector"
+                return false
+              end
+            end
+
+            document.update!(title:, content_snapshot: content, provenance_spans: spans)
+            payload[:outcome] = "persisted"
+          end
         end
+        true
+      rescue ArgumentError => e
+        # A state vector that cannot be decoded is a client bug or corruption,
+        # not ordinary staleness — log it so it is distinguishable, but keep
+        # the false return so callers treat it as "snapshot not accepted".
+        payload[:outcome] = "invalid_state_vector"
+        Rails.logger.warn("YjsPersistence: invalid state vector for document #{document.id}: #{e.message}")
+        false
       end
-      true
-    rescue ArgumentError
-      false
     end
 
     private
+
+    # Instrument wrapper: seeds the payload, defaults the outcome, and lets
+    # exceptions propagate after the event records the rejection outcome.
+    def instrument(event, payload, &)
+      ActiveSupport::Notifications.instrument(event, payload, &)
+    end
+
+    def monotonic_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+    end
 
     def load_ydoc(document)
       ydoc = Y::Doc.new

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -79,15 +79,15 @@ class YjsPersistence
     def state_b64(document)
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
+        from_columns = document.yjs_state.present? && document.yjs_state_vector.present?
+        payload[:served_from] = from_columns ? "columns" : "rebuild"
         encoded =
-          if document.yjs_state.present? && document.yjs_state_vector.present?
-            payload[:served_from] = "columns"
+          if from_columns
             [
               Base64.strict_encode64(document.yjs_state),
               Base64.strict_encode64(document.yjs_state_vector)
             ]
           else
-            payload[:served_from] = "rebuild"
             ydoc = load_ydoc(document)
             [
               Base64.strict_encode64(ydoc.full_diff.pack("C*")),
@@ -120,7 +120,13 @@ class YjsPersistence
             end
 
             if client_state && document.yjs_state.present?
-              server_state = decode_state_vector(server_state_vector(document))
+              server_state = begin
+                decode_state_vector(server_state_vector(document))
+              rescue ArgumentError
+                # A corrupt stored vector must not masquerade as client
+                # staleness — derive the truth from the blob instead.
+                decode_state_vector(load_ydoc(document).state)
+              end
               current = server_state.all? do |client_id, clock|
                 client_state.fetch(client_id, 0) >= clock
               end
@@ -158,9 +164,7 @@ class YjsPersistence
       ydoc
     end
 
-    # The server-side state vector for staleness gating: the merge-time
-    # column when present, else derived from the blob (legacy rows written
-    # before yjs_state_vector existed).
+    # Stored vector when present; otherwise derive from the blob (legacy rows).
     def server_state_vector(document)
       return document.yjs_state_vector.unpack("C*") if document.yjs_state_vector.present?
 

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -24,7 +24,9 @@ class YjsPersistence
     # rather than persisted.
     def merge(document, base64_update, generation: nil, token: nil, user: nil)
       update = decode(base64_update)
-      instrument("merge.yjs", document_id: document.id, update_bytes: update.length) do |payload|
+      ActiveSupport::Notifications.instrument(
+        "merge.yjs", document_id: document.id, update_bytes: update.length
+      ) do |payload|
         entered_at = monotonic_ms
         lock_for(document.id).synchronize do
           document.with_lock do
@@ -60,6 +62,7 @@ class YjsPersistence
               updated_at: Time.current
             )
             payload[:outcome] = "merged"
+            true
           end
         end
       end
@@ -67,13 +70,18 @@ class YjsPersistence
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
     def state_b64(document)
-      instrument("state.yjs", document_id: document.id) do |payload|
+      ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
         ydoc = load_ydoc(document)
-        [
+        encoded = [
           Base64.strict_encode64(ydoc.full_diff.pack("C*")),
           Base64.strict_encode64(ydoc.state.pack("C*"))
         ]
+        # Outcome is assigned last so an exception leaves it unset and the
+        # log subscriber's exception fallback classifies the event as a
+        # failure rather than a success.
+        payload[:outcome] = "ok"
+        encoded
       end
     end
 
@@ -83,7 +91,7 @@ class YjsPersistence
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
                          token: nil, user: nil)
-      instrument("snapshot.yjs", document_id: document.id) do |payload|
+      ActiveSupport::Notifications.instrument("snapshot.yjs", document_id: document.id) do |payload|
         client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
         lock_for(document.id).synchronize do
@@ -112,21 +120,16 @@ class YjsPersistence
         true
       rescue ArgumentError => e
         # A state vector that cannot be decoded is a client bug or corruption,
-        # not ordinary staleness — log it so it is distinguishable, but keep
-        # the false return so callers treat it as "snapshot not accepted".
+        # not ordinary staleness — the outcome (with the error message) makes
+        # it distinguishable in the event stream, while the false return keeps
+        # callers treating it as "snapshot not accepted".
         payload[:outcome] = "invalid_state_vector"
-        Rails.logger.warn("YjsPersistence: invalid state vector for document #{document.id}: #{e.message}")
+        payload[:error] = e.message
         false
       end
     end
 
     private
-
-    # Instrument wrapper: seeds the payload, defaults the outcome, and lets
-    # exceptions propagate after the event records the rejection outcome.
-    def instrument(event, payload, &)
-      ActiveSupport::Notifications.instrument(event, payload, &)
-    end
 
     def monotonic_ms
       Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -10,7 +10,25 @@ Rails.application.config.after_initialize do
 
   ActiveSupport::Notifications.subscribe(/\.yjs\z/) do |event|
     payload = event.payload
-    outcome = payload[:outcome] || payload[:reason] || (payload[:exception] ? "error" : "ok")
+    outcome = payload[:outcome] || (payload[:exception] ? "error" : "ok")
+
+    # Failure outcomes self-classify by the emitters' naming convention
+    # (rejected_* / invalid_* / dropped_*, plus the exception fallback), so
+    # new success outcomes never rot an allowlist into false warns.
+    failure = outcome == "error" || outcome.start_with?("rejected_", "invalid_", "dropped_")
+
+    # Pick the level before building the log line: the merge path emits an
+    # event per collaborative frame, and assembling a string that a
+    # production logger would immediately discard is wasted hot-path work
+    # inside the persist-before-broadcast window.
+    level = if failure
+      :warn
+    elsif event.duration >= slow_ms && Rails.logger.info?
+      :info
+    elsif Rails.logger.debug?
+      :debug
+    end
+    next unless level
 
     fields = {
       event: event.name,
@@ -19,19 +37,14 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       sequence expected_sequence].each do |key|
+       sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
-    fields[:error] = payload[:exception].first if payload[:exception]
+    # Class and message ("Document::StaleGenerationError: Client generation 3
+    # is behind..."); messages in this event family never carry doc content.
+    fields[:error] ||= payload[:exception].join(": ") if payload[:exception]
     line = fields.map { |key, value| "#{key}=#{value}" }.join(" ")
 
-    success = %w[merged noop persisted ok].include?(outcome)
-    if !success
-      Rails.logger.warn(line)
-    elsif event.duration >= slow_ms
-      Rails.logger.info(line)
-    else
-      Rails.logger.debug(line)
-    end
+    Rails.logger.public_send(level, line)
   end
 end

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -1,0 +1,37 @@
+# Renders the structured events emitted by YjsPersistence and SyncChannel
+# (merge.yjs, state.yjs, snapshot.yjs, frame_dropped.yjs) as single-line
+# structured logs. Payloads carry ids, outcomes, and byte sizes only — never
+# document content. External APMs can subscribe to the same /\.yjs$/ events.
+Rails.application.config.after_initialize do
+  # Successful hot-path operations slower than this are logged at info so
+  # slow merges/joins surface without turning routine traffic into log noise.
+  # Arbitrary starting point — tune once real distributions exist.
+  slow_ms = 250.0
+
+  ActiveSupport::Notifications.subscribe(/\.yjs\z/) do |event|
+    payload = event.payload
+    outcome = payload[:outcome] || payload[:reason] || (payload[:exception] ? "error" : "ok")
+
+    fields = {
+      event: event.name,
+      document_id: payload[:document_id],
+      outcome: outcome,
+      duration_ms: event.duration.round(1)
+    }
+    %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
+       sequence expected_sequence].each do |key|
+      fields[key] = payload[key] if payload.key?(key)
+    end
+    fields[:error] = payload[:exception].first if payload[:exception]
+    line = fields.map { |key, value| "#{key}=#{value}" }.join(" ")
+
+    success = %w[merged noop persisted ok].include?(outcome)
+    if !success
+      Rails.logger.warn(line)
+    elsif event.duration >= slow_ms
+      Rails.logger.info(line)
+    else
+      Rails.logger.debug(line)
+    end
+  end
+end

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -37,7 +37,7 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       sequence expected_sequence error].each do |key|
+       served_from sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
     # Class and message ("Document::StaleGenerationError: Client generation 3

--- a/db/migrate/20260702062833_add_yjs_state_vector_to_documents.rb
+++ b/db/migrate/20260702062833_add_yjs_state_vector_to_documents.rb
@@ -1,0 +1,5 @@
+class AddYjsStateVectorToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :yjs_state_vector, :binary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_090000) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.binary "yjs_state"
+    t.binary "yjs_state_vector"
     t.index ["owner_token"], name: "index_documents_on_owner_token"
     t.index ["slug"], name: "index_documents_on_slug", unique: true
     t.index ["user_id"], name: "index_documents_on_user_id"

--- a/docs/plans/2026-07-02-004-feat-yjs-persistence-instrumentation-plan.md
+++ b/docs/plans/2026-07-02-004-feat-yjs-persistence-instrumentation-plan.md
@@ -1,0 +1,122 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Instrument the Yjs persistence hot path"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #2)
+depth: standard
+---
+
+# feat: Instrument the Yjs persistence hot path
+
+## Summary
+
+`YjsPersistence` hosts every silent data-loss and performance path in the collaborative-editing stack, yet contains zero logging, metrics, or `ActiveSupport::Notifications` instrumentation. `persist_snapshot` swallows state-vector decode errors as an indistinguishable `false`; sequence-gap drops and stale-generation rejections vanish into unsampled `Rails.logger.warn` lines; merge duration and blob-size distributions are unmeasurable. This plan wraps the persistence hot path (`merge`, `state_b64`, `persist_snapshot`) and the SyncChannel drop paths in structured `ActiveSupport::Notifications` events with an outcome taxonomy and byte-size payloads, plus a log subscriber that turns them into legible structured logs. The measured distributions become the tuning inputs for every follow-up storage change (compaction triggers, debounce windows, size caps).
+
+## Problem Frame
+
+- `app/services/yjs_persistence.rb` has no `Rails.logger`, `ActiveSupport::Notifications`, or `instrument` calls at all.
+- `persist_snapshot` ends in `rescue ArgumentError → false`: a corrupt state vector is indistinguishable from a legitimately-stale client at the API boundary, and nothing is logged.
+- The only pipeline signals are three `Rails.logger.warn` lines in `app/channels/sync_channel.rb` (malformed frame, gap drop, generic merge failure) — the gap-drop path discards user edits with only an unstructured warn.
+- Every performance claim about the write path (O(document) per-frame cost, burst amplification, join cost) is unmeasured; there is no blob-size or merge-latency distribution to size future compaction/debounce/cap thresholds from.
+
+## Requirements
+
+- R1: Every `YjsPersistence.merge` call emits one structured event carrying document id, outcome, update bytes, blob bytes before/after, and duration.
+- R2: Every `YjsPersistence.state_b64` call emits one structured event carrying document id and served blob bytes.
+- R3: Every `YjsPersistence.persist_snapshot` call emits one structured event with outcome (`persisted`, `rejected_stale_vector`, `rejected_locked`, `invalid_state_vector`), and the invalid-state-vector path logs a warning instead of failing silently (return value stays `false` — API contract unchanged).
+- R4: SyncChannel frame drops (malformed base64, excessive sequence gap) emit structured events with a reason, replacing bare warn lines with subscriber-driven logs.
+- R5: A log subscriber renders these events as single-line structured logs — non-success outcomes at `warn`, slow operations at `info`, routine successes at `debug` — without ever logging document content.
+- R6: No behavior change to persistence semantics: same return values, same raised errors, same locking, same broadcast ordering.
+
+## Key Technical Decisions
+
+- **`ActiveSupport::Notifications`, not an APM gem.** The repo has no APM integration; Rails-native events cost nothing extra and give any future APM (AppSignal, Datadog) a ready subscription point. Adding a paid APM dependency is out of scope.
+- **Event names namespaced `merge.yjs` / `state.yjs` / `snapshot.yjs` / `frame_dropped.yjs`** following Rails' `event.namespace` convention so a single `/\.yjs$/` regex subscription covers them all.
+- **Outcome taxonomy in the payload, not in event names.** One event per operation with an `outcome` key (`merged`, `noop`, `rejected_stale`, `rejected_locked`, `persisted`, `rejected_stale_vector`, `invalid_state_vector`, `dropped_gap`, `dropped_malformed`) keeps cardinality low and subscription simple.
+- **Byte sizes only, never content.** Payloads carry `update_bytes`, `blob_bytes_before`, `blob_bytes_after` — document text never reaches logs.
+- **Exceptions still propagate.** `EditingLockedError` / `StaleGenerationError` raise through the instrument block; the payload records the outcome before raising so subscribers see the rejection without changing the caller contract.
+
+---
+
+## Implementation Units
+
+### U1. Instrument YjsPersistence operations
+
+**Goal:** `merge`, `state_b64`, and `persist_snapshot` each emit one `ActiveSupport::Notifications` event with document id, outcome, and byte sizes; the snapshot decode failure logs a warning.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** none
+
+**Files:**
+- `app/services/yjs_persistence.rb`
+- `test/services/yjs_persistence_test.rb`
+
+**Approach:** Wrap each public method body in `ActiveSupport::Notifications.instrument("<op>.yjs", payload)` and mutate `payload[:outcome]` (plus byte counts) as the operation resolves. For `merge`, set `outcome: "rejected_locked"` / `"rejected_stale"` immediately before raising so the event records the rejection; `"noop"` when the state comparison short-circuits; `"merged"` with `blob_bytes_before`/`blob_bytes_after` on persist. For `persist_snapshot`, replace the bare `rescue ArgumentError; false` with a rescue that sets `outcome: "invalid_state_vector"`, logs one warn line with the document id and error message, and still returns `false`. Measure lock wait by capturing a monotonic timestamp at method entry and recording `lock_wait_ms` once inside the `with_lock` block.
+
+**Patterns to follow:** payload/no-content discipline mirrors `config/initializers/filter_parameter_logging.rb` intent; test style mirrors existing `test/services/yjs_persistence_test.rb` helpers (`b64_update_for`, `text_of`).
+
+**Test scenarios:**
+- Happy path: `merge` of a real update emits `merge.yjs` with `outcome: "merged"`, positive `update_bytes` and `blob_bytes_after`, and `document_id`.
+- No-op: the empty sync-reply emits `outcome: "noop"` and (existing assertion) does not persist or flip `seed_state`.
+- Error path: stale-generation merge emits `outcome: "rejected_stale"` and still raises `Document::StaleGenerationError`; read-only doc emits `outcome: "rejected_locked"` and still raises `Document::EditingLockedError`.
+- `state_b64` emits `state.yjs` with `blob_bytes` matching the stored blob size.
+- `persist_snapshot` success emits `outcome: "persisted"`; behind-client emits `outcome: "rejected_stale_vector"` and returns false.
+- Error path: corrupt state vector emits `outcome: "invalid_state_vector"`, returns false, and logs a warning (assert via `Rails.logger` expectation or log capture).
+- Regression: all existing persistence tests stay green (R6).
+
+**Verification:** `bin/rails test test/services/yjs_persistence_test.rb` green; subscribing to `/\.yjs$/` in a test captures the expected events.
+
+### U2. Emit structured drop events from SyncChannel
+
+**Goal:** The malformed-frame and sequence-gap drop paths emit `frame_dropped.yjs` events with a reason and document id.
+
+**Requirements:** R4, R6
+
+**Dependencies:** U1 (shares the event-naming convention)
+
+**Files:**
+- `app/channels/sync_channel.rb`
+- `test/channels/sync_channel_test.rb`
+
+**Approach:** In `receive`'s malformed-base64 rescue and `enqueue_update`'s gap branch, publish `ActiveSupport::Notifications.instrument("frame_dropped.yjs", document_id:, reason: "malformed"/"gap", ...)` carrying the gap distance for the gap case. Remove the now-redundant inline `Rails.logger.warn` lines (the U3 subscriber renders these events at warn). Keep the generic merge-failure rescue's warn line — it wraps unexpected exceptions, not a taxonomized outcome.
+
+**Test scenarios:**
+- Malformed frame: sending non-base64 `update` emits `frame_dropped.yjs` with `reason: "malformed"` and does not broadcast.
+- Gap drop: a frame with `seq` beyond `MAX_SEQUENCE_GAP` emits `reason: "gap"` with the offending sequence and expected sequence, and does not persist.
+- Regression: in-order and out-of-order-within-gap sequences still persist and broadcast (existing tests).
+
+**Verification:** `bin/rails test test/channels/sync_channel_test.rb` green.
+
+### U3. Log subscriber initializer
+
+**Goal:** One initializer translates `*.yjs` events into single-line structured logs with severity by outcome.
+
+**Requirements:** R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `config/initializers/yjs_instrumentation.rb` (new)
+- `test/services/yjs_persistence_test.rb` (subscriber formatting covered implicitly via one log-capture assertion)
+
+**Approach:** `ActiveSupport::Notifications.subscribe(/\.yjs$/)` building a `key=value` log line (event, document_id, outcome, byte counts, duration rounded to ms). Severity routing: non-success outcomes (`rejected_*`, `invalid_*`, `dropped_*`) → `warn`; successful operations slower than 250 ms → `info`; everything else → `debug`. Guard against missing payload keys so a future event shape change cannot raise inside the subscriber.
+
+**Test scenarios:**
+- One log-capture test: a stale-generation rejection produces a `warn` line containing `outcome=rejected_stale` and the document id, and no document content.
+- Test expectation beyond that: none — severity threshold routing is presentation-only; the events themselves are asserted in U1/U2.
+
+**Verification:** `bin/rails test` green; a manual merge in `bin/rails console` shows the debug line when the log level permits.
+
+---
+
+## Scope Boundaries
+
+- **In scope:** events, payloads, log subscriber, snapshot decode-failure logging.
+- **Deferred to follow-up work:** wiring events to an external APM (AppSignal); dashboards/alerting; using the measured distributions to set compaction or debounce thresholds (ideas #1/#4 from the ideation doc); any payload-size caps (idea #5's hardening).
+- **Non-goals:** changing persistence semantics, locking, broadcast ordering, or the wire protocol.
+
+## Deferred to Implementation
+
+- Exact payload key names beyond those listed (keep `document_id`, `outcome` stable — the subscriber and tests depend on them).
+- Whether the slow-operation `info` threshold is 250 ms or another value — pick one constant, name it, and leave tuning to real data.

--- a/docs/plans/2026-07-02-005-feat-yjs-state-vector-column-plan.md
+++ b/docs/plans/2026-07-02-005-feat-yjs-state-vector-column-plan.md
@@ -1,0 +1,97 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Materialize the Yjs state vector at write time"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #3)
+depth: standard
+base: cursor/yjs-instrumentation-0857 (stacked on the instrumentation PR)
+---
+
+# feat: Materialize the Yjs state vector at write time
+
+## Summary
+
+Every subscribe calls `YjsPersistence.state_b64`, which builds a fresh `Y::Doc` from the stored blob and re-encodes both `full_diff` and the state vector — immediately after the merge that produced the blob computed and discarded those exact values. `persist_snapshot`'s staleness gate does the same full-doc load just to read the server state vector. This plan persists the state vector as a `documents.yjs_state_vector` binary column written inside the existing merge `update_columns`, so joins and snapshot gates become column reads with zero yrs instantiation. Reconnect storms (every deploy re-fires every client's handshake) stop paying O(document) CPU per subscriber.
+
+## Problem Frame
+
+- `state_b64` cost is O(document) CPU per join/reconnect; the write path already holds the identical bytes and discards them (`app/services/yjs_persistence.rb`).
+- `persist_snapshot` loads the full doc per snapshot submission only to decode its state vector.
+- yrs-kvstore (official yrs persistence layer) stores the state vector as its own key precisely so reads skip doc instantiation.
+- The stored blob **is** the previous merge's `full_diff` output, so serving it directly is byte-faithful; the rebuild path only re-derives it.
+
+## Requirements
+
+- R1: `merge` persists `yjs_state_vector` alongside `yjs_state` in the same `update_columns` write.
+- R2: `state_b64` serves the stored blob + stored state vector directly (no `Y::Doc`) when both columns are present; documents written before the migration (blob present, vector nil) fall back to the existing rebuild path.
+- R3: `persist_snapshot` uses the stored state vector for its staleness gate when present, falling back to the rebuild path otherwise.
+- R4: `Document#replace_content!` nulls `yjs_state_vector` together with `yjs_state`.
+- R5: The `state.yjs` instrumentation event records whether the handshake was served from columns or rebuilt, so the rollout is observable.
+- R6: Wire format and handshake semantics unchanged: clients receive the same `[full_state_b64, state_vector_b64]` pair.
+
+## Key Technical Decisions
+
+- **Nullable column, no backfill migration.** Legacy rows heal lazily: the first merge after deploy writes the vector. A backfill would load every document's blob through yrs at migrate time for no urgency — the fallback path keeps legacy rows correct.
+- **Serve the stored blob bytes, not a re-encode.** `Base64.strict_encode64(document.yjs_state)` is exactly the previous merge's `full_diff` output; round-tripping through a fresh doc could only re-encode (never improve) it.
+- **Column-vs-rebuild guard requires *both* columns.** A blob without a vector (legacy row) or a vector without a blob (impossible by construction, but cheap to guard) routes to the rebuild path.
+
+---
+
+## Implementation Units
+
+### U1. Migration: add yjs_state_vector to documents
+
+**Goal:** Nullable binary column exists.
+
+**Requirements:** R1
+
+**Dependencies:** none
+
+**Files:**
+- `db/migrate/*_add_yjs_state_vector_to_documents.rb` (new)
+- `db/schema.rb`
+
+**Approach:** `add_column :documents, :yjs_state_vector, :binary`. No default, no backfill.
+
+**Test scenarios:** Test expectation: none — pure schema addition; behavior covered in U2.
+
+**Verification:** `bin/rails db:migrate` clean; schema.rb shows the column.
+
+### U2. Write the vector at merge time; serve columns on read
+
+**Goal:** `merge` persists the vector; `state_b64` and `persist_snapshot` read it instead of rebuilding the doc; `replace_content!` clears it.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/services/yjs_persistence.rb`
+- `app/models/document.rb`
+- `test/services/yjs_persistence_test.rb`
+
+**Approach:** In `merge`'s persist branch, add `yjs_state_vector: ydoc.state.pack("C*")` to `update_columns`. In `state_b64`, when `yjs_state.present? && yjs_state_vector.present?`, return base64 of the two columns and set the event payload's `served_from: "columns"`; otherwise keep the rebuild path with `served_from: "rebuild"`. In `persist_snapshot`, use `document.yjs_state_vector` (unpacked) for `server_state` when present, else load the doc. In `replace_content!`, add `yjs_state_vector: nil` to the reset attributes.
+
+**Patterns to follow:** rollout-compatibility branching mirrors the seq-less / nil-generation convention documented in `app/channels/sync_channel.rb`.
+
+**Test scenarios:**
+- Happy path: after a merge, `yjs_state_vector` equals the merged doc's `state` bytes; `state_b64` returns values that round-trip into a client doc with the merged content (existing handshake test extended).
+- Column path is doc-free: with both columns present, `state_b64` does not construct a `Y::Doc` (stub `Y::Doc.new` to raise inside the call and assert it still serves).
+- Fallback: a document with a blob but a nil vector (simulated legacy row via `update_columns`) still serves a correct handshake and reports `served_from: "rebuild"`.
+- Reset path: `replace_content!` leaves `yjs_state_vector` nil; the next merge repopulates it.
+- Snapshot gate: existing stale/ahead/reordered-vector tests stay green with the stored vector supplying the server state; a legacy row (nil vector) still gates correctly.
+- Empty document: a document that has never merged serves the same empty-doc handshake as before.
+
+**Verification:** `bin/rails test` green; `script/sync_check.mjs` (two-client convergence + late joiner) passes against `bin/dev`.
+
+---
+
+## Scope Boundaries
+
+- **In scope:** the column, write-through, column-served handshake, snapshot gate read, reset behavior, observability of the serve path.
+- **Deferred to follow-up work:** a differential handshake (client sends its sv, server serves a delta) — blocked on the y-rb `diff` multi-client-vector bug; caching the base64-encoded pair; dropping `yjs_state_b64` from Inertia props.
+- **Non-goals:** changing the wire protocol or the dual-model split.
+
+## Deferred to Implementation
+
+- Whether `persist_snapshot`'s fallback doc load warrants its own payload marker (decide while instrumenting).

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -7,6 +7,17 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     Base64.strict_encode64(ydoc.diff.pack("C*"))
   end
 
+  def capture_yjs_events(name)
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
+      events << event
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
   def build_sequential_updates
     ydoc = Y::Doc.new
     text = ydoc.get_text("t")
@@ -326,6 +337,38 @@ class SyncChannelTest < ActionCable::Channel::TestCase
       subscribe slug: doc.slug
       assert_equal true, transmissions.last["seed"], "doc must remain seedable after a no-op merge"
     end
+  end
+
+  test "a malformed frame emits a frame_dropped event" do
+    doc = Document.create!(title: "Poison metered")
+    subscribe slug: doc.slug
+
+    events = capture_yjs_events("frame_dropped.yjs") do
+      perform :receive, { "type" => "update", "update" => "not!!base64!!", "cid" => "x" }
+    end
+
+    payload = events.first.payload
+    assert_equal doc.id, payload[:document_id]
+    assert_equal "malformed", payload[:reason]
+  end
+
+  test "an excessive sequence gap emits a frame_dropped event and drops the frame" do
+    doc = Document.create!(title: "Gapped")
+    subscribe slug: doc.slug
+    update = build_update_b64("too far ahead")
+    beyond_gap = SyncChannel::MAX_SEQUENCE_GAP + 2
+
+    events = capture_yjs_events("frame_dropped.yjs") do
+      assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
+        perform :receive, { "type" => "update", "update" => update, "cid" => "x", "seq" => beyond_gap }
+      end
+    end
+
+    payload = events.first.payload
+    assert_equal "gap", payload[:reason]
+    assert_equal beyond_gap, payload[:sequence]
+    assert_equal 1, payload[:expected_sequence]
+    assert_nil doc.reload.yjs_state
   end
 
   test "awareness messages relay without persisting" do

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -7,17 +7,6 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     Base64.strict_encode64(ydoc.diff.pack("C*"))
   end
 
-  def capture_yjs_events(name)
-    events = []
-    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
-      events << event
-    end
-    yield
-    events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscription)
-  end
-
   def build_sequential_updates
     ydoc = Y::Doc.new
     text = ydoc.get_text("t")
@@ -343,13 +332,9 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     doc = Document.create!(title: "Poison metered")
     subscribe slug: doc.slug
 
-    events = capture_yjs_events("frame_dropped.yjs") do
+    assert_notification("frame_dropped.yjs", document_id: doc.id, outcome: "dropped_malformed") do
       perform :receive, { "type" => "update", "update" => "not!!base64!!", "cid" => "x" }
     end
-
-    payload = events.first.payload
-    assert_equal doc.id, payload[:document_id]
-    assert_equal "malformed", payload[:reason]
   end
 
   test "an excessive sequence gap emits a frame_dropped event and drops the frame" do
@@ -358,16 +343,15 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     update = build_update_b64("too far ahead")
     beyond_gap = SyncChannel::MAX_SEQUENCE_GAP + 2
 
-    events = capture_yjs_events("frame_dropped.yjs") do
+    assert_notification(
+      "frame_dropped.yjs",
+      outcome: "dropped_gap", sequence: beyond_gap, expected_sequence: 1
+    ) do
       assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
         perform :receive, { "type" => "update", "update" => update, "cid" => "x", "seq" => beyond_gap }
       end
     end
 
-    payload = events.first.payload
-    assert_equal "gap", payload[:reason]
-    assert_equal beyond_gap, payload[:sequence]
-    assert_equal 1, payload[:expected_sequence]
     assert_nil doc.reload.yjs_state
   end
 

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -178,7 +178,126 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "ordered independently", doc.reload.content_snapshot
   end
 
+  test "merge emits a merged event with byte sizes" do
+    doc = Document.create!(title: "Metered")
+    events = capture_yjs_events("merge.yjs") do
+      YjsPersistence.merge(doc, b64_update_for("measured content"))
+    end
+
+    assert_equal 1, events.length
+    payload = events.first.payload
+    assert_equal doc.id, payload[:document_id]
+    assert_equal "merged", payload[:outcome]
+    assert_operator payload[:update_bytes], :>, 0
+    assert_equal 0, payload[:blob_bytes_before]
+    assert_operator payload[:blob_bytes_after], :>, 0
+    assert payload.key?(:lock_wait_ms)
+  end
+
+  test "a no-op merge emits a noop event" do
+    doc = Document.create!(title: "Noop", seed_markdown: "# Template")
+    empty_update = Base64.strict_encode64(Y::Doc.new.full_diff.pack("C*"))
+
+    events = capture_yjs_events("merge.yjs") { YjsPersistence.merge(doc, empty_update) }
+
+    assert_equal "noop", events.first.payload[:outcome]
+  end
+
+  test "a stale-generation rejection emits a rejected_stale event and still raises" do
+    doc = Document.create!(title: "Stale", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("live"))
+    stale_generation = doc.content_generation
+    doc.replace_content!(source: "# Replacement")
+
+    events = capture_yjs_events("merge.yjs") do
+      assert_raises(Document::StaleGenerationError) do
+        YjsPersistence.merge(doc, b64_update_for("stale"), generation: stale_generation)
+      end
+    end
+
+    assert_equal "rejected_stale", events.first.payload[:outcome]
+  end
+
+  test "a locked rejection emits a rejected_locked event and still raises" do
+    doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
+
+    events = capture_yjs_events("merge.yjs") do
+      assert_raises(Document::EditingLockedError) do
+        YjsPersistence.merge(doc, b64_update_for("forbidden"))
+      end
+    end
+
+    assert_equal "rejected_locked", events.first.payload[:outcome]
+  end
+
+  test "state_b64 emits a state event with the stored blob size" do
+    doc = Document.create!(title: "Join")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+    doc.reload
+
+    events = capture_yjs_events("state.yjs") { YjsPersistence.state_b64(doc) }
+
+    assert_equal doc.yjs_state.bytesize, events.first.payload[:blob_bytes]
+  end
+
+  test "snapshot outcomes are taxonomized in events" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    events = capture_yjs_events("snapshot.yjs") do
+      YjsPersistence.persist_snapshot(doc, state_vector_b64: stale_vector, content: "stale", spans: [])
+    end
+    assert_equal "rejected_stale_vector", events.first.payload[:outcome]
+
+    events = capture_yjs_events("snapshot.yjs") do
+      YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "fresh", spans: [])
+    end
+    assert_equal "persisted", events.first.payload[:outcome]
+  end
+
+  test "an undecodable state vector emits invalid_state_vector, logs, and returns false" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    garbage_vector = Base64.strict_encode64([ 0x85, 0xff, 0xff ].pack("C*"))
+
+    logged = capture_rails_log do
+      events = capture_yjs_events("snapshot.yjs") do
+        persisted = YjsPersistence.persist_snapshot(
+          doc, state_vector_b64: garbage_vector, content: "corrupt", spans: []
+        )
+        assert_not persisted
+      end
+      assert_equal "invalid_state_vector", events.first.payload[:outcome]
+    end
+
+    assert_includes logged, "invalid state vector"
+    assert_includes logged, doc.id.to_s
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
   private
+
+  def capture_yjs_events(name)
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
+      events << event
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  def capture_rails_log
+    io = StringIO.new
+    original = Rails.logger
+    Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(io))
+    yield
+    io.string
+  ensure
+    Rails.logger = original
+  end
 
   def decode_state_vector_for_test(bytes)
     index = 0

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -180,8 +180,8 @@ class YjsPersistenceTest < ActiveSupport::TestCase
 
   test "merge emits a merged event with byte sizes" do
     doc = Document.create!(title: "Metered")
-    events = capture_yjs_events("merge.yjs") do
-      YjsPersistence.merge(doc, b64_update_for("measured content"))
+    events = capture_notifications("merge.yjs") do
+      assert_equal true, YjsPersistence.merge(doc, b64_update_for("measured content"))
     end
 
     assert_equal 1, events.length
@@ -198,9 +198,7 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     doc = Document.create!(title: "Noop", seed_markdown: "# Template")
     empty_update = Base64.strict_encode64(Y::Doc.new.full_diff.pack("C*"))
 
-    events = capture_yjs_events("merge.yjs") { YjsPersistence.merge(doc, empty_update) }
-
-    assert_equal "noop", events.first.payload[:outcome]
+    assert_notification("merge.yjs", outcome: "noop") { YjsPersistence.merge(doc, empty_update) }
   end
 
   test "a stale-generation rejection emits a rejected_stale event and still raises" do
@@ -209,25 +207,21 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     stale_generation = doc.content_generation
     doc.replace_content!(source: "# Replacement")
 
-    events = capture_yjs_events("merge.yjs") do
+    assert_notification("merge.yjs", outcome: "rejected_stale") do
       assert_raises(Document::StaleGenerationError) do
         YjsPersistence.merge(doc, b64_update_for("stale"), generation: stale_generation)
       end
     end
-
-    assert_equal "rejected_stale", events.first.payload[:outcome]
   end
 
   test "a locked rejection emits a rejected_locked event and still raises" do
     doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
 
-    events = capture_yjs_events("merge.yjs") do
+    assert_notification("merge.yjs", outcome: "rejected_locked") do
       assert_raises(Document::EditingLockedError) do
         YjsPersistence.merge(doc, b64_update_for("forbidden"))
       end
     end
-
-    assert_equal "rejected_locked", events.first.payload[:outcome]
   end
 
   test "state_b64 emits a state event with the stored blob size" do
@@ -235,9 +229,38 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     YjsPersistence.merge(doc, b64_update_for("content"))
     doc.reload
 
-    events = capture_yjs_events("state.yjs") { YjsPersistence.state_b64(doc) }
+    assert_notification("state.yjs", outcome: "ok", blob_bytes: doc.yjs_state.bytesize) do
+      YjsPersistence.state_b64(doc)
+    end
+  end
 
-    assert_equal doc.yjs_state.bytesize, events.first.payload[:blob_bytes]
+  test "a state_b64 failure is not classified as a success event" do
+    doc = Document.create!(title: "Corrupt join")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+
+    original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
+    YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "corrupt blob" }
+    begin
+      events = capture_notifications("state.yjs") do
+        assert_raises(RuntimeError) { YjsPersistence.state_b64(doc.reload) }
+      end
+
+      payload = events.first.payload
+      assert_nil payload[:outcome], "outcome must stay unset so the subscriber logs the failure"
+      assert payload[:exception].present?
+    ensure
+      YjsPersistence.singleton_class.define_method(:load_ydoc, original)
+    end
+  end
+
+  test "a locked snapshot emits rejected_locked and still raises" do
+    doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
+
+    assert_notification("snapshot.yjs", outcome: "rejected_locked") do
+      assert_raises(Document::EditingLockedError) do
+        YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "nope", spans: [])
+      end
+    end
   end
 
   test "snapshot outcomes are taxonomized in events" do
@@ -245,49 +268,39 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     YjsPersistence.merge(doc, b64_update_for("server content"))
     stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
 
-    events = capture_yjs_events("snapshot.yjs") do
+    assert_notification("snapshot.yjs", outcome: "rejected_stale_vector") do
       YjsPersistence.persist_snapshot(doc, state_vector_b64: stale_vector, content: "stale", spans: [])
     end
-    assert_equal "rejected_stale_vector", events.first.payload[:outcome]
 
-    events = capture_yjs_events("snapshot.yjs") do
+    assert_notification("snapshot.yjs", outcome: "persisted") do
       YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "fresh", spans: [])
     end
-    assert_equal "persisted", events.first.payload[:outcome]
   end
 
-  test "an undecodable state vector emits invalid_state_vector, logs, and returns false" do
+  test "an undecodable state vector emits invalid_state_vector, warns, and returns false" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))
     garbage_vector = Base64.strict_encode64([ 0x85, 0xff, 0xff ].pack("C*"))
 
     logged = capture_rails_log do
-      events = capture_yjs_events("snapshot.yjs") do
+      event = assert_notification("snapshot.yjs", outcome: "invalid_state_vector") do
         persisted = YjsPersistence.persist_snapshot(
           doc, state_vector_b64: garbage_vector, content: "corrupt", spans: []
         )
         assert_not persisted
       end
-      assert_equal "invalid_state_vector", events.first.payload[:outcome]
+      assert event.payload[:error].present?
     end
 
-    assert_includes logged, "invalid state vector"
-    assert_includes logged, doc.id.to_s
+    # The log subscriber (config/initializers/yjs_instrumentation.rb) renders
+    # non-success outcomes at warn — one structured line, no document content.
+    assert_includes logged, "outcome=invalid_state_vector"
+    assert_includes logged, "document_id=#{doc.id}"
+    assert_not_includes logged, "corrupt"
     assert_equal "current", doc.reload.content_snapshot
   end
 
   private
-
-  def capture_yjs_events(name)
-    events = []
-    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
-      events << event
-    end
-    yield
-    events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscription)
-  end
 
   def capture_rails_log
     io = StringIO.new

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -183,6 +183,43 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert doc.reload.yjs_state_vector.present?
   end
 
+  test "the snapshot staleness gate reads the stored vector without building a doc" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
+    YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "gate must not build a Y::Doc" }
+    begin
+      persisted = YjsPersistence.persist_snapshot(
+        doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+      )
+      assert_not persisted
+    ensure
+      YjsPersistence.singleton_class.define_method(:load_ydoc, original)
+    end
+
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
+  test "a corrupt stored vector falls back to the blob for the snapshot gate" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    client = Y::Doc.new
+    YjsPersistence.merge(doc, b64_update_for("server content", from_doc: client))
+    doc.update_columns(yjs_state_vector: [ 0x85, 0xff ].pack("C*"))
+
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+    assert_not YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+    ), "a behind client must still be rejected when the stored vector is corrupt"
+
+    current_vector = Base64.strict_encode64(client.state.pack("C*"))
+    assert YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: current_vector, content: "fresh", spans: []
+    ), "a current client must still be accepted when the stored vector is corrupt"
+    assert_equal "fresh", doc.reload.content_snapshot
+  end
+
   test "snapshot staleness gate works from a legacy row without a stored vector" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -119,6 +119,84 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "server content", client.get_text("t").to_s
   end
 
+  test "merge persists the state vector alongside the blob" do
+    doc = Document.create!(title: "Vectored")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+    doc.reload
+
+    assert doc.yjs_state_vector.present?
+    ydoc = Y::Doc.new
+    ydoc.sync(doc.yjs_state.unpack("C*"))
+    assert_equal ydoc.state, doc.yjs_state_vector.unpack("C*")
+  end
+
+  test "state_b64 serves the handshake from columns without building a doc" do
+    doc = Document.create!(title: "Fast join")
+    YjsPersistence.merge(doc, b64_update_for("column served"))
+    doc.reload
+
+    event = nil
+    original = Y::Doc.method(:new)
+    Y::Doc.define_singleton_method(:new) { |*| raise "state_b64 must not build a Y::Doc" }
+    begin
+      event = assert_notification("state.yjs", served_from: "columns") do
+        full_state, state_vector = YjsPersistence.state_b64(doc)
+        assert_equal Base64.strict_encode64(doc.yjs_state), full_state
+        assert_equal Base64.strict_encode64(doc.yjs_state_vector), state_vector
+      end
+    ensure
+      Y::Doc.define_singleton_method(:new, original)
+    end
+
+    client = Y::Doc.new
+    client.sync(doc.yjs_state.unpack("C*"))
+    assert_equal "column served", client.get_text("t").to_s
+    assert_equal "ok", event.payload[:outcome]
+  end
+
+  test "a legacy row without a stored vector falls back to rebuilding" do
+    doc = Document.create!(title: "Legacy")
+    YjsPersistence.merge(doc, b64_update_for("old row"))
+    doc.update_columns(yjs_state_vector: nil)
+    doc.reload
+
+    full_state, state_vector = nil, nil
+    assert_notification("state.yjs", served_from: "rebuild") do
+      full_state, state_vector = YjsPersistence.state_b64(doc)
+    end
+
+    client = Y::Doc.new
+    client.sync(Base64.strict_decode64(full_state).unpack("C*"))
+    assert_equal "old row", client.get_text("t").to_s
+    assert state_vector.present?
+  end
+
+  test "replace_content! clears the stored state vector until the next merge" do
+    doc = Document.create!(title: "Reset", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("live"))
+    assert doc.reload.yjs_state_vector.present?
+
+    doc.replace_content!(source: "# Replacement")
+    assert_nil doc.reload.yjs_state_vector
+
+    YjsPersistence.merge(doc, b64_update_for("fresh"))
+    assert doc.reload.yjs_state_vector.present?
+  end
+
+  test "snapshot staleness gate works from a legacy row without a stored vector" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    doc.update_columns(yjs_state_vector: nil)
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+    )
+
+    assert_not persisted
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
   test "snapshot persistence rejects a client behind the current Yjs state" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))
@@ -237,6 +315,9 @@ class YjsPersistenceTest < ActiveSupport::TestCase
   test "a state_b64 failure is not classified as a success event" do
     doc = Document.create!(title: "Corrupt join")
     YjsPersistence.merge(doc, b64_update_for("content"))
+    # Legacy row shape (no stored vector) forces the rebuild path, which is
+    # where a corrupt blob can raise.
+    doc.update_columns(yjs_state_vector: nil)
 
     original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
     YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "corrupt blob" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements idea #3 from `docs/ideation/2026-07-02-yjs-storage-ideation.html` (PR #131). **Stacked on #134** (instrumentation) — GitHub will retarget to `main` when that merges.

Every subscribe previously rebuilt a fresh `Y::Doc` from the stored blob and re-encoded `full_diff` + state vector — values the merge that produced the blob had just computed and discarded. Joins therefore cost O(document) CPU per subscriber, worst at reconnect storms after deploys.

- New nullable `documents.yjs_state_vector` binary column, written inside the existing merge `update_columns` (single atomic UPDATE under the same locks).
- `state_b64` serves the handshake straight from the two stored columns when both are present — zero yrs instantiation (proved by a test that stubs `Y::Doc.new` to raise). Legacy rows (nil vector) fall back to the rebuild path and heal on their next merge; the `state.yjs` event records `served_from=columns|rebuild` so the rollout is observable.
- `persist_snapshot`'s staleness gate reads the stored vector (doc-free, also test-proved), with a corrupt-vector fallback that re-derives from the blob rather than misclassifying clients.
- `Document#replace_content!` nulls the vector together with the blob.
- Wire format unchanged; no backfill (lazy healing). Plan: `docs/plans/2026-07-02-005-feat-yjs-state-vector-column-plan.md`.

## Review notes

Persona review (correctness, testing+reliability) + simplification pass applied: corrupt-stored-vector hardening in the snapshot gate, doc-free gate coverage, hoisted `served_from` assignment. Known mixed-version deploy window: an old-code merge during cutover can leave a stale vector; a joiner then gets a slightly-behind sv (benign — its sync-reply is a superset, merges are idempotent) and the row heals on the next new-code merge. After a `kamal rollback` + roll-forward, run `Document.update_all(yjs_state_vector: nil)` before serving traffic.

## Testing

- ✅ `bin/rails test` — 524 runs, 0 failures (7 new tests incl. doc-free column path, legacy fallback, corrupt-vector gate, reset-and-heal)
- ✅ `bin/rubocop`, ✅ `npm run check`
- ✅ End-to-end: `script/sync_check.mjs` against `bin/dev` — convergence + late joiner green; dev log shows the late joiner served from columns in 0.0 ms (`event=state.yjs … served_from=columns`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

