### PR TITLE
feat(yjs): self-healing durability stack for CRDT state

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -87,3 +87,67 @@ bin/kamal deploy
 
 DNS for every `KAMAL_PROXY_HOSTS` entry must point to a configured host before
 the first TLS-enabled deploy.
+
+## Back up the SQLite database with Litestream
+
+The CRDT blobs in `storage/production.sqlite3` are the only copy of every
+document's live state — the content snapshots and HTML projections are lossy
+derivations. The Kamal volume is a single point of failure, so stream the
+database off-host with [Litestream](https://litestream.io/) before relying on
+the deployment for real work.
+
+Add a Litestream accessory to `config/deploy.yml` (adjust the bucket, region,
+and endpoint for your object store; any S3-compatible target works):
+
+```yaml
+accessories:
+  litestream:
+    image: litestream/litestream:0.3
+    hosts:
+      - <your production host>
+    volumes:
+      - "<%= ENV.fetch("KAMAL_STORAGE_VOLUME") %>:/rails/storage"
+    files:
+      - config/litestream.yml:/etc/litestream.yml
+    env:
+      secret:
+        - LITESTREAM_ACCESS_KEY_ID
+        - LITESTREAM_SECRET_ACCESS_KEY
+    cmd: replicate
+```
+
+With `config/litestream.yml`:
+
+```yaml
+dbs:
+  - path: /rails/storage/production.sqlite3
+    replicas:
+      - type: s3
+        bucket: your-backup-bucket
+        path: thinkroom/production
+        region: auto
+        # endpoint: https://<account>.r2.cloudflarestorage.com  # non-AWS stores
+```
+
+Add the two secrets to `.kamal/secrets`, then `bin/kamal accessory boot litestream`.
+The queue/cache/cable databases are derivable and do not need replication.
+
+### Rehearse the restore before you need it
+
+A backup that has never been restored is a hope, not a backup. On the host
+(or any machine with the credentials):
+
+1. Restore to a scratch path — never directly over the live file:
+   `litestream restore -config /etc/litestream.yml -o /tmp/restored.sqlite3 /rails/storage/production.sqlite3`
+2. Integrity-check the restored file:
+   `sqlite3 /tmp/restored.sqlite3 "PRAGMA integrity_check;"` (expect `ok`) and
+   spot-check `SELECT COUNT(*) FROM documents;`.
+3. To actually fail over: stop the app (`bin/kamal app stop`), move the
+   restored file into place on the volume, clear derived state that may be
+   ahead of the restore (`DELETE FROM solid_cable_messages;` on the cable DB
+   is safe — it is transient), and `bin/kamal app boot`.
+4. Clients holding newer state than the restore point re-upload it through
+   the sync handshake on reconnect; `yjs_state_archives` checkpoints inside
+   the database itself cover shorter-horizon, per-document recovery.
+
+Rehearse steps 1-2 quarterly; they are read-only and safe against production.

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -64,7 +64,7 @@ class SyncChannel < ApplicationCable::Channel
         Base64.strict_decode64(update)
       rescue ArgumentError
         ActiveSupport::Notifications.instrument(
-          "frame_dropped.yjs", document_id: @document.id, reason: "malformed"
+          "frame_dropped.yjs", document_id: @document.id, outcome: "dropped_malformed"
         )
         return
       end
@@ -103,7 +103,7 @@ class SyncChannel < ApplicationCable::Channel
       if sequence > @next_sequence + MAX_SEQUENCE_GAP
         ActiveSupport::Notifications.instrument(
           "frame_dropped.yjs",
-          document_id: @document.id, reason: "gap",
+          document_id: @document.id, outcome: "dropped_gap",
           sequence: sequence, expected_sequence: @next_sequence
         )
         return

--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -63,7 +63,9 @@ class SyncChannel < ApplicationCable::Channel
       begin
         Base64.strict_decode64(update)
       rescue ArgumentError
-        Rails.logger.warn("SyncChannel: dropped malformed update frame")
+        ActiveSupport::Notifications.instrument(
+          "frame_dropped.yjs", document_id: @document.id, reason: "malformed"
+        )
         return
       end
 
@@ -99,7 +101,11 @@ class SyncChannel < ApplicationCable::Channel
     @sequence_lock.synchronize do
       return if sequence < @next_sequence
       if sequence > @next_sequence + MAX_SEQUENCE_GAP
-        Rails.logger.warn("SyncChannel: dropped update with excessive sequence gap")
+        ActiveSupport::Notifications.instrument(
+          "frame_dropped.yjs",
+          document_id: @document.id, reason: "gap",
+          sequence: sequence, expected_sequence: @next_sequence
+        )
         return
       end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -179,7 +179,7 @@ class Document < ApplicationRecord
       # Keep what this replacement is about to destroy — tagged with the
       # pre-bump generation so it is a manual-undo artifact only, never an
       # automatic restore candidate (see YjsStateArchive).
-      YjsStateArchive.record!(self, kind: "replacement") if yjs_state.present?
+      YjsStateArchive.record!(self, kind: YjsStateArchive::REPLACEMENT, generation: content_generation) if yjs_state.present?
       attributes = {
         seed_content: source,
         content_snapshot: nil,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,6 +42,7 @@ class Document < ApplicationRecord
   has_many :activities, dependent: :destroy
   has_many :agent_presences, dependent: :destroy
   has_many :document_assets, dependent: :destroy
+  has_many :yjs_state_archives, dependent: :destroy
   belongs_to :user, optional: true
 
   before_validation :ensure_slug, on: :create
@@ -175,12 +176,17 @@ class Document < ApplicationRecord
   def replace_content!(source:, title: nil, seed_author_kind: nil, seed_author_name: nil)
     with_lock do
       reload
+      # Keep what this replacement is about to destroy — tagged with the
+      # pre-bump generation so it is a manual-undo artifact only, never an
+      # automatic restore candidate (see YjsStateArchive).
+      YjsStateArchive.record!(self, kind: "replacement") if yjs_state.present?
       attributes = {
         seed_content: source,
         content_snapshot: nil,
         provenance_spans: [],
         yjs_state: nil,
         yjs_state_vector: nil,
+        yjs_state_checksum: nil,
         seed_state: "pending",
         seed_claimed_at: nil,
         # Advances the generation so any SyncChannel client still holding a

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -180,6 +180,7 @@ class Document < ApplicationRecord
         content_snapshot: nil,
         provenance_spans: [],
         yjs_state: nil,
+        yjs_state_vector: nil,
         seed_state: "pending",
         seed_claimed_at: nil,
         # Advances the generation so any SyncChannel client still holding a

--- a/app/models/yjs_state_archive.rb
+++ b/app/models/yjs_state_archive.rb
@@ -1,0 +1,34 @@
+# A retained copy of a document's CRDT state, written by the durability
+# layer in YjsPersistence and Document#replace_content!. See the kind
+# comments in the migration; only same-generation checkpoints are ever
+# restored automatically (restoring across a generation bump would
+# resurrect content a replacement deliberately wiped).
+class YjsStateArchive < ApplicationRecord
+  KINDS = %w[checkpoint replacement quarantine].freeze
+
+  # Newest archives kept per document and kind; older ones are pruned on
+  # every insert so retention stays bounded.
+  MAX_PER_KIND = 5
+
+  belongs_to :document
+
+  validates :kind, inclusion: { in: KINDS }
+
+  # Snapshot the document's current CRDT columns into an archive row and
+  # prune the kind down to MAX_PER_KIND. Callers are expected to hold the
+  # document's persistence locks (YjsPersistence) or row lock
+  # (Document#replace_content!).
+  def self.record!(document, kind:, generation: document.content_generation, error: nil)
+    archive = create!(
+      document:,
+      kind:,
+      content_generation: generation,
+      yjs_state: document.yjs_state,
+      yjs_state_vector: document.yjs_state_vector,
+      error:
+    )
+    stale_ids = where(document:, kind:).order(created_at: :desc, id: :desc).offset(MAX_PER_KIND).ids
+    where(id: stale_ids).delete_all if stale_ids.any?
+    archive
+  end
+end

--- a/app/models/yjs_state_archive.rb
+++ b/app/models/yjs_state_archive.rb
@@ -4,7 +4,15 @@
 # restored automatically (restoring across a generation bump would
 # resurrect content a replacement deliberately wiped).
 class YjsStateArchive < ApplicationRecord
-  KINDS = %w[checkpoint replacement quarantine].freeze
+  # Interval-gated pre-merge snapshot — the automatic restore candidate.
+  CHECKPOINT = "checkpoint".freeze
+  # State wiped by Document#replace_content! — manual undo only (its
+  # generation is pre-bump, so automatic restore would resurrect content).
+  REPLACEMENT = "replacement".freeze
+  # Corrupt bytes kept for forensics — never restored.
+  QUARANTINE = "quarantine".freeze
+
+  KINDS = [ CHECKPOINT, REPLACEMENT, QUARANTINE ].freeze
 
   # Newest archives kept per document and kind; older ones are pruned on
   # every insert so retention stays bounded.

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -58,6 +58,7 @@ class YjsPersistence
             payload[:blob_bytes_after] = blob.bytesize
             document.update_columns(
               yjs_state: blob,
+              yjs_state_vector: ydoc.state.pack("C*"),
               seed_state: "seeded",
               updated_at: Time.current
             )
@@ -69,14 +70,30 @@ class YjsPersistence
     end
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
+    #
+    # The stored blob is exactly the previous merge's full_diff output and
+    # the stored vector its state, so when both columns are present the
+    # handshake is served from them directly — no Y::Doc instantiation.
+    # Documents written before yjs_state_vector existed (blob present,
+    # vector nil) fall back to rebuilding; their next merge heals them.
     def state_b64(document)
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
-        ydoc = load_ydoc(document)
-        encoded = [
-          Base64.strict_encode64(ydoc.full_diff.pack("C*")),
-          Base64.strict_encode64(ydoc.state.pack("C*"))
-        ]
+        encoded =
+          if document.yjs_state.present? && document.yjs_state_vector.present?
+            payload[:served_from] = "columns"
+            [
+              Base64.strict_encode64(document.yjs_state),
+              Base64.strict_encode64(document.yjs_state_vector)
+            ]
+          else
+            payload[:served_from] = "rebuild"
+            ydoc = load_ydoc(document)
+            [
+              Base64.strict_encode64(ydoc.full_diff.pack("C*")),
+              Base64.strict_encode64(ydoc.state.pack("C*"))
+            ]
+          end
         # Outcome is assigned last so an exception leaves it unset and the
         # log subscriber's exception fallback classifies the event as a
         # failure rather than a success.
@@ -103,7 +120,7 @@ class YjsPersistence
             end
 
             if client_state && document.yjs_state.present?
-              server_state = decode_state_vector(load_ydoc(document).state)
+              server_state = decode_state_vector(server_state_vector(document))
               current = server_state.all? do |client_id, clock|
                 client_state.fetch(client_id, 0) >= clock
               end
@@ -139,6 +156,15 @@ class YjsPersistence
       ydoc = Y::Doc.new
       ydoc.sync(document.yjs_state.unpack("C*")) if document.yjs_state.present?
       ydoc
+    end
+
+    # The server-side state vector for staleness gating: the merge-time
+    # column when present, else derived from the blob (legacy rows written
+    # before yjs_state_vector existed).
+    def server_state_vector(document)
+      return document.yjs_state_vector.unpack("C*") if document.yjs_state_vector.present?
+
+      load_ydoc(document).state
     end
 
     def decode(base64_update)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -24,39 +24,57 @@ class YjsPersistence
     # rather than persisted.
     def merge(document, base64_update, generation: nil, token: nil, user: nil)
       update = decode(base64_update)
-      lock_for(document.id).synchronize do
-        document.with_lock do
-          document.reload
-          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
-          if generation && generation != document.content_generation
-            raise Document::StaleGenerationError,
-                  "Client generation #{generation} is behind document generation #{document.content_generation}."
+      instrument("merge.yjs", document_id: document.id, update_bytes: update.length) do |payload|
+        entered_at = monotonic_ms
+        lock_for(document.id).synchronize do
+          document.with_lock do
+            payload[:lock_wait_ms] = (monotonic_ms - entered_at).round(1)
+            document.reload
+            unless document.writable_by?(token, user:)
+              payload[:outcome] = "rejected_locked"
+              raise Document::EditingLockedError, "This document is read-only."
+            end
+            if generation && generation != document.content_generation
+              payload[:outcome] = "rejected_stale"
+              raise Document::StaleGenerationError,
+                    "Client generation #{generation} is behind document generation #{document.content_generation}."
+            end
+
+            ydoc = load_ydoc(document)
+            before = ydoc.state
+            ydoc.sync(update)
+            # A no-op update (e.g. the empty sync-reply a client joining an
+            # empty doc sends) must not persist — flipping seed_state to
+            # "seeded" without content would permanently block the seed claim.
+            if ydoc.state == before
+              payload[:outcome] = "noop"
+              next
+            end
+
+            payload[:blob_bytes_before] = document.yjs_state&.bytesize || 0
+            blob = ydoc.full_diff.pack("C*")
+            payload[:blob_bytes_after] = blob.bytesize
+            document.update_columns(
+              yjs_state: blob,
+              seed_state: "seeded",
+              updated_at: Time.current
+            )
+            payload[:outcome] = "merged"
           end
-
-          ydoc = load_ydoc(document)
-          before = ydoc.state
-          ydoc.sync(update)
-          # A no-op update (e.g. the empty sync-reply a client joining an
-          # empty doc sends) must not persist — flipping seed_state to
-          # "seeded" without content would permanently block the seed claim.
-          next if ydoc.state == before
-
-          document.update_columns(
-            yjs_state: ydoc.full_diff.pack("C*"),
-            seed_state: "seeded",
-            updated_at: Time.current
-          )
         end
       end
     end
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
     def state_b64(document)
-      ydoc = load_ydoc(document)
-      [
-        Base64.strict_encode64(ydoc.full_diff.pack("C*")),
-        Base64.strict_encode64(ydoc.state.pack("C*"))
-      ]
+      instrument("state.yjs", document_id: document.id) do |payload|
+        payload[:blob_bytes] = document.yjs_state&.bytesize || 0
+        ydoc = load_ydoc(document)
+        [
+          Base64.strict_encode64(ydoc.full_diff.pack("C*")),
+          Base64.strict_encode64(ydoc.state.pack("C*"))
+        ]
+      end
     end
 
     # Persist a derived source/provenance snapshot only when the submitting
@@ -65,30 +83,54 @@ class YjsPersistence
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
                          token: nil, user: nil)
-      client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
+      instrument("snapshot.yjs", document_id: document.id) do |payload|
+        client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
-      lock_for(document.id).synchronize do
-        document.with_lock do
-          document.reload
-          raise Document::EditingLockedError, "This document is read-only." unless document.writable_by?(token, user:)
-
-          if client_state && document.yjs_state.present?
-            server_state = decode_state_vector(load_ydoc(document).state)
-            current = server_state.all? do |client_id, clock|
-              client_state.fetch(client_id, 0) >= clock
+        lock_for(document.id).synchronize do
+          document.with_lock do
+            document.reload
+            unless document.writable_by?(token, user:)
+              payload[:outcome] = "rejected_locked"
+              raise Document::EditingLockedError, "This document is read-only."
             end
-            return false unless current
-          end
 
-          document.update!(title:, content_snapshot: content, provenance_spans: spans)
+            if client_state && document.yjs_state.present?
+              server_state = decode_state_vector(load_ydoc(document).state)
+              current = server_state.all? do |client_id, clock|
+                client_state.fetch(client_id, 0) >= clock
+              end
+              unless current
+                payload[:outcome] = "rejected_stale_vector"
+                return false
+              end
+            end
+
+            document.update!(title:, content_snapshot: content, provenance_spans: spans)
+            payload[:outcome] = "persisted"
+          end
         end
+        true
+      rescue ArgumentError => e
+        # A state vector that cannot be decoded is a client bug or corruption,
+        # not ordinary staleness — log it so it is distinguishable, but keep
+        # the false return so callers treat it as "snapshot not accepted".
+        payload[:outcome] = "invalid_state_vector"
+        Rails.logger.warn("YjsPersistence: invalid state vector for document #{document.id}: #{e.message}")
+        false
       end
-      true
-    rescue ArgumentError
-      false
     end
 
     private
+
+    # Instrument wrapper: seeds the payload, defaults the outcome, and lets
+    # exceptions propagate after the event records the rejection outcome.
+    def instrument(event, payload, &)
+      ActiveSupport::Notifications.instrument(event, payload, &)
+    end
+
+    def monotonic_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+    end
 
     def load_ydoc(document)
       ydoc = Y::Doc.new

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -79,15 +79,15 @@ class YjsPersistence
     def state_b64(document)
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
+        from_columns = document.yjs_state.present? && document.yjs_state_vector.present?
+        payload[:served_from] = from_columns ? "columns" : "rebuild"
         encoded =
-          if document.yjs_state.present? && document.yjs_state_vector.present?
-            payload[:served_from] = "columns"
+          if from_columns
             [
               Base64.strict_encode64(document.yjs_state),
               Base64.strict_encode64(document.yjs_state_vector)
             ]
           else
-            payload[:served_from] = "rebuild"
             ydoc = load_ydoc(document)
             [
               Base64.strict_encode64(ydoc.full_diff.pack("C*")),
@@ -120,7 +120,13 @@ class YjsPersistence
             end
 
             if client_state && document.yjs_state.present?
-              server_state = decode_state_vector(server_state_vector(document))
+              server_state = begin
+                decode_state_vector(server_state_vector(document))
+              rescue ArgumentError
+                # A corrupt stored vector must not masquerade as client
+                # staleness — derive the truth from the blob instead.
+                decode_state_vector(load_ydoc(document).state)
+              end
               current = server_state.all? do |client_id, clock|
                 client_state.fetch(client_id, 0) >= clock
               end
@@ -158,9 +164,7 @@ class YjsPersistence
       ydoc
     end
 
-    # The server-side state vector for staleness gating: the merge-time
-    # column when present, else derived from the blob (legacy rows written
-    # before yjs_state_vector existed).
+    # Stored vector when present; otherwise derive from the blob (legacy rows).
     def server_state_vector(document)
       return document.yjs_state_vector.unpack("C*") if document.yjs_state_vector.present?
 

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -4,12 +4,29 @@
 # joining clients. See README for why we relay manually instead of using
 # y-rb_actioncable's channel.
 class YjsPersistence
+  # Raised when a freshly encoded blob fails the round-trip probe: persisting
+  # it would brick every future load, so the frame is rejected instead
+  # (SyncChannel's rescue keeps it unbroadcast — durable-before-broadcast).
+  class EncodeValidationError < StandardError; end
+
+  # Raised when a stored blob fails its checksum or cannot be synced into a
+  # fresh doc. Callers holding the document locks heal via
+  # heal_corrupt_state! and retry.
+  class CorruptStateError < StandardError; end
+
   # Per-document, in-process locks. ActionCable handles channel actions on a
   # thread pool; without this, two concurrent receives could both read the same
   # stored blob and the later write would drop the earlier update. The app runs
   # single-process in development (async cable adapter), so an in-process lock
   # is sufficient; the DB transaction below is the second guard.
   LOCKS = Concurrent::Map.new
+
+  # A merge archives the pre-merge state at most this often per document,
+  # bounding what a corrupt-blob heal can lose to one interval of edits.
+  CHECKPOINT_INTERVAL = 10.minutes
+
+  # Newest archives kept per document and kind.
+  MAX_ARCHIVES_PER_KIND = 5
 
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
@@ -42,7 +59,7 @@ class YjsPersistence
                     "Client generation #{generation} is behind document generation #{document.content_generation}."
             end
 
-            ydoc = load_ydoc(document)
+            ydoc = load_or_heal_ydoc(document)
             before = ydoc.state
             ydoc.sync(update)
             # A no-op update (e.g. the empty sync-reply a client joining an
@@ -56,9 +73,18 @@ class YjsPersistence
             payload[:blob_bytes_before] = document.yjs_state&.bytesize || 0
             blob = ydoc.full_diff.pack("C*")
             payload[:blob_bytes_after] = blob.bytesize
+            unless blob_loadable?(blob)
+              payload[:outcome] = "rejected_invalid_encode"
+              raise EncodeValidationError,
+                    "Refusing to persist a blob that cannot round-trip into a fresh doc " \
+                    "(document #{document.id})."
+            end
+
+            maybe_checkpoint(document)
             document.update_columns(
               yjs_state: blob,
               yjs_state_vector: ydoc.state.pack("C*"),
+              yjs_state_checksum: Digest::SHA256.hexdigest(blob),
               seed_state: "seeded",
               updated_at: Time.current
             )
@@ -78,22 +104,24 @@ class YjsPersistence
     # vector nil) fall back to rebuilding; their next merge heals them.
     def state_b64(document)
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
-        payload[:blob_bytes] = document.yjs_state&.bytesize || 0
-        from_columns = document.yjs_state.present? && document.yjs_state_vector.present?
-        payload[:served_from] = from_columns ? "columns" : "rebuild"
-        encoded =
-          if from_columns
-            [
-              Base64.strict_encode64(document.yjs_state),
-              Base64.strict_encode64(document.yjs_state_vector)
-            ]
-          else
-            ydoc = load_ydoc(document)
-            [
-              Base64.strict_encode64(ydoc.full_diff.pack("C*")),
-              Base64.strict_encode64(ydoc.state.pack("C*"))
-            ]
+        encoded = begin
+          encode_handshake(document, payload)
+        rescue CorruptStateError => e
+          # The fast path holds no locks, so corruption is healed here:
+          # acquire both, re-check (another thread may have healed first),
+          # heal, and rebuild the handshake from the restored state.
+          lock_for(document.id).synchronize do
+            document.with_lock do
+              document.reload
+              begin
+                encode_handshake(document, payload)
+              rescue CorruptStateError
+                heal_corrupt_state!(document, e)
+                encode_handshake(document, payload)
+              end
+            end
           end
+        end
         # Outcome is assigned last so an exception leaves it unset and the
         # log subscriber's exception fallback classifies the event as a
         # failure rather than a success.
@@ -125,7 +153,7 @@ class YjsPersistence
               rescue ArgumentError
                 # A corrupt stored vector must not masquerade as client
                 # staleness — derive the truth from the blob instead.
-                decode_state_vector(load_ydoc(document).state)
+                decode_state_vector(load_or_heal_ydoc(document).state)
               end
               current = server_state.all? do |client_id, clock|
                 client_state.fetch(client_id, 0) >= clock
@@ -160,8 +188,106 @@ class YjsPersistence
 
     def load_ydoc(document)
       ydoc = Y::Doc.new
-      ydoc.sync(document.yjs_state.unpack("C*")) if document.yjs_state.present?
+      if document.yjs_state.present?
+        verify_checksum!(document)
+        begin
+          ydoc.sync(document.yjs_state.unpack("C*"))
+        rescue StandardError => e
+          raise CorruptStateError, "document #{document.id}: #{e.class}: #{e.message}"
+        end
+      end
       ydoc
+    end
+
+    # For callers already holding both document locks (merge,
+    # persist_snapshot): a corrupt blob heals in place and the load retries
+    # once on the restored state.
+    def load_or_heal_ydoc(document)
+      load_ydoc(document)
+    rescue CorruptStateError => e
+      heal_corrupt_state!(document, e)
+      load_ydoc(document)
+    end
+
+    def verify_checksum!(document)
+      checksum = document.yjs_state_checksum
+      return if checksum.blank? # legacy row — heals on its next merge
+      return if checksum == Digest::SHA256.hexdigest(document.yjs_state)
+
+      raise CorruptStateError, "document #{document.id}: yjs_state checksum mismatch"
+    end
+
+    def blob_loadable?(blob)
+      Y::Doc.new.sync(blob.unpack("C*"))
+      true
+    rescue StandardError
+      false
+    end
+
+    def encode_handshake(document, payload)
+      payload[:blob_bytes] = document.yjs_state&.bytesize || 0
+      from_columns = document.yjs_state.present? && document.yjs_state_vector.present?
+      payload[:served_from] = from_columns ? "columns" : "rebuild"
+      if from_columns
+        verify_checksum!(document)
+        [
+          Base64.strict_encode64(document.yjs_state),
+          Base64.strict_encode64(document.yjs_state_vector)
+        ]
+      else
+        ydoc = load_ydoc(document)
+        [
+          Base64.strict_encode64(ydoc.full_diff.pack("C*")),
+          Base64.strict_encode64(ydoc.state.pack("C*"))
+        ]
+      end
+    end
+
+    # Contain-and-restore for a corrupt stored blob. Callers must hold both
+    # the per-document mutex and the row lock. The corrupt bytes are
+    # quarantined for forensics, then the newest loadable checkpoint from
+    # the *current* content generation is restored — never an older
+    # generation, which would resurrect content a replacement wiped. With
+    # no restorable checkpoint the document degrades to empty and connected
+    # clients re-upload their state through the sync-reply handshake.
+    def heal_corrupt_state!(document, error)
+      ActiveSupport::Notifications.instrument("recovered.yjs", document_id: document.id) do |payload|
+        YjsStateArchive.record!(document, kind: "quarantine", error: error.message)
+
+        checkpoint = document.yjs_state_archives
+                             .where(kind: "checkpoint", content_generation: document.content_generation)
+                             .order(created_at: :desc, id: :desc)
+                             .detect { |archive| archive.yjs_state.present? && blob_loadable?(archive.yjs_state) }
+        if checkpoint
+          document.update_columns(
+            yjs_state: checkpoint.yjs_state,
+            yjs_state_vector: checkpoint.yjs_state_vector,
+            yjs_state_checksum: Digest::SHA256.hexdigest(checkpoint.yjs_state),
+            updated_at: Time.current
+          )
+          payload[:restored_from] = "checkpoint"
+        else
+          document.update_columns(
+            yjs_state: nil,
+            yjs_state_vector: nil,
+            yjs_state_checksum: nil,
+            updated_at: Time.current
+          )
+          payload[:restored_from] = "empty"
+        end
+        payload[:outcome] = "recovered"
+      end
+    end
+
+    # Interval-gated archive of the pre-merge state, bounding what a future
+    # heal can lose to at most one interval of edits. Caller holds both locks.
+    def maybe_checkpoint(document)
+      return if document.yjs_state.blank?
+
+      newest = document.yjs_state_archives.where(kind: "checkpoint").maximum(:created_at)
+      return if newest && newest > CHECKPOINT_INTERVAL.ago
+
+      YjsStateArchive.record!(document, kind: "checkpoint")
     end
 
     # Stored vector when present; otherwise derive from the blob (legacy rows).

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -24,7 +24,9 @@ class YjsPersistence
     # rather than persisted.
     def merge(document, base64_update, generation: nil, token: nil, user: nil)
       update = decode(base64_update)
-      instrument("merge.yjs", document_id: document.id, update_bytes: update.length) do |payload|
+      ActiveSupport::Notifications.instrument(
+        "merge.yjs", document_id: document.id, update_bytes: update.length
+      ) do |payload|
         entered_at = monotonic_ms
         lock_for(document.id).synchronize do
           document.with_lock do
@@ -60,6 +62,7 @@ class YjsPersistence
               updated_at: Time.current
             )
             payload[:outcome] = "merged"
+            true
           end
         end
       end
@@ -67,13 +70,18 @@ class YjsPersistence
 
     # => [full_state_b64, state_vector_b64] for the sync handshake.
     def state_b64(document)
-      instrument("state.yjs", document_id: document.id) do |payload|
+      ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         payload[:blob_bytes] = document.yjs_state&.bytesize || 0
         ydoc = load_ydoc(document)
-        [
+        encoded = [
           Base64.strict_encode64(ydoc.full_diff.pack("C*")),
           Base64.strict_encode64(ydoc.state.pack("C*"))
         ]
+        # Outcome is assigned last so an exception leaves it unset and the
+        # log subscriber's exception fallback classifies the event as a
+        # failure rather than a success.
+        payload[:outcome] = "ok"
+        encoded
       end
     end
 
@@ -83,7 +91,7 @@ class YjsPersistence
     # may not overwrite the API read model from behind.
     def persist_snapshot(document, state_vector_b64:, content:, spans:, title: document.title,
                          token: nil, user: nil)
-      instrument("snapshot.yjs", document_id: document.id) do |payload|
+      ActiveSupport::Notifications.instrument("snapshot.yjs", document_id: document.id) do |payload|
         client_state = decode_state_vector(decode(state_vector_b64)) if state_vector_b64.present?
 
         lock_for(document.id).synchronize do
@@ -112,21 +120,16 @@ class YjsPersistence
         true
       rescue ArgumentError => e
         # A state vector that cannot be decoded is a client bug or corruption,
-        # not ordinary staleness — log it so it is distinguishable, but keep
-        # the false return so callers treat it as "snapshot not accepted".
+        # not ordinary staleness — the outcome (with the error message) makes
+        # it distinguishable in the event stream, while the false return keeps
+        # callers treating it as "snapshot not accepted".
         payload[:outcome] = "invalid_state_vector"
-        Rails.logger.warn("YjsPersistence: invalid state vector for document #{document.id}: #{e.message}")
+        payload[:error] = e.message
         false
       end
     end
 
     private
-
-    # Instrument wrapper: seeds the payload, defaults the outcome, and lets
-    # exceptions propagate after the event records the rejection outcome.
-    def instrument(event, payload, &)
-      ActiveSupport::Notifications.instrument(event, payload, &)
-    end
 
     def monotonic_ms
       Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -25,9 +25,6 @@ class YjsPersistence
   # bounding what a corrupt-blob heal can lose to one interval of edits.
   CHECKPOINT_INTERVAL = 10.minutes
 
-  # Newest archives kept per document and kind.
-  MAX_ARCHIVES_PER_KIND = 5
-
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
     #
@@ -84,7 +81,7 @@ class YjsPersistence
             document.update_columns(
               yjs_state: blob,
               yjs_state_vector: ydoc.state.pack("C*"),
-              yjs_state_checksum: Digest::SHA256.hexdigest(blob),
+              yjs_state_checksum: state_checksum(blob),
               seed_state: "seeded",
               updated_at: Time.current
             )
@@ -106,21 +103,8 @@ class YjsPersistence
       ActiveSupport::Notifications.instrument("state.yjs", document_id: document.id) do |payload|
         encoded = begin
           encode_handshake(document, payload)
-        rescue CorruptStateError => e
-          # The fast path holds no locks, so corruption is healed here:
-          # acquire both, re-check (another thread may have healed first),
-          # heal, and rebuild the handshake from the restored state.
-          lock_for(document.id).synchronize do
-            document.with_lock do
-              document.reload
-              begin
-                encode_handshake(document, payload)
-              rescue CorruptStateError
-                heal_corrupt_state!(document, e)
-                encode_handshake(document, payload)
-              end
-            end
-          end
+        rescue CorruptStateError
+          heal_and_reencode_handshake(document, payload)
         end
         # Outcome is assigned last so an exception leaves it unset and the
         # log subscriber's exception fallback classifies the event as a
@@ -150,9 +134,10 @@ class YjsPersistence
             if client_state && document.yjs_state.present?
               server_state = begin
                 decode_state_vector(server_state_vector(document))
-              rescue ArgumentError
-                # A corrupt stored vector must not masquerade as client
-                # staleness — derive the truth from the blob instead.
+              rescue ArgumentError, CorruptStateError
+                # A corrupt stored vector (or, on legacy rows without a
+                # stored vector, a corrupt blob) must not masquerade as
+                # client staleness — heal and derive the truth instead.
                 decode_state_vector(load_or_heal_ydoc(document).state)
               end
               current = server_state.all? do |client_id, clock|
@@ -212,9 +197,13 @@ class YjsPersistence
     def verify_checksum!(document)
       checksum = document.yjs_state_checksum
       return if checksum.blank? # legacy row — heals on its next merge
-      return if checksum == Digest::SHA256.hexdigest(document.yjs_state)
+      return if checksum == state_checksum(document.yjs_state)
 
       raise CorruptStateError, "document #{document.id}: yjs_state checksum mismatch"
+    end
+
+    def state_checksum(blob)
+      Digest::SHA256.hexdigest(blob)
     end
 
     def blob_loadable?(blob)
@@ -230,6 +219,13 @@ class YjsPersistence
       payload[:served_from] = from_columns ? "columns" : "rebuild"
       if from_columns
         verify_checksum!(document)
+        # Legacy rows carry no checksum yet, so probe loadability before
+        # serving — otherwise a corrupt pre-migration blob would be relayed
+        # verbatim on every join with no heal. The probe cost lasts only
+        # until the row's next merge stamps a checksum.
+        if document.yjs_state_checksum.blank? && !blob_loadable?(document.yjs_state)
+          raise CorruptStateError, "document #{document.id}: stored blob is not loadable"
+        end
         [
           Base64.strict_encode64(document.yjs_state),
           Base64.strict_encode64(document.yjs_state_vector)
@@ -243,6 +239,23 @@ class YjsPersistence
       end
     end
 
+    # The handshake fast path holds no locks, so corruption is healed here:
+    # acquire both, re-check (another thread may have healed first), heal,
+    # and rebuild the handshake from the restored state.
+    def heal_and_reencode_handshake(document, payload)
+      lock_for(document.id).synchronize do
+        document.with_lock do
+          document.reload
+          begin
+            encode_handshake(document, payload)
+          rescue CorruptStateError => e
+            heal_corrupt_state!(document, e)
+            encode_handshake(document, payload)
+          end
+        end
+      end
+    end
+
     # Contain-and-restore for a corrupt stored blob. Callers must hold both
     # the per-document mutex and the row lock. The corrupt bytes are
     # quarantined for forensics, then the newest loadable checkpoint from
@@ -252,17 +265,30 @@ class YjsPersistence
     # clients re-upload their state through the sync-reply handshake.
     def heal_corrupt_state!(document, error)
       ActiveSupport::Notifications.instrument("recovered.yjs", document_id: document.id) do |payload|
-        YjsStateArchive.record!(document, kind: "quarantine", error: error.message)
+        # A loadable blob with a mismatched checksum is not corruption — it
+        # is a write from a pre-checksum code version (mixed-version deploy
+        # window or rollback). Re-stamp instead of destroying healthy state.
+        if document.yjs_state.present? && blob_loadable?(document.yjs_state)
+          document.update_columns(
+            yjs_state_checksum: state_checksum(document.yjs_state),
+            updated_at: Time.current
+          )
+          payload[:restored_from] = "restamped"
+          payload[:outcome] = "recovered"
+          return
+        end
+
+        YjsStateArchive.record!(document, kind: YjsStateArchive::QUARANTINE, error: error.message)
 
         checkpoint = document.yjs_state_archives
-                             .where(kind: "checkpoint", content_generation: document.content_generation)
+                             .where(kind: YjsStateArchive::CHECKPOINT, content_generation: document.content_generation)
                              .order(created_at: :desc, id: :desc)
                              .detect { |archive| archive.yjs_state.present? && blob_loadable?(archive.yjs_state) }
         if checkpoint
           document.update_columns(
             yjs_state: checkpoint.yjs_state,
             yjs_state_vector: checkpoint.yjs_state_vector,
-            yjs_state_checksum: Digest::SHA256.hexdigest(checkpoint.yjs_state),
+            yjs_state_checksum: state_checksum(checkpoint.yjs_state),
             updated_at: Time.current
           )
           payload[:restored_from] = "checkpoint"
@@ -284,10 +310,12 @@ class YjsPersistence
     def maybe_checkpoint(document)
       return if document.yjs_state.blank?
 
-      newest = document.yjs_state_archives.where(kind: "checkpoint").maximum(:created_at)
+      newest = document.yjs_state_archives
+                       .where(kind: YjsStateArchive::CHECKPOINT, content_generation: document.content_generation)
+                       .maximum(:created_at)
       return if newest && newest > CHECKPOINT_INTERVAL.ago
 
-      YjsStateArchive.record!(document, kind: "checkpoint")
+      YjsStateArchive.record!(document, kind: YjsStateArchive::CHECKPOINT)
     end
 
     # Stored vector when present; otherwise derive from the blob (legacy rows).

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -10,7 +10,25 @@ Rails.application.config.after_initialize do
 
   ActiveSupport::Notifications.subscribe(/\.yjs\z/) do |event|
     payload = event.payload
-    outcome = payload[:outcome] || payload[:reason] || (payload[:exception] ? "error" : "ok")
+    outcome = payload[:outcome] || (payload[:exception] ? "error" : "ok")
+
+    # Failure outcomes self-classify by the emitters' naming convention
+    # (rejected_* / invalid_* / dropped_*, plus the exception fallback), so
+    # new success outcomes never rot an allowlist into false warns.
+    failure = outcome == "error" || outcome.start_with?("rejected_", "invalid_", "dropped_")
+
+    # Pick the level before building the log line: the merge path emits an
+    # event per collaborative frame, and assembling a string that a
+    # production logger would immediately discard is wasted hot-path work
+    # inside the persist-before-broadcast window.
+    level = if failure
+      :warn
+    elsif event.duration >= slow_ms && Rails.logger.info?
+      :info
+    elsif Rails.logger.debug?
+      :debug
+    end
+    next unless level
 
     fields = {
       event: event.name,
@@ -19,19 +37,14 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       sequence expected_sequence].each do |key|
+       sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
-    fields[:error] = payload[:exception].first if payload[:exception]
+    # Class and message ("Document::StaleGenerationError: Client generation 3
+    # is behind..."); messages in this event family never carry doc content.
+    fields[:error] ||= payload[:exception].join(": ") if payload[:exception]
     line = fields.map { |key, value| "#{key}=#{value}" }.join(" ")
 
-    success = %w[merged noop persisted ok].include?(outcome)
-    if !success
-      Rails.logger.warn(line)
-    elsif event.duration >= slow_ms
-      Rails.logger.info(line)
-    else
-      Rails.logger.debug(line)
-    end
+    Rails.logger.public_send(level, line)
   end
 end

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -1,0 +1,37 @@
+# Renders the structured events emitted by YjsPersistence and SyncChannel
+# (merge.yjs, state.yjs, snapshot.yjs, frame_dropped.yjs) as single-line
+# structured logs. Payloads carry ids, outcomes, and byte sizes only — never
+# document content. External APMs can subscribe to the same /\.yjs$/ events.
+Rails.application.config.after_initialize do
+  # Successful hot-path operations slower than this are logged at info so
+  # slow merges/joins surface without turning routine traffic into log noise.
+  # Arbitrary starting point — tune once real distributions exist.
+  slow_ms = 250.0
+
+  ActiveSupport::Notifications.subscribe(/\.yjs\z/) do |event|
+    payload = event.payload
+    outcome = payload[:outcome] || payload[:reason] || (payload[:exception] ? "error" : "ok")
+
+    fields = {
+      event: event.name,
+      document_id: payload[:document_id],
+      outcome: outcome,
+      duration_ms: event.duration.round(1)
+    }
+    %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
+       sequence expected_sequence].each do |key|
+      fields[key] = payload[key] if payload.key?(key)
+    end
+    fields[:error] = payload[:exception].first if payload[:exception]
+    line = fields.map { |key, value| "#{key}=#{value}" }.join(" ")
+
+    success = %w[merged noop persisted ok].include?(outcome)
+    if !success
+      Rails.logger.warn(line)
+    elsif event.duration >= slow_ms
+      Rails.logger.info(line)
+    else
+      Rails.logger.debug(line)
+    end
+  end
+end

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -37,7 +37,7 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       sequence expected_sequence error].each do |key|
+       served_from sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
     # Class and message ("Document::StaleGenerationError: Client generation 3

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -13,9 +13,12 @@ Rails.application.config.after_initialize do
     outcome = payload[:outcome] || (payload[:exception] ? "error" : "ok")
 
     # Failure outcomes self-classify by the emitters' naming convention
-    # (rejected_* / invalid_* / dropped_*, plus the exception fallback), so
-    # new success outcomes never rot an allowlist into false warns.
-    failure = outcome == "error" || outcome.start_with?("rejected_", "invalid_", "dropped_")
+    # (rejected_* / invalid_* / dropped_* / recovered*, plus the exception
+    # fallback), so new success outcomes never rot an allowlist into false
+    # warns. Recoveries are successes for the caller but demand operator
+    # attention, so they log at warn too.
+    failure = outcome == "error" ||
+              outcome.start_with?("rejected_", "invalid_", "dropped_", "recovered")
 
     # Pick the level before building the log line: the merge path emits an
     # event per collaborative frame, and assembling a string that a
@@ -37,7 +40,7 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       served_from sequence expected_sequence error].each do |key|
+       served_from restored_from sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
     # Class and message ("Document::StaleGenerationError: Client generation 3

--- a/db/migrate/20260702062833_add_yjs_state_vector_to_documents.rb
+++ b/db/migrate/20260702062833_add_yjs_state_vector_to_documents.rb
@@ -1,0 +1,5 @@
+class AddYjsStateVectorToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :yjs_state_vector, :binary
+  end
+end

--- a/db/migrate/20260702065648_create_yjs_state_archives.rb
+++ b/db/migrate/20260702065648_create_yjs_state_archives.rb
@@ -1,0 +1,18 @@
+class CreateYjsStateArchives < ActiveRecord::Migration[8.1]
+  def change
+    create_table :yjs_state_archives do |t|
+      t.references :document, null: false, foreign_key: true
+      # checkpoint: interval-gated pre-merge snapshot (restore candidate)
+      # replacement: state wiped by Document#replace_content! (manual undo)
+      # quarantine: corrupt bytes kept for forensics, never restored
+      t.string :kind, null: false
+      t.integer :content_generation, null: false
+      t.binary :yjs_state
+      t.binary :yjs_state_vector
+      t.string :error
+      t.datetime :created_at, null: false
+    end
+
+    add_index :yjs_state_archives, [ :document_id, :kind, :created_at ]
+  end
+end

--- a/db/migrate/20260702065649_add_yjs_state_checksum_to_documents.rb
+++ b/db/migrate/20260702065649_add_yjs_state_checksum_to_documents.rb
@@ -1,0 +1,5 @@
+class AddYjsStateChecksumToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :yjs_state_checksum, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_090000) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.binary "yjs_state"
+    t.binary "yjs_state_vector"
     t.index ["owner_token"], name: "index_documents_on_owner_token"
     t.index ["slug"], name: "index_documents_on_slug", unique: true
     t.index ["user_id"], name: "index_documents_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_065649) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.binary "yjs_state"
+    t.string "yjs_state_checksum"
     t.binary "yjs_state_vector"
     t.index ["owner_token"], name: "index_documents_on_owner_token"
     t.index ["slug"], name: "index_documents_on_slug", unique: true
@@ -196,6 +197,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
     t.index ["google_uid"], name: "index_users_on_google_uid", unique: true
   end
 
+  create_table "yjs_state_archives", force: :cascade do |t|
+    t.integer "content_generation", null: false
+    t.datetime "created_at", null: false
+    t.integer "document_id", null: false
+    t.string "error"
+    t.string "kind", null: false
+    t.binary "yjs_state"
+    t.binary "yjs_state_vector"
+    t.index ["document_id", "kind", "created_at"], name: "idx_on_document_id_kind_created_at_571a89cbf8"
+    t.index ["document_id"], name: "index_yjs_state_archives_on_document_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activities", "documents"
@@ -207,4 +220,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_062833) do
   add_foreign_key "documents", "users"
   add_foreign_key "feedback_runs", "users"
   add_foreign_key "suggestions", "documents"
+  add_foreign_key "yjs_state_archives", "documents"
 end

--- a/docs/plans/2026-07-02-004-feat-yjs-persistence-instrumentation-plan.md
+++ b/docs/plans/2026-07-02-004-feat-yjs-persistence-instrumentation-plan.md
@@ -1,0 +1,122 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Instrument the Yjs persistence hot path"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #2)
+depth: standard
+---
+
+# feat: Instrument the Yjs persistence hot path
+
+## Summary
+
+`YjsPersistence` hosts every silent data-loss and performance path in the collaborative-editing stack, yet contains zero logging, metrics, or `ActiveSupport::Notifications` instrumentation. `persist_snapshot` swallows state-vector decode errors as an indistinguishable `false`; sequence-gap drops and stale-generation rejections vanish into unsampled `Rails.logger.warn` lines; merge duration and blob-size distributions are unmeasurable. This plan wraps the persistence hot path (`merge`, `state_b64`, `persist_snapshot`) and the SyncChannel drop paths in structured `ActiveSupport::Notifications` events with an outcome taxonomy and byte-size payloads, plus a log subscriber that turns them into legible structured logs. The measured distributions become the tuning inputs for every follow-up storage change (compaction triggers, debounce windows, size caps).
+
+## Problem Frame
+
+- `app/services/yjs_persistence.rb` has no `Rails.logger`, `ActiveSupport::Notifications`, or `instrument` calls at all.
+- `persist_snapshot` ends in `rescue ArgumentError → false`: a corrupt state vector is indistinguishable from a legitimately-stale client at the API boundary, and nothing is logged.
+- The only pipeline signals are three `Rails.logger.warn` lines in `app/channels/sync_channel.rb` (malformed frame, gap drop, generic merge failure) — the gap-drop path discards user edits with only an unstructured warn.
+- Every performance claim about the write path (O(document) per-frame cost, burst amplification, join cost) is unmeasured; there is no blob-size or merge-latency distribution to size future compaction/debounce/cap thresholds from.
+
+## Requirements
+
+- R1: Every `YjsPersistence.merge` call emits one structured event carrying document id, outcome, update bytes, blob bytes before/after, and duration.
+- R2: Every `YjsPersistence.state_b64` call emits one structured event carrying document id and served blob bytes.
+- R3: Every `YjsPersistence.persist_snapshot` call emits one structured event with outcome (`persisted`, `rejected_stale_vector`, `rejected_locked`, `invalid_state_vector`), and the invalid-state-vector path logs a warning instead of failing silently (return value stays `false` — API contract unchanged).
+- R4: SyncChannel frame drops (malformed base64, excessive sequence gap) emit structured events with a reason, replacing bare warn lines with subscriber-driven logs.
+- R5: A log subscriber renders these events as single-line structured logs — non-success outcomes at `warn`, slow operations at `info`, routine successes at `debug` — without ever logging document content.
+- R6: No behavior change to persistence semantics: same return values, same raised errors, same locking, same broadcast ordering.
+
+## Key Technical Decisions
+
+- **`ActiveSupport::Notifications`, not an APM gem.** The repo has no APM integration; Rails-native events cost nothing extra and give any future APM (AppSignal, Datadog) a ready subscription point. Adding a paid APM dependency is out of scope.
+- **Event names namespaced `merge.yjs` / `state.yjs` / `snapshot.yjs` / `frame_dropped.yjs`** following Rails' `event.namespace` convention so a single `/\.yjs$/` regex subscription covers them all.
+- **Outcome taxonomy in the payload, not in event names.** One event per operation with an `outcome` key (`merged`, `noop`, `rejected_stale`, `rejected_locked`, `persisted`, `rejected_stale_vector`, `invalid_state_vector`, `dropped_gap`, `dropped_malformed`) keeps cardinality low and subscription simple.
+- **Byte sizes only, never content.** Payloads carry `update_bytes`, `blob_bytes_before`, `blob_bytes_after` — document text never reaches logs.
+- **Exceptions still propagate.** `EditingLockedError` / `StaleGenerationError` raise through the instrument block; the payload records the outcome before raising so subscribers see the rejection without changing the caller contract.
+
+---
+
+## Implementation Units
+
+### U1. Instrument YjsPersistence operations
+
+**Goal:** `merge`, `state_b64`, and `persist_snapshot` each emit one `ActiveSupport::Notifications` event with document id, outcome, and byte sizes; the snapshot decode failure logs a warning.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** none
+
+**Files:**
+- `app/services/yjs_persistence.rb`
+- `test/services/yjs_persistence_test.rb`
+
+**Approach:** Wrap each public method body in `ActiveSupport::Notifications.instrument("<op>.yjs", payload)` and mutate `payload[:outcome]` (plus byte counts) as the operation resolves. For `merge`, set `outcome: "rejected_locked"` / `"rejected_stale"` immediately before raising so the event records the rejection; `"noop"` when the state comparison short-circuits; `"merged"` with `blob_bytes_before`/`blob_bytes_after` on persist. For `persist_snapshot`, replace the bare `rescue ArgumentError; false` with a rescue that sets `outcome: "invalid_state_vector"`, logs one warn line with the document id and error message, and still returns `false`. Measure lock wait by capturing a monotonic timestamp at method entry and recording `lock_wait_ms` once inside the `with_lock` block.
+
+**Patterns to follow:** payload/no-content discipline mirrors `config/initializers/filter_parameter_logging.rb` intent; test style mirrors existing `test/services/yjs_persistence_test.rb` helpers (`b64_update_for`, `text_of`).
+
+**Test scenarios:**
+- Happy path: `merge` of a real update emits `merge.yjs` with `outcome: "merged"`, positive `update_bytes` and `blob_bytes_after`, and `document_id`.
+- No-op: the empty sync-reply emits `outcome: "noop"` and (existing assertion) does not persist or flip `seed_state`.
+- Error path: stale-generation merge emits `outcome: "rejected_stale"` and still raises `Document::StaleGenerationError`; read-only doc emits `outcome: "rejected_locked"` and still raises `Document::EditingLockedError`.
+- `state_b64` emits `state.yjs` with `blob_bytes` matching the stored blob size.
+- `persist_snapshot` success emits `outcome: "persisted"`; behind-client emits `outcome: "rejected_stale_vector"` and returns false.
+- Error path: corrupt state vector emits `outcome: "invalid_state_vector"`, returns false, and logs a warning (assert via `Rails.logger` expectation or log capture).
+- Regression: all existing persistence tests stay green (R6).
+
+**Verification:** `bin/rails test test/services/yjs_persistence_test.rb` green; subscribing to `/\.yjs$/` in a test captures the expected events.
+
+### U2. Emit structured drop events from SyncChannel
+
+**Goal:** The malformed-frame and sequence-gap drop paths emit `frame_dropped.yjs` events with a reason and document id.
+
+**Requirements:** R4, R6
+
+**Dependencies:** U1 (shares the event-naming convention)
+
+**Files:**
+- `app/channels/sync_channel.rb`
+- `test/channels/sync_channel_test.rb`
+
+**Approach:** In `receive`'s malformed-base64 rescue and `enqueue_update`'s gap branch, publish `ActiveSupport::Notifications.instrument("frame_dropped.yjs", document_id:, reason: "malformed"/"gap", ...)` carrying the gap distance for the gap case. Remove the now-redundant inline `Rails.logger.warn` lines (the U3 subscriber renders these events at warn). Keep the generic merge-failure rescue's warn line — it wraps unexpected exceptions, not a taxonomized outcome.
+
+**Test scenarios:**
+- Malformed frame: sending non-base64 `update` emits `frame_dropped.yjs` with `reason: "malformed"` and does not broadcast.
+- Gap drop: a frame with `seq` beyond `MAX_SEQUENCE_GAP` emits `reason: "gap"` with the offending sequence and expected sequence, and does not persist.
+- Regression: in-order and out-of-order-within-gap sequences still persist and broadcast (existing tests).
+
+**Verification:** `bin/rails test test/channels/sync_channel_test.rb` green.
+
+### U3. Log subscriber initializer
+
+**Goal:** One initializer translates `*.yjs` events into single-line structured logs with severity by outcome.
+
+**Requirements:** R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `config/initializers/yjs_instrumentation.rb` (new)
+- `test/services/yjs_persistence_test.rb` (subscriber formatting covered implicitly via one log-capture assertion)
+
+**Approach:** `ActiveSupport::Notifications.subscribe(/\.yjs$/)` building a `key=value` log line (event, document_id, outcome, byte counts, duration rounded to ms). Severity routing: non-success outcomes (`rejected_*`, `invalid_*`, `dropped_*`) → `warn`; successful operations slower than 250 ms → `info`; everything else → `debug`. Guard against missing payload keys so a future event shape change cannot raise inside the subscriber.
+
+**Test scenarios:**
+- One log-capture test: a stale-generation rejection produces a `warn` line containing `outcome=rejected_stale` and the document id, and no document content.
+- Test expectation beyond that: none — severity threshold routing is presentation-only; the events themselves are asserted in U1/U2.
+
+**Verification:** `bin/rails test` green; a manual merge in `bin/rails console` shows the debug line when the log level permits.
+
+---
+
+## Scope Boundaries
+
+- **In scope:** events, payloads, log subscriber, snapshot decode-failure logging.
+- **Deferred to follow-up work:** wiring events to an external APM (AppSignal); dashboards/alerting; using the measured distributions to set compaction or debounce thresholds (ideas #1/#4 from the ideation doc); any payload-size caps (idea #5's hardening).
+- **Non-goals:** changing persistence semantics, locking, broadcast ordering, or the wire protocol.
+
+## Deferred to Implementation
+
+- Exact payload key names beyond those listed (keep `document_id`, `outcome` stable — the subscriber and tests depend on them).
+- Whether the slow-operation `info` threshold is 250 ms or another value — pick one constant, name it, and leave tuning to real data.

--- a/docs/plans/2026-07-02-005-feat-yjs-state-vector-column-plan.md
+++ b/docs/plans/2026-07-02-005-feat-yjs-state-vector-column-plan.md
@@ -1,0 +1,97 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Materialize the Yjs state vector at write time"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #3)
+depth: standard
+base: cursor/yjs-instrumentation-0857 (stacked on the instrumentation PR)
+---
+
+# feat: Materialize the Yjs state vector at write time
+
+## Summary
+
+Every subscribe calls `YjsPersistence.state_b64`, which builds a fresh `Y::Doc` from the stored blob and re-encodes both `full_diff` and the state vector — immediately after the merge that produced the blob computed and discarded those exact values. `persist_snapshot`'s staleness gate does the same full-doc load just to read the server state vector. This plan persists the state vector as a `documents.yjs_state_vector` binary column written inside the existing merge `update_columns`, so joins and snapshot gates become column reads with zero yrs instantiation. Reconnect storms (every deploy re-fires every client's handshake) stop paying O(document) CPU per subscriber.
+
+## Problem Frame
+
+- `state_b64` cost is O(document) CPU per join/reconnect; the write path already holds the identical bytes and discards them (`app/services/yjs_persistence.rb`).
+- `persist_snapshot` loads the full doc per snapshot submission only to decode its state vector.
+- yrs-kvstore (official yrs persistence layer) stores the state vector as its own key precisely so reads skip doc instantiation.
+- The stored blob **is** the previous merge's `full_diff` output, so serving it directly is byte-faithful; the rebuild path only re-derives it.
+
+## Requirements
+
+- R1: `merge` persists `yjs_state_vector` alongside `yjs_state` in the same `update_columns` write.
+- R2: `state_b64` serves the stored blob + stored state vector directly (no `Y::Doc`) when both columns are present; documents written before the migration (blob present, vector nil) fall back to the existing rebuild path.
+- R3: `persist_snapshot` uses the stored state vector for its staleness gate when present, falling back to the rebuild path otherwise.
+- R4: `Document#replace_content!` nulls `yjs_state_vector` together with `yjs_state`.
+- R5: The `state.yjs` instrumentation event records whether the handshake was served from columns or rebuilt, so the rollout is observable.
+- R6: Wire format and handshake semantics unchanged: clients receive the same `[full_state_b64, state_vector_b64]` pair.
+
+## Key Technical Decisions
+
+- **Nullable column, no backfill migration.** Legacy rows heal lazily: the first merge after deploy writes the vector. A backfill would load every document's blob through yrs at migrate time for no urgency — the fallback path keeps legacy rows correct.
+- **Serve the stored blob bytes, not a re-encode.** `Base64.strict_encode64(document.yjs_state)` is exactly the previous merge's `full_diff` output; round-tripping through a fresh doc could only re-encode (never improve) it.
+- **Column-vs-rebuild guard requires *both* columns.** A blob without a vector (legacy row) or a vector without a blob (impossible by construction, but cheap to guard) routes to the rebuild path.
+
+---
+
+## Implementation Units
+
+### U1. Migration: add yjs_state_vector to documents
+
+**Goal:** Nullable binary column exists.
+
+**Requirements:** R1
+
+**Dependencies:** none
+
+**Files:**
+- `db/migrate/*_add_yjs_state_vector_to_documents.rb` (new)
+- `db/schema.rb`
+
+**Approach:** `add_column :documents, :yjs_state_vector, :binary`. No default, no backfill.
+
+**Test scenarios:** Test expectation: none — pure schema addition; behavior covered in U2.
+
+**Verification:** `bin/rails db:migrate` clean; schema.rb shows the column.
+
+### U2. Write the vector at merge time; serve columns on read
+
+**Goal:** `merge` persists the vector; `state_b64` and `persist_snapshot` read it instead of rebuilding the doc; `replace_content!` clears it.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `app/services/yjs_persistence.rb`
+- `app/models/document.rb`
+- `test/services/yjs_persistence_test.rb`
+
+**Approach:** In `merge`'s persist branch, add `yjs_state_vector: ydoc.state.pack("C*")` to `update_columns`. In `state_b64`, when `yjs_state.present? && yjs_state_vector.present?`, return base64 of the two columns and set the event payload's `served_from: "columns"`; otherwise keep the rebuild path with `served_from: "rebuild"`. In `persist_snapshot`, use `document.yjs_state_vector` (unpacked) for `server_state` when present, else load the doc. In `replace_content!`, add `yjs_state_vector: nil` to the reset attributes.
+
+**Patterns to follow:** rollout-compatibility branching mirrors the seq-less / nil-generation convention documented in `app/channels/sync_channel.rb`.
+
+**Test scenarios:**
+- Happy path: after a merge, `yjs_state_vector` equals the merged doc's `state` bytes; `state_b64` returns values that round-trip into a client doc with the merged content (existing handshake test extended).
+- Column path is doc-free: with both columns present, `state_b64` does not construct a `Y::Doc` (stub `Y::Doc.new` to raise inside the call and assert it still serves).
+- Fallback: a document with a blob but a nil vector (simulated legacy row via `update_columns`) still serves a correct handshake and reports `served_from: "rebuild"`.
+- Reset path: `replace_content!` leaves `yjs_state_vector` nil; the next merge repopulates it.
+- Snapshot gate: existing stale/ahead/reordered-vector tests stay green with the stored vector supplying the server state; a legacy row (nil vector) still gates correctly.
+- Empty document: a document that has never merged serves the same empty-doc handshake as before.
+
+**Verification:** `bin/rails test` green; `script/sync_check.mjs` (two-client convergence + late joiner) passes against `bin/dev`.
+
+---
+
+## Scope Boundaries
+
+- **In scope:** the column, write-through, column-served handshake, snapshot gate read, reset behavior, observability of the serve path.
+- **Deferred to follow-up work:** a differential handshake (client sends its sv, server serves a delta) — blocked on the y-rb `diff` multi-client-vector bug; caching the base64-encoded pair; dropping `yjs_state_b64` from Inertia props.
+- **Non-goals:** changing the wire protocol or the dual-model split.
+
+## Deferred to Implementation
+
+- Whether `persist_snapshot`'s fallback doc load warrants its own payload marker (decide while instrumenting).

--- a/docs/plans/2026-07-02-006-feat-yjs-durability-stack-plan.md
+++ b/docs/plans/2026-07-02-006-feat-yjs-durability-stack-plan.md
@@ -1,0 +1,161 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Self-healing durability stack for Yjs state"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #5)
+depth: deep
+base: cursor/yjs-state-vector-column-0857 (stacked on the state-vector PR)
+---
+
+# feat: Self-healing durability stack for Yjs state
+
+## Summary
+
+The CRDT blob is the only unreconstructable dataset in the product, and it currently has a validated-but-unfixed P2: a corrupt `yjs_state` blob raises inside `load_ydoc` on every subscribe, permanently bricking the document, with no backups anywhere (no litestream, no restore docs) and `replace_content!` destroying prior state irrecoverably. This plan layers three defenses, each covering the failure the previous cannot: **prevent** (never commit a blob that cannot round-trip into a fresh `Y::Doc`; checksum every stored blob), **contain** (on corrupt load: quarantine the bytes for forensics, restore the last-good same-generation checkpoint — or degrade to empty — and let connected clients re-upload the tail via the protocol's existing sync-reply), and **recover** (documented Litestream off-host replication with a rehearsed restore, since volume loss is beyond the app's reach).
+
+## Problem Frame
+
+- `docs/residual-review-findings/feat-proof-reimagining.md` P2: "Corrupt stored yjs_state blob bricks every subscribe permanently. Fix shape: rescue y-rb sync failures in `load_ydoc`, log, degrade to empty doc (connected clients re-upload via sync-reply)."
+- Degrading to an *empty* doc silently loses all content when no client happens to be connected; a retained last-good snapshot bounds the loss instead.
+- `Document#replace_content!` nulls `yjs_state` — the product's most destructive operation has no undo artifact.
+- No backup tooling exists; production is one SQLite file on one Docker volume.
+
+## Requirements
+
+- R1: `merge` refuses to persist a blob that cannot be loaded into a fresh `Y::Doc` (raises; frame is not broadcast — durable-before-broadcast preserved).
+- R2: Every persisted blob carries a SHA-256 checksum column; loads verify it and treat mismatch as corruption.
+- R3: A corrupt blob encountered on merge, join, or snapshot-gate paths never bricks the document: the corrupt bytes are quarantined (kept, not destroyed), the document is restored to the most recent **same-generation** checkpoint (or emptied when none exists), and the operation proceeds on the restored state.
+- R4: Restoration never resurrects content across a `replace_content!` boundary: only archives tagged with the document's current `content_generation` are restore candidates.
+- R5: `merge` writes a periodic checkpoint archive (at most one per interval per document) of the pre-merge state; `replace_content!` archives the state it wipes (tagged with the pre-bump generation, for manual undo).
+- R6: Archives are pruned per document and kind so storage stays bounded.
+- R7: All prevention/containment actions are observable through the existing `*.yjs` event stream (`rejected_invalid_encode`, `recovered.yjs` with a `restored_from` marker).
+- R8: DEPLOYING.md documents Litestream replication and a step-by-step restore rehearsal.
+
+## Key Technical Decisions
+
+- **Round-trip validation targets loadability, not byte equality.** The anti-brick property is "the blob we persist can be synced into a fresh doc without raising". State-vector equality would not catch y-rb's pending-struct drop (pending structs do not advance the vector), and that hazard is already guarded by the channel's per-client sequencing — validation is the tripwire for encode/decode failures specifically.
+- **One `yjs_state_archives` table with a `kind` discriminator** (`checkpoint` / `replacement` / `quarantine`) instead of three tables: identical column shape (blob, vector, generation, optional error), one pruning mechanism.
+- **Generation-tagged restores (R4).** A `replacement` archive's generation is by construction behind the current one, so the same-generation restore rule structurally prevents the resurrection class of bug that `content_generation` exists to stop. Replacement archives serve manual undo only.
+- **Healing always happens under both locks.** `merge` and `persist_snapshot` already hold the per-doc mutex + row lock when they load; `state_b64` acquires them only when corruption is detected (the fast path stays lock-free). The in-process mutex is not reentrant, so healing is invoked from the lock-holding frame rather than acquiring inside `load_ydoc`.
+- **Litestream stays documentation.** Deploys are manual (AGENTS.md) and Kamal accessory changes cannot be tested from this environment; shipping untested deploy config is riskier than a precise runbook.
+
+## High-Level Technical Design
+
+```
+merge/persist_snapshot (locks held)          state_b64 (lock-free fast path)
+        |                                            |
+   verified load  --CorruptStateError-->   verified load/columns
+        |                :                           |            :
+        |           heal_corrupt_state!              |    (acquire locks, re-check,
+        |             - quarantine bytes             |     heal_corrupt_state!, retry)
+        |             - restore same-gen checkpoint
+        |               (else empty)
+        |             - emit recovered.yjs
+        v
+   sync update -> full_diff -> ROUND-TRIP PROBE -> update_columns(blob, sv, checksum)
+                                   : raise EncodeValidationError    |
+                                     (frame not persisted,          +-- maybe checkpoint archive
+                                      not broadcast)                    (interval-gated, pruned)
+```
+
+---
+
+## Implementation Units
+
+### U1. Schema: checksum column + archives table
+
+**Goal:** `documents.yjs_state_checksum` string column; `yjs_state_archives` table (document FK, kind, content_generation, yjs_state, yjs_state_vector, error, created_at, index on [document_id, kind, created_at]).
+
+**Requirements:** R2, R5
+
+**Dependencies:** none
+
+**Files:** `db/migrate/*` (two migrations or one), `db/schema.rb`, `app/models/yjs_state_archive.rb` (new), `app/models/document.rb` (association)
+
+**Approach:** Plain migration; `YjsStateArchive` model with `KINDS = %w[checkpoint replacement quarantine]`, validation on kind, `belongs_to :document`; `Document has_many :yjs_state_archives, dependent: :destroy`.
+
+**Test scenarios:** Model: invalid kind rejected; destroying a document destroys its archives.
+
+**Verification:** migration runs; model tests green.
+
+### U2. Prevent: round-trip probe + checksum at write time
+
+**Goal:** `merge` validates the new blob loads into a fresh doc before `update_columns`, and persists its SHA-256 alongside.
+
+**Requirements:** R1, R2, R7
+
+**Dependencies:** U1
+
+**Files:** `app/services/yjs_persistence.rb`, `test/services/yjs_persistence_test.rb`
+
+**Approach:** After `blob = ydoc.full_diff.pack("C*")`, run `probe = Y::Doc.new; probe.sync(blob.unpack("C*"))` inside a rescue; on raise set `payload[:outcome] = "rejected_invalid_encode"` and raise `YjsPersistence::EncodeValidationError` (frame not persisted; SyncChannel's StandardError rescue keeps it unbroadcast). Add `yjs_state_checksum: Digest::SHA256.hexdigest(blob)` to `update_columns`.
+
+**Test scenarios:**
+- Happy path: merged docs carry a checksum matching the blob.
+- Error path: stub `full_diff` to return garbage; merge raises `EncodeValidationError`, emits `rejected_invalid_encode`, persists nothing.
+- Channel integration: a frame whose persist raises is not broadcast (existing "update that fails persistence is not relayed" test pattern).
+
+### U3. Contain: verified loads, quarantine, same-generation restore
+
+**Goal:** Corrupt blobs (checksum mismatch or y-rb raise) heal in place on merge, join, and snapshot paths.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** U1, U2
+
+**Files:** `app/services/yjs_persistence.rb`, `app/models/document.rb` (checkpoint/restore helpers if cleaner there), `test/services/yjs_persistence_test.rb`, `test/channels/sync_channel_test.rb`
+
+**Approach:** `load_ydoc` verifies checksum (skip when column nil — legacy rows) and wraps `ydoc.sync` errors, raising `CorruptStateError`. `merge`/`persist_snapshot` rescue it in their lock-holding frames: call `heal_corrupt_state!(document)` — INSERT quarantine archive (corrupt bytes + error), restore newest checkpoint archive with `content_generation == document.content_generation` (blob+vector+recomputed checksum) or null all three, emit `recovered.yjs` with `restored_from: "checkpoint"|"empty"` — then retry the load once and continue. `state_b64`: rescue from both column path (checksum verify before serving) and rebuild path; acquire mutex + `with_lock`, reload, re-verify (another thread may have healed), heal, retry.
+
+**Test scenarios:**
+- Corrupt blob + existing same-generation checkpoint: merge heals, retains a quarantine archive with the corrupt bytes, restores checkpoint content, applies the update on top, and the doc round-trips.
+- Corrupt blob + no checkpoint: merge heals to empty and persists the incoming update alone.
+- A `replacement`-kind archive from a previous generation is NOT restored (R4) — heal goes to empty instead.
+- Join path: `state_b64` on a corrupt doc (checksum mismatch) returns a servable handshake and the doc is healed; subscribing via SyncChannel to a corrupt doc succeeds (no brick).
+- Snapshot path: `persist_snapshot` on a corrupt doc does not raise; the gate operates on restored state.
+- Legacy row (nil checksum) loads without verification.
+
+### U4. Checkpoint + replacement archives, pruning
+
+**Goal:** merge writes interval-gated checkpoints of pre-merge state; `replace_content!` archives what it wipes; both prune to the newest N per kind.
+
+**Requirements:** R5, R6
+
+**Dependencies:** U1
+
+**Files:** `app/services/yjs_persistence.rb`, `app/models/document.rb`, `test/services/yjs_persistence_test.rb`, `test/models/document_test.rb`
+
+**Approach:** In merge's persist branch (locks held), when the pre-merge blob is present and the newest checkpoint for the doc is older than `CHECKPOINT_INTERVAL` (10 minutes), archive the pre-merge columns (kind `checkpoint`, current generation), then prune (keep newest 5 per document+kind). In `replace_content!`, archive pre-wipe columns (kind `replacement`, **pre-bump** generation) when blob present, prune to 5.
+
+**Test scenarios:**
+- Second merge creates one checkpoint; an immediate third merge does not (interval gate); `travel` past the interval → next merge checkpoints again.
+- Checkpoint content equals the pre-merge blob (restoring it yields the older text).
+- `replace_content!` writes a replacement archive carrying the wiped state and the pre-bump generation.
+- Pruning: more than 5 checkpoints → oldest deleted, other kinds untouched.
+
+### U5. Recover: Litestream runbook
+
+**Goal:** DEPLOYING.md gains an off-host replication + restore-rehearsal section.
+
+**Requirements:** R8
+
+**Dependencies:** none
+
+**Files:** `DEPLOYING.md`
+
+**Approach:** Concrete Kamal accessory config for Litestream replicating `storage/production.sqlite3` (and the cable DB excluded, derivable), S3-compatible target via env, and a numbered restore rehearsal (restore to a scratch path, integrity-check, swap). Marked as config-to-apply, not applied.
+
+**Test scenarios:** Test expectation: none — documentation.
+
+---
+
+## Scope Boundaries
+
+- **In scope:** the three layers above, observability, tests.
+- **Deferred to follow-up work:** applying the Litestream accessory to `config/deploy.yml` (needs a deploy rehearsal the maintainer runs); a UI/CLI for manual restore from `replacement` archives; extending checkpoints to an update-log world (idea #1 builds on this).
+- **Non-goals:** changing the wire protocol; automatic restore across generations; APM wiring.
+
+## Deferred to Implementation
+
+- Whether `heal_corrupt_state!` lives on `YjsPersistence` or `Document` (pick the one that keeps locking obvious).
+- Exact constants (`CHECKPOINT_INTERVAL = 10.minutes`, `MAX_ARCHIVES = 5`) — named constants, tuned later via the instrumentation distributions.

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -7,6 +7,17 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     Base64.strict_encode64(ydoc.diff.pack("C*"))
   end
 
+  def capture_yjs_events(name)
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
+      events << event
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
   def build_sequential_updates
     ydoc = Y::Doc.new
     text = ydoc.get_text("t")
@@ -326,6 +337,38 @@ class SyncChannelTest < ActionCable::Channel::TestCase
       subscribe slug: doc.slug
       assert_equal true, transmissions.last["seed"], "doc must remain seedable after a no-op merge"
     end
+  end
+
+  test "a malformed frame emits a frame_dropped event" do
+    doc = Document.create!(title: "Poison metered")
+    subscribe slug: doc.slug
+
+    events = capture_yjs_events("frame_dropped.yjs") do
+      perform :receive, { "type" => "update", "update" => "not!!base64!!", "cid" => "x" }
+    end
+
+    payload = events.first.payload
+    assert_equal doc.id, payload[:document_id]
+    assert_equal "malformed", payload[:reason]
+  end
+
+  test "an excessive sequence gap emits a frame_dropped event and drops the frame" do
+    doc = Document.create!(title: "Gapped")
+    subscribe slug: doc.slug
+    update = build_update_b64("too far ahead")
+    beyond_gap = SyncChannel::MAX_SEQUENCE_GAP + 2
+
+    events = capture_yjs_events("frame_dropped.yjs") do
+      assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
+        perform :receive, { "type" => "update", "update" => update, "cid" => "x", "seq" => beyond_gap }
+      end
+    end
+
+    payload = events.first.payload
+    assert_equal "gap", payload[:reason]
+    assert_equal beyond_gap, payload[:sequence]
+    assert_equal 1, payload[:expected_sequence]
+    assert_nil doc.reload.yjs_state
   end
 
   test "awareness messages relay without persisting" do

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -7,17 +7,6 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     Base64.strict_encode64(ydoc.diff.pack("C*"))
   end
 
-  def capture_yjs_events(name)
-    events = []
-    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
-      events << event
-    end
-    yield
-    events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscription)
-  end
-
   def build_sequential_updates
     ydoc = Y::Doc.new
     text = ydoc.get_text("t")
@@ -343,13 +332,9 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     doc = Document.create!(title: "Poison metered")
     subscribe slug: doc.slug
 
-    events = capture_yjs_events("frame_dropped.yjs") do
+    assert_notification("frame_dropped.yjs", document_id: doc.id, outcome: "dropped_malformed") do
       perform :receive, { "type" => "update", "update" => "not!!base64!!", "cid" => "x" }
     end
-
-    payload = events.first.payload
-    assert_equal doc.id, payload[:document_id]
-    assert_equal "malformed", payload[:reason]
   end
 
   test "an excessive sequence gap emits a frame_dropped event and drops the frame" do
@@ -358,16 +343,15 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     update = build_update_b64("too far ahead")
     beyond_gap = SyncChannel::MAX_SEQUENCE_GAP + 2
 
-    events = capture_yjs_events("frame_dropped.yjs") do
+    assert_notification(
+      "frame_dropped.yjs",
+      outcome: "dropped_gap", sequence: beyond_gap, expected_sequence: 1
+    ) do
       assert_no_broadcasts(SyncChannel.broadcasting_for(doc)) do
         perform :receive, { "type" => "update", "update" => update, "cid" => "x", "seq" => beyond_gap }
       end
     end
 
-    payload = events.first.payload
-    assert_equal "gap", payload[:reason]
-    assert_equal beyond_gap, payload[:sequence]
-    assert_equal 1, payload[:expected_sequence]
     assert_nil doc.reload.yjs_state
   end
 

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -355,6 +355,21 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert_nil doc.reload.yjs_state
   end
 
+  test "subscribing to a document with a corrupt blob heals instead of bricking" do
+    doc = Document.create!(title: "Corrupted")
+    YjsPersistence.merge(doc, build_update_b64("was here"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes")
+
+    subscribe slug: doc.slug
+
+    assert subscription.confirmed?
+    message = transmissions.last
+    assert_equal "sync", message["type"]
+    assert message.key?("update"), "the handshake must still be served after healing"
+    assert doc.reload.yjs_state_archives.where(kind: "quarantine").exists?,
+           "the corrupt bytes must be quarantined for forensics"
+  end
+
   test "awareness messages relay without persisting" do
     doc = Document.create!(title: "Presence")
     subscribe slug: doc.slug

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -1,6 +1,41 @@
 require "test_helper"
 
 class DocumentTest < ActiveSupport::TestCase
+  test "replace_content! archives the wiped state with the pre-bump generation" do
+    doc = Document.create!(title: "Replaced", seed_content: "# Seed")
+    ydoc = Y::Doc.new
+    ydoc.get_text("t") << "about to be wiped"
+    YjsPersistence.merge(doc, Base64.strict_encode64(ydoc.diff.pack("C*")))
+    wiped_blob = doc.reload.yjs_state
+    pre_bump_generation = doc.content_generation
+
+    doc.replace_content!(source: "# Replacement")
+
+    archive = doc.yjs_state_archives.where(kind: "replacement").sole
+    assert_equal wiped_blob, archive.yjs_state
+    assert_equal pre_bump_generation, archive.content_generation
+    assert_nil doc.reload.yjs_state_checksum
+  end
+
+  test "replace_content! on a document without state writes no replacement archive" do
+    doc = Document.create!(title: "Never edited", seed_content: "# Seed")
+
+    doc.replace_content!(source: "# Replacement")
+
+    assert_not doc.yjs_state_archives.exists?
+  end
+
+  test "yjs state archives reject unknown kinds and die with the document" do
+    doc = Document.create!(title: "Archived")
+    assert_raises(ActiveRecord::RecordInvalid) do
+      doc.yjs_state_archives.create!(kind: "bogus", content_generation: 0)
+    end
+
+    doc.yjs_state_archives.create!(kind: "checkpoint", content_generation: 0)
+    doc.destroy!
+    assert_equal 0, YjsStateArchive.count
+  end
+
   test "account ownership takes precedence over an anonymous token" do
     user = User.create!(
       name: "Kieran",

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -119,7 +119,7 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "server content", client.get_text("t").to_s
   end
 
-  test "merge persists the state vector alongside the blob" do
+  test "merge persists the state vector and checksum alongside the blob" do
     doc = Document.create!(title: "Vectored")
     YjsPersistence.merge(doc, b64_update_for("content"))
     doc.reload
@@ -128,6 +128,154 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     ydoc = Y::Doc.new
     ydoc.sync(doc.yjs_state.unpack("C*"))
     assert_equal ydoc.state, doc.yjs_state_vector.unpack("C*")
+    assert_equal Digest::SHA256.hexdigest(doc.yjs_state), doc.yjs_state_checksum
+  end
+
+  test "merge refuses to persist a blob that cannot round-trip" do
+    doc = Document.create!(title: "Unloadable")
+    original = YjsPersistence.singleton_class.instance_method(:blob_loadable?)
+    YjsPersistence.define_singleton_method(:blob_loadable?) { |*| false }
+    begin
+      assert_notification("merge.yjs", outcome: "rejected_invalid_encode") do
+        assert_raises(YjsPersistence::EncodeValidationError) do
+          YjsPersistence.merge(doc, b64_update_for("would brick"))
+        end
+      end
+    ensure
+      YjsPersistence.singleton_class.define_method(:blob_loadable?, original)
+    end
+
+    assert_nil doc.reload.yjs_state, "a rejected encode must not persist"
+  end
+
+  test "a corrupt blob on merge heals from the latest same-generation checkpoint" do
+    doc = Document.create!(title: "Healable")
+    YjsPersistence.merge(doc, b64_update_for("first. "))
+    # The second merge checkpoints the pre-merge state ("first. ").
+    YjsPersistence.merge(doc, b64_update_for("second. ", from_doc: doc_from(doc)))
+    assert_equal 1, doc.yjs_state_archives.where(kind: "checkpoint").count
+
+    doc.reload.update_columns(yjs_state: "garbage-bytes")
+
+    event = assert_notification("recovered.yjs", outcome: "recovered", restored_from: "checkpoint") do
+      YjsPersistence.merge(doc.reload, b64_update_for("third."))
+    end
+    assert_equal doc.id, event.payload[:document_id]
+
+    merged = text_of(doc.reload)
+    assert_includes merged, "first", "checkpoint content must be restored"
+    assert_includes merged, "third", "the incoming update must still apply"
+    assert_not_includes merged, "second", "edits after the checkpoint are the bounded loss"
+
+    quarantine = doc.yjs_state_archives.where(kind: "quarantine").sole
+    assert_equal "garbage-bytes", quarantine.yjs_state
+    assert quarantine.error.present?
+  end
+
+  test "a corrupt blob with no checkpoint heals to empty" do
+    doc = Document.create!(title: "Empty heal")
+    YjsPersistence.merge(doc, b64_update_for("only content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes")
+
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      YjsPersistence.merge(doc.reload, b64_update_for("fresh start"))
+    end
+
+    assert_equal "fresh start", text_of(doc.reload)
+    assert doc.yjs_state_archives.where(kind: "quarantine").exists?
+  end
+
+  test "healing never restores a replacement archive from a previous generation" do
+    doc = Document.create!(title: "No resurrection", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("pre-replacement secret. "))
+    doc.replace_content!(source: "# Replacement")
+    assert doc.yjs_state_archives.where(kind: "replacement").exists?
+
+    YjsPersistence.merge(doc.reload, b64_update_for("new generation content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes")
+
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      YjsPersistence.merge(doc.reload, b64_update_for("after heal"))
+    end
+
+    merged = text_of(doc.reload)
+    assert_not_includes merged, "pre-replacement secret",
+                        "a heal must never resurrect content a replacement wiped"
+  end
+
+  test "a corrupt blob on the join path heals instead of bricking" do
+    doc = Document.create!(title: "Join heal")
+    YjsPersistence.merge(doc, b64_update_for("served content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes")
+
+    full_state, state_vector = nil
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      full_state, state_vector = YjsPersistence.state_b64(doc.reload)
+    end
+
+    assert full_state.present?
+    assert state_vector.present?
+    assert doc.reload.yjs_state_archives.where(kind: "quarantine").exists?
+  end
+
+  test "a corrupt blob does not raise out of the snapshot gate" do
+    doc = Document.create!(title: "Snapshot heal", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes", yjs_state_vector: "also-garbage")
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc.reload,
+      state_vector_b64: Base64.strict_encode64(Y::Doc.new.state.pack("C*")),
+      content: "fresh", spans: []
+    )
+
+    assert persisted, "after healing to empty, a fresh client snapshot is acceptable"
+    assert_equal "fresh", doc.reload.content_snapshot
+  end
+
+  test "a legacy row without a checksum loads without verification" do
+    doc = Document.create!(title: "Legacy checksum")
+    YjsPersistence.merge(doc, b64_update_for("old row"))
+    doc.update_columns(yjs_state_checksum: nil, yjs_state_vector: nil)
+
+    full_state, = YjsPersistence.state_b64(doc.reload)
+
+    client = Y::Doc.new
+    client.sync(Base64.strict_decode64(full_state).unpack("C*"))
+    assert_equal "old row", client.get_text("t").to_s
+  end
+
+  test "checkpoints are interval-gated" do
+    doc = Document.create!(title: "Checkpointed")
+    YjsPersistence.merge(doc, b64_update_for("one. "))
+    YjsPersistence.merge(doc, b64_update_for("two. ", from_doc: doc_from(doc)))
+    YjsPersistence.merge(doc, b64_update_for("three. ", from_doc: doc_from(doc)))
+    assert_equal 1, doc.yjs_state_archives.where(kind: "checkpoint").count,
+                 "checkpoints within the interval must not accumulate"
+
+    travel YjsPersistence::CHECKPOINT_INTERVAL + 1.minute do
+      YjsPersistence.merge(doc, b64_update_for("four.", from_doc: doc_from(doc)))
+    end
+    assert_equal 2, doc.yjs_state_archives.where(kind: "checkpoint").count
+  end
+
+  test "archive pruning keeps the newest entries per kind" do
+    doc = Document.create!(title: "Pruned")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+    doc.reload
+
+    8.times { YjsStateArchive.record!(doc, kind: "checkpoint") }
+    assert_equal YjsStateArchive::MAX_PER_KIND, doc.yjs_state_archives.where(kind: "checkpoint").count
+
+    YjsStateArchive.record!(doc, kind: "quarantine", error: "x")
+    assert_equal 1, doc.yjs_state_archives.where(kind: "quarantine").count,
+                 "pruning one kind must not touch another"
+  end
+
+  def doc_from(document)
+    ydoc = Y::Doc.new
+    ydoc.sync(document.reload.yjs_state.unpack("C*"))
+    ydoc
   end
 
   test "state_b64 serves the handshake from columns without building a doc" do

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -178,7 +178,126 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "ordered independently", doc.reload.content_snapshot
   end
 
+  test "merge emits a merged event with byte sizes" do
+    doc = Document.create!(title: "Metered")
+    events = capture_yjs_events("merge.yjs") do
+      YjsPersistence.merge(doc, b64_update_for("measured content"))
+    end
+
+    assert_equal 1, events.length
+    payload = events.first.payload
+    assert_equal doc.id, payload[:document_id]
+    assert_equal "merged", payload[:outcome]
+    assert_operator payload[:update_bytes], :>, 0
+    assert_equal 0, payload[:blob_bytes_before]
+    assert_operator payload[:blob_bytes_after], :>, 0
+    assert payload.key?(:lock_wait_ms)
+  end
+
+  test "a no-op merge emits a noop event" do
+    doc = Document.create!(title: "Noop", seed_markdown: "# Template")
+    empty_update = Base64.strict_encode64(Y::Doc.new.full_diff.pack("C*"))
+
+    events = capture_yjs_events("merge.yjs") { YjsPersistence.merge(doc, empty_update) }
+
+    assert_equal "noop", events.first.payload[:outcome]
+  end
+
+  test "a stale-generation rejection emits a rejected_stale event and still raises" do
+    doc = Document.create!(title: "Stale", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("live"))
+    stale_generation = doc.content_generation
+    doc.replace_content!(source: "# Replacement")
+
+    events = capture_yjs_events("merge.yjs") do
+      assert_raises(Document::StaleGenerationError) do
+        YjsPersistence.merge(doc, b64_update_for("stale"), generation: stale_generation)
+      end
+    end
+
+    assert_equal "rejected_stale", events.first.payload[:outcome]
+  end
+
+  test "a locked rejection emits a rejected_locked event and still raises" do
+    doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
+
+    events = capture_yjs_events("merge.yjs") do
+      assert_raises(Document::EditingLockedError) do
+        YjsPersistence.merge(doc, b64_update_for("forbidden"))
+      end
+    end
+
+    assert_equal "rejected_locked", events.first.payload[:outcome]
+  end
+
+  test "state_b64 emits a state event with the stored blob size" do
+    doc = Document.create!(title: "Join")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+    doc.reload
+
+    events = capture_yjs_events("state.yjs") { YjsPersistence.state_b64(doc) }
+
+    assert_equal doc.yjs_state.bytesize, events.first.payload[:blob_bytes]
+  end
+
+  test "snapshot outcomes are taxonomized in events" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    events = capture_yjs_events("snapshot.yjs") do
+      YjsPersistence.persist_snapshot(doc, state_vector_b64: stale_vector, content: "stale", spans: [])
+    end
+    assert_equal "rejected_stale_vector", events.first.payload[:outcome]
+
+    events = capture_yjs_events("snapshot.yjs") do
+      YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "fresh", spans: [])
+    end
+    assert_equal "persisted", events.first.payload[:outcome]
+  end
+
+  test "an undecodable state vector emits invalid_state_vector, logs, and returns false" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    garbage_vector = Base64.strict_encode64([ 0x85, 0xff, 0xff ].pack("C*"))
+
+    logged = capture_rails_log do
+      events = capture_yjs_events("snapshot.yjs") do
+        persisted = YjsPersistence.persist_snapshot(
+          doc, state_vector_b64: garbage_vector, content: "corrupt", spans: []
+        )
+        assert_not persisted
+      end
+      assert_equal "invalid_state_vector", events.first.payload[:outcome]
+    end
+
+    assert_includes logged, "invalid state vector"
+    assert_includes logged, doc.id.to_s
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
   private
+
+  def capture_yjs_events(name)
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
+      events << event
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  def capture_rails_log
+    io = StringIO.new
+    original = Rails.logger
+    Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(io))
+    yield
+    io.string
+  ensure
+    Rails.logger = original
+  end
 
   def decode_state_vector_for_test(bytes)
     index = 0

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -180,8 +180,8 @@ class YjsPersistenceTest < ActiveSupport::TestCase
 
   test "merge emits a merged event with byte sizes" do
     doc = Document.create!(title: "Metered")
-    events = capture_yjs_events("merge.yjs") do
-      YjsPersistence.merge(doc, b64_update_for("measured content"))
+    events = capture_notifications("merge.yjs") do
+      assert_equal true, YjsPersistence.merge(doc, b64_update_for("measured content"))
     end
 
     assert_equal 1, events.length
@@ -198,9 +198,7 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     doc = Document.create!(title: "Noop", seed_markdown: "# Template")
     empty_update = Base64.strict_encode64(Y::Doc.new.full_diff.pack("C*"))
 
-    events = capture_yjs_events("merge.yjs") { YjsPersistence.merge(doc, empty_update) }
-
-    assert_equal "noop", events.first.payload[:outcome]
+    assert_notification("merge.yjs", outcome: "noop") { YjsPersistence.merge(doc, empty_update) }
   end
 
   test "a stale-generation rejection emits a rejected_stale event and still raises" do
@@ -209,25 +207,21 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     stale_generation = doc.content_generation
     doc.replace_content!(source: "# Replacement")
 
-    events = capture_yjs_events("merge.yjs") do
+    assert_notification("merge.yjs", outcome: "rejected_stale") do
       assert_raises(Document::StaleGenerationError) do
         YjsPersistence.merge(doc, b64_update_for("stale"), generation: stale_generation)
       end
     end
-
-    assert_equal "rejected_stale", events.first.payload[:outcome]
   end
 
   test "a locked rejection emits a rejected_locked event and still raises" do
     doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
 
-    events = capture_yjs_events("merge.yjs") do
+    assert_notification("merge.yjs", outcome: "rejected_locked") do
       assert_raises(Document::EditingLockedError) do
         YjsPersistence.merge(doc, b64_update_for("forbidden"))
       end
     end
-
-    assert_equal "rejected_locked", events.first.payload[:outcome]
   end
 
   test "state_b64 emits a state event with the stored blob size" do
@@ -235,9 +229,38 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     YjsPersistence.merge(doc, b64_update_for("content"))
     doc.reload
 
-    events = capture_yjs_events("state.yjs") { YjsPersistence.state_b64(doc) }
+    assert_notification("state.yjs", outcome: "ok", blob_bytes: doc.yjs_state.bytesize) do
+      YjsPersistence.state_b64(doc)
+    end
+  end
 
-    assert_equal doc.yjs_state.bytesize, events.first.payload[:blob_bytes]
+  test "a state_b64 failure is not classified as a success event" do
+    doc = Document.create!(title: "Corrupt join")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+
+    original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
+    YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "corrupt blob" }
+    begin
+      events = capture_notifications("state.yjs") do
+        assert_raises(RuntimeError) { YjsPersistence.state_b64(doc.reload) }
+      end
+
+      payload = events.first.payload
+      assert_nil payload[:outcome], "outcome must stay unset so the subscriber logs the failure"
+      assert payload[:exception].present?
+    ensure
+      YjsPersistence.singleton_class.define_method(:load_ydoc, original)
+    end
+  end
+
+  test "a locked snapshot emits rejected_locked and still raises" do
+    doc = Document.create!(title: "Locked", owner_token: "owner", owner_name: "O", link_access: "view")
+
+    assert_notification("snapshot.yjs", outcome: "rejected_locked") do
+      assert_raises(Document::EditingLockedError) do
+        YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "nope", spans: [])
+      end
+    end
   end
 
   test "snapshot outcomes are taxonomized in events" do
@@ -245,49 +268,39 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     YjsPersistence.merge(doc, b64_update_for("server content"))
     stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
 
-    events = capture_yjs_events("snapshot.yjs") do
+    assert_notification("snapshot.yjs", outcome: "rejected_stale_vector") do
       YjsPersistence.persist_snapshot(doc, state_vector_b64: stale_vector, content: "stale", spans: [])
     end
-    assert_equal "rejected_stale_vector", events.first.payload[:outcome]
 
-    events = capture_yjs_events("snapshot.yjs") do
+    assert_notification("snapshot.yjs", outcome: "persisted") do
       YjsPersistence.persist_snapshot(doc, state_vector_b64: nil, content: "fresh", spans: [])
     end
-    assert_equal "persisted", events.first.payload[:outcome]
   end
 
-  test "an undecodable state vector emits invalid_state_vector, logs, and returns false" do
+  test "an undecodable state vector emits invalid_state_vector, warns, and returns false" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))
     garbage_vector = Base64.strict_encode64([ 0x85, 0xff, 0xff ].pack("C*"))
 
     logged = capture_rails_log do
-      events = capture_yjs_events("snapshot.yjs") do
+      event = assert_notification("snapshot.yjs", outcome: "invalid_state_vector") do
         persisted = YjsPersistence.persist_snapshot(
           doc, state_vector_b64: garbage_vector, content: "corrupt", spans: []
         )
         assert_not persisted
       end
-      assert_equal "invalid_state_vector", events.first.payload[:outcome]
+      assert event.payload[:error].present?
     end
 
-    assert_includes logged, "invalid state vector"
-    assert_includes logged, doc.id.to_s
+    # The log subscriber (config/initializers/yjs_instrumentation.rb) renders
+    # non-success outcomes at warn — one structured line, no document content.
+    assert_includes logged, "outcome=invalid_state_vector"
+    assert_includes logged, "document_id=#{doc.id}"
+    assert_not_includes logged, "corrupt"
     assert_equal "current", doc.reload.content_snapshot
   end
 
   private
-
-  def capture_yjs_events(name)
-    events = []
-    subscription = ActiveSupport::Notifications.subscribe(name) do |event|
-      events << event
-    end
-    yield
-    events
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscription)
-  end
 
   def capture_rails_log
     io = StringIO.new

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -172,6 +172,78 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert quarantine.error.present?
   end
 
+  test "a valid blob written by pre-checksum code is re-stamped, not destroyed" do
+    doc = Document.create!(title: "Mixed version")
+    YjsPersistence.merge(doc, b64_update_for("current content. "))
+
+    # Simulate an old-code merge during a deploy window: the blob and vector
+    # advance but the checksum column is not written, leaving it stale.
+    ydoc = doc_from(doc)
+    ydoc.get_text("t") << "old-code edit. "
+    doc.reload.update_columns(
+      yjs_state: ydoc.full_diff.pack("C*"),
+      yjs_state_vector: ydoc.state.pack("C*")
+    )
+
+    assert_notification("recovered.yjs", restored_from: "restamped") do
+      YjsPersistence.merge(doc.reload, b64_update_for("new-code edit."))
+    end
+
+    merged = text_of(doc.reload)
+    assert_includes merged, "current content", "healthy state must survive a stale checksum"
+    assert_includes merged, "old-code edit", "the pre-checksum write must survive"
+    assert_includes merged, "new-code edit"
+    assert_not doc.yjs_state_archives.where(kind: "quarantine").exists?,
+               "a stale checksum on a loadable blob is not corruption"
+    assert_equal Digest::SHA256.hexdigest(doc.yjs_state), doc.yjs_state_checksum
+  end
+
+  test "a corrupt legacy row without a checksum heals on merge" do
+    doc = Document.create!(title: "Legacy corrupt")
+    YjsPersistence.merge(doc, b64_update_for("pre-migration content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes", yjs_state_checksum: nil)
+
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      YjsPersistence.merge(doc.reload, b64_update_for("recovered"))
+    end
+
+    assert_equal "recovered", text_of(doc.reload)
+  end
+
+  test "a corrupt legacy row without a checksum heals on the join path" do
+    doc = Document.create!(title: "Legacy corrupt join")
+    YjsPersistence.merge(doc, b64_update_for("pre-migration content"))
+    doc.reload.update_columns(yjs_state: "garbage-bytes", yjs_state_checksum: nil)
+
+    full_state, state_vector = nil
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      full_state, state_vector = YjsPersistence.state_b64(doc.reload)
+    end
+
+    assert full_state.present?
+    assert state_vector.present?
+  end
+
+  test "the snapshot gate heals a corrupt legacy row instead of raising" do
+    doc = Document.create!(title: "Legacy snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    doc.reload.update_columns(
+      yjs_state: "garbage-bytes", yjs_state_checksum: nil, yjs_state_vector: nil
+    )
+
+    persisted = nil
+    assert_notification("recovered.yjs", restored_from: "empty") do
+      persisted = YjsPersistence.persist_snapshot(
+        doc.reload,
+        state_vector_b64: Base64.strict_encode64(Y::Doc.new.state.pack("C*")),
+        content: "fresh", spans: []
+      )
+    end
+
+    assert persisted
+    assert_equal "fresh", doc.reload.content_snapshot
+  end
+
   test "a corrupt blob with no checkpoint heals to empty" do
     doc = Document.create!(title: "Empty heal")
     YjsPersistence.merge(doc, b64_update_for("only content"))
@@ -264,12 +336,28 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     YjsPersistence.merge(doc, b64_update_for("content"))
     doc.reload
 
-    8.times { YjsStateArchive.record!(doc, kind: "checkpoint") }
-    assert_equal YjsStateArchive::MAX_PER_KIND, doc.yjs_state_archives.where(kind: "checkpoint").count
+    created = 8.times.map { YjsStateArchive.record!(doc, kind: "checkpoint") }
+    survivors = doc.yjs_state_archives.where(kind: "checkpoint").order(:id).ids
+    assert_equal created.last(YjsStateArchive::MAX_PER_KIND).map(&:id), survivors,
+                 "the newest archives must survive pruning"
 
     YjsStateArchive.record!(doc, kind: "quarantine", error: "x")
     assert_equal 1, doc.yjs_state_archives.where(kind: "quarantine").count,
                  "pruning one kind must not touch another"
+  end
+
+  test "a new generation gets its own checkpoint despite a recent old-generation one" do
+    doc = Document.create!(title: "Regenerated", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("gen zero. "))
+    YjsPersistence.merge(doc, b64_update_for("more gen zero. ", from_doc: doc_from(doc)))
+    assert doc.yjs_state_archives.where(kind: "checkpoint", content_generation: 0).exists?
+
+    doc.replace_content!(source: "# Replacement")
+    YjsPersistence.merge(doc.reload, b64_update_for("gen one. "))
+    YjsPersistence.merge(doc, b64_update_for("more gen one.", from_doc: doc_from(doc)))
+
+    assert doc.yjs_state_archives.where(kind: "checkpoint", content_generation: 1).exists?,
+           "the interval gate must not let an old generation's checkpoint block the new one"
   end
 
   def doc_from(document)

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -183,6 +183,43 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert doc.reload.yjs_state_vector.present?
   end
 
+  test "the snapshot staleness gate reads the stored vector without building a doc" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
+    YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "gate must not build a Y::Doc" }
+    begin
+      persisted = YjsPersistence.persist_snapshot(
+        doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+      )
+      assert_not persisted
+    ensure
+      YjsPersistence.singleton_class.define_method(:load_ydoc, original)
+    end
+
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
+  test "a corrupt stored vector falls back to the blob for the snapshot gate" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    client = Y::Doc.new
+    YjsPersistence.merge(doc, b64_update_for("server content", from_doc: client))
+    doc.update_columns(yjs_state_vector: [ 0x85, 0xff ].pack("C*"))
+
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+    assert_not YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+    ), "a behind client must still be rejected when the stored vector is corrupt"
+
+    current_vector = Base64.strict_encode64(client.state.pack("C*"))
+    assert YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: current_vector, content: "fresh", spans: []
+    ), "a current client must still be accepted when the stored vector is corrupt"
+    assert_equal "fresh", doc.reload.content_snapshot
+  end
+
   test "snapshot staleness gate works from a legacy row without a stored vector" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -119,6 +119,84 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "server content", client.get_text("t").to_s
   end
 
+  test "merge persists the state vector alongside the blob" do
+    doc = Document.create!(title: "Vectored")
+    YjsPersistence.merge(doc, b64_update_for("content"))
+    doc.reload
+
+    assert doc.yjs_state_vector.present?
+    ydoc = Y::Doc.new
+    ydoc.sync(doc.yjs_state.unpack("C*"))
+    assert_equal ydoc.state, doc.yjs_state_vector.unpack("C*")
+  end
+
+  test "state_b64 serves the handshake from columns without building a doc" do
+    doc = Document.create!(title: "Fast join")
+    YjsPersistence.merge(doc, b64_update_for("column served"))
+    doc.reload
+
+    event = nil
+    original = Y::Doc.method(:new)
+    Y::Doc.define_singleton_method(:new) { |*| raise "state_b64 must not build a Y::Doc" }
+    begin
+      event = assert_notification("state.yjs", served_from: "columns") do
+        full_state, state_vector = YjsPersistence.state_b64(doc)
+        assert_equal Base64.strict_encode64(doc.yjs_state), full_state
+        assert_equal Base64.strict_encode64(doc.yjs_state_vector), state_vector
+      end
+    ensure
+      Y::Doc.define_singleton_method(:new, original)
+    end
+
+    client = Y::Doc.new
+    client.sync(doc.yjs_state.unpack("C*"))
+    assert_equal "column served", client.get_text("t").to_s
+    assert_equal "ok", event.payload[:outcome]
+  end
+
+  test "a legacy row without a stored vector falls back to rebuilding" do
+    doc = Document.create!(title: "Legacy")
+    YjsPersistence.merge(doc, b64_update_for("old row"))
+    doc.update_columns(yjs_state_vector: nil)
+    doc.reload
+
+    full_state, state_vector = nil, nil
+    assert_notification("state.yjs", served_from: "rebuild") do
+      full_state, state_vector = YjsPersistence.state_b64(doc)
+    end
+
+    client = Y::Doc.new
+    client.sync(Base64.strict_decode64(full_state).unpack("C*"))
+    assert_equal "old row", client.get_text("t").to_s
+    assert state_vector.present?
+  end
+
+  test "replace_content! clears the stored state vector until the next merge" do
+    doc = Document.create!(title: "Reset", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("live"))
+    assert doc.reload.yjs_state_vector.present?
+
+    doc.replace_content!(source: "# Replacement")
+    assert_nil doc.reload.yjs_state_vector
+
+    YjsPersistence.merge(doc, b64_update_for("fresh"))
+    assert doc.reload.yjs_state_vector.present?
+  end
+
+  test "snapshot staleness gate works from a legacy row without a stored vector" do
+    doc = Document.create!(title: "Snapshot", content_snapshot: "current")
+    YjsPersistence.merge(doc, b64_update_for("server content"))
+    doc.update_columns(yjs_state_vector: nil)
+    stale_vector = Base64.strict_encode64(Y::Doc.new.state.pack("C*"))
+
+    persisted = YjsPersistence.persist_snapshot(
+      doc.reload, state_vector_b64: stale_vector, content: "stale", spans: []
+    )
+
+    assert_not persisted
+    assert_equal "current", doc.reload.content_snapshot
+  end
+
   test "snapshot persistence rejects a client behind the current Yjs state" do
     doc = Document.create!(title: "Snapshot", content_snapshot: "current")
     YjsPersistence.merge(doc, b64_update_for("server content"))
@@ -237,6 +315,9 @@ class YjsPersistenceTest < ActiveSupport::TestCase
   test "a state_b64 failure is not classified as a success event" do
     doc = Document.create!(title: "Corrupt join")
     YjsPersistence.merge(doc, b64_update_for("content"))
+    # Legacy row shape (no stored vector) forces the rebuild path, which is
+    # where a corrupt blob can raise.
+    doc.update_columns(yjs_state_vector: nil)
 
     original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
     YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "corrupt blob" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements idea #5 from `docs/ideation/2026-07-02-yjs-storage-ideation.html` (PR #131). **Stacked on #135** (state-vector column). Fixes the standing P2 from `docs/residual-review-findings/feat-proof-reimagining.md` — "corrupt stored yjs_state blob bricks every subscribe permanently" — with three layers, each covering the failure the previous cannot:

**Prevent** — `merge` refuses to persist a blob that cannot round-trip into a fresh `Y::Doc` (`EncodeValidationError`, frame not broadcast — durable-before-broadcast preserved), and every stored blob carries a SHA-256 checksum verified on load.

**Contain** — a corrupt blob on the merge, join, or snapshot path never bricks the document: the bytes are quarantined (kept for forensics, never destroyed), the newest *loadable, same-generation* checkpoint is restored — never across a `replace_content!` generation bump, so heals can't resurrect wiped content — or the doc degrades to empty and connected clients re-upload via the existing sync-reply handshake. Merges write interval-gated checkpoints (10 min) of pre-merge state, bounding heal loss to one interval; `replace_content!` archives what it wipes (pre-bump generation, manual-undo artifact); archives prune to 5 per kind. Everything emits through the `*.yjs` event stream (`recovered.yjs` with `restored_from=checkpoint|empty|restamped` logs at warn).

**Recover** — `DEPLOYING.md` gains a Litestream replication accessory config and a numbered, rehearsable restore procedure (applying it to `config/deploy.yml` is deliberately left to the maintainer — deploys are manual and untestable from this environment).

Plan: `docs/plans/2026-07-02-006-feat-yjs-durability-stack-plan.md`.

## Review

Two persona-review agents (correctness+adversarial, testing+reliability+migration) surfaced and I fixed:
- **P0**: a mixed-version deploy window (old code writing blobs without checksums) would have triggered destructive false heals on healthy documents — heals now re-stamp a loadable blob's checksum instead of quarantining it.
- **P2 ×2**: corrupt *legacy* rows (nil checksum) previously escaped healing on the join and snapshot paths — column handshakes now probe loadability for checksum-less rows, and the snapshot gate rescues `CorruptStateError`.
- **P3**: the checkpoint interval gate is now generation-scoped so a fresh generation checkpoints promptly.

**Known residual (deliberate, needs a protocol decision):** after a heal, already-connected clients are not proactively resynced — their next frames apply on top of restored state and the tail beyond the checkpoint re-uploads only on their next handshake (reconnect/reload). A server-initiated re-handshake broadcast would close this but interacts with the client's `updateSequence` reset semantics; deferred as follow-up.

## Testing

- ✅ `bin/rails test` — 542 runs, 0 failures (20 new tests: heal-from-checkpoint, heal-to-empty, no-resurrection-across-generations, join/snapshot/channel heal paths, mixed-version re-stamp, legacy-row shapes, interval gating, pruning, replacement archives)
- ✅ `bin/rubocop`
- ✅ End-to-end: `script/sync_check.mjs` against `bin/dev` — convergence + late joiner green with the durability layer active
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

