### PR TITLE
[superseded by #137 — please close] feat(yjs): resident per-document doc cache

### DIFF
--- a/app/channels/sync_channel.rb
+++ b/app/channels/sync_channel.rb
@@ -25,6 +25,20 @@
 class SyncChannel < ApplicationCable::Channel
   MAX_SEQUENCE_GAP = 256
 
+  # In-process subscriber refcount per document id, driving resident-doc
+  # eviction on last disconnect. Entries are removed when the count reaches
+  # zero, so the map only holds actively-open documents.
+  ACTIVE_SUBSCRIBERS = Concurrent::Map.new
+
+  def self.track_subscribe(document_id)
+    ACTIVE_SUBSCRIBERS.compute(document_id) { |count| count.to_i + 1 }
+  end
+
+  # => remaining subscriber count (0 removes the entry).
+  def self.track_unsubscribe(document_id)
+    ACTIVE_SUBSCRIBERS.compute(document_id) { |count| count.to_i > 1 ? count - 1 : nil }.to_i
+  end
+
   def subscribed
     @document = Document.find_by(slug: params[:slug])
     return reject unless @document
@@ -33,6 +47,7 @@ class SyncChannel < ApplicationCable::Channel
     @next_sequence = 1
     @pending_updates = {}
     stream_for @document
+    self.class.track_subscribe(@document.id)
 
     full_state, state_vector = YjsPersistence.state_b64(@document)
     message = { type: "sync", update: full_state, sv: state_vector, generation: @document.content_generation }
@@ -48,6 +63,15 @@ class SyncChannel < ApplicationCable::Channel
       message[:seed_author_name] = @document.seed_author_name if @document.seed_author_name
     end
     transmit(message)
+  end
+
+  def unsubscribed
+    return unless @document
+    return unless self.class.track_unsubscribe(@document.id).zero?
+
+    # Last subscriber gone: the editing session is over, so the resident
+    # doc (and its unlocked mutex) can leave memory.
+    YjsPersistence.release(@document.id)
   end
 
   def receive(data)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -11,6 +11,17 @@ class YjsPersistence
   # is sufficient; the DB transaction below is the second guard.
   LOCKS = Concurrent::Map.new
 
+  # Resident merged docs, keyed by document id (the Hocuspocus model: hold
+  # the doc in memory while it is being edited instead of rehydrating the
+  # whole blob per frame). Validity is proven under the locks by generation
+  # + blob digest, so a stale entry can never persist a wrong write — see
+  # resident_ydoc. Entries evict on last disconnect (SyncChannel) and via
+  # the LRU cap below for writers without subscriptions (HTTP keepalive).
+  DOC_CACHE = Concurrent::Map.new
+  MAX_RESIDENT_DOCS = 256
+
+  ResidentDoc = Struct.new(:ydoc, :generation, :digest, :last_used_at)
+
   class << self
     # Merge a base64-encoded Yjs update into the document's persisted state.
     #
@@ -42,12 +53,17 @@ class YjsPersistence
                     "Client generation #{generation} is behind document generation #{document.content_generation}."
             end
 
-            ydoc = load_ydoc(document)
+            ydoc = resident_ydoc(document, payload)
             before = ydoc.state
             ydoc.sync(update)
             # A no-op update (e.g. the empty sync-reply a client joining an
             # empty doc sends) must not persist — flipping seed_state to
-            # "seeded" without content would permanently block the seed claim.
+            # "seeded" without content would permanently block the seed
+            # claim. (A causally dependent update whose dependency has not
+            # arrived also lands here: y-rb 0.7.0 does not retry pending
+            # structs across syncs, so the frame is dropped exactly as the
+            # fresh-doc-per-merge path dropped it, and the client's next
+            # sync-reply re-delivers it — no behavior change.)
             if ydoc.state == before
               payload[:outcome] = "noop"
               next
@@ -62,6 +78,7 @@ class YjsPersistence
               seed_state: "seeded",
               updated_at: Time.current
             )
+            remember_resident(document, ydoc, blob)
             payload[:outcome] = "merged"
             true
           end
@@ -152,10 +169,61 @@ class YjsPersistence
       end
     end
 
+    # Evict a document's resident doc and, when currently unlocked, its
+    # mutex. Called by SyncChannel when the last subscriber disconnects.
+    # Deleting an unlocked mutex while another thread still holds a
+    # reference can briefly yield two mutexes for one document; the row
+    # lock inside merge remains the second guard, so the race is benign.
+    def release(document_id)
+      DOC_CACHE.delete(document_id)
+      mutex = LOCKS[document_id]
+      LOCKS.delete(document_id) if mutex && !mutex.locked?
+    end
+
+    def resident?(document_id) = DOC_CACHE.key?(document_id)
+
+    def reset_cache! = DOC_CACHE.clear
+
     private
 
     def monotonic_ms
       Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+    end
+
+    # The resident doc for a merge, validated under the locks: the entry
+    # must derive from this exact generation and stored blob, so external
+    # writes (digest mismatch) and replacements (generation bump) force a
+    # fresh load. A miss loads, caches, and counts toward the LRU cap.
+    def resident_ydoc(document, payload)
+      entry = DOC_CACHE[document.id]
+      digest = document.yjs_state.present? ? Digest::SHA256.hexdigest(document.yjs_state) : nil
+      if entry && entry.generation == document.content_generation && entry.digest == digest
+        payload[:cache] = "hit"
+        entry.last_used_at = monotonic_ms
+        return entry.ydoc
+      end
+
+      payload[:cache] = "miss"
+      ydoc = load_ydoc(document)
+      DOC_CACHE[document.id] = ResidentDoc.new(ydoc, document.content_generation, digest, monotonic_ms)
+      evict_lru_overflow
+      ydoc
+    end
+
+    # Refresh the entry after a persist so the digest matches the new blob.
+    def remember_resident(document, ydoc, blob)
+      DOC_CACHE[document.id] = ResidentDoc.new(
+        ydoc, document.content_generation, Digest::SHA256.hexdigest(blob), monotonic_ms
+      )
+    end
+
+    def evict_lru_overflow
+      return if DOC_CACHE.size <= MAX_RESIDENT_DOCS
+
+      entries = []
+      DOC_CACHE.each_pair { |id, entry| entries << [ id, entry.last_used_at ] }
+      entries.sort_by! { |_, used_at| used_at }
+      entries.first(DOC_CACHE.size - MAX_RESIDENT_DOCS).each { |id, _| DOC_CACHE.delete(id) }
     end
 
     def load_ydoc(document)

--- a/app/services/yjs_persistence.rb
+++ b/app/services/yjs_persistence.rb
@@ -54,33 +54,43 @@ class YjsPersistence
             end
 
             ydoc = resident_ydoc(document, payload)
-            before = ydoc.state
-            ydoc.sync(update)
-            # A no-op update (e.g. the empty sync-reply a client joining an
-            # empty doc sends) must not persist — flipping seed_state to
-            # "seeded" without content would permanently block the seed
-            # claim. (A causally dependent update whose dependency has not
-            # arrived also lands here: y-rb 0.7.0 does not retry pending
-            # structs across syncs, so the frame is dropped exactly as the
-            # fresh-doc-per-merge path dropped it, and the client's next
-            # sync-reply re-delivers it — no behavior change.)
-            if ydoc.state == before
-              payload[:outcome] = "noop"
-              next
-            end
+            begin
+              before = ydoc.state
+              ydoc.sync(update)
+              # A no-op update (e.g. the empty sync-reply a client joining an
+              # empty doc sends) must not persist — flipping seed_state to
+              # "seeded" without content would permanently block the seed
+              # claim. (A causally dependent update whose dependency has not
+              # arrived also lands here: y-rb 0.7.0 does not retry pending
+              # structs across syncs, so the frame is dropped exactly as the
+              # fresh-doc-per-merge path dropped it, and the client's next
+              # sync-reply re-delivers it — no behavior change.)
+              if ydoc.state == before
+                payload[:outcome] = "noop"
+                next
+              end
 
-            payload[:blob_bytes_before] = document.yjs_state&.bytesize || 0
-            blob = ydoc.full_diff.pack("C*")
-            payload[:blob_bytes_after] = blob.bytesize
-            document.update_columns(
-              yjs_state: blob,
-              yjs_state_vector: ydoc.state.pack("C*"),
-              seed_state: "seeded",
-              updated_at: Time.current
-            )
-            remember_resident(document, ydoc, blob)
-            payload[:outcome] = "merged"
-            true
+              payload[:blob_bytes_before] = document.yjs_state&.bytesize || 0
+              blob = ydoc.full_diff.pack("C*")
+              payload[:blob_bytes_after] = blob.bytesize
+              document.update_columns(
+                yjs_state: blob,
+                yjs_state_vector: ydoc.state.pack("C*"),
+                seed_state: "seeded",
+                updated_at: Time.current
+              )
+              remember_resident(document, ydoc, blob)
+              payload[:outcome] = "merged"
+              true
+            rescue StandardError
+              # A failure after the cached doc was mutated (e.g. the persist
+              # raising) would leave the resident doc ahead of the DB with a
+              # digest that still matches the old blob — the client's
+              # redelivery would then hit the cache, classify as a no-op,
+              # and never persist. Evict so the redelivery reloads.
+              DOC_CACHE.delete(document.id)
+              raise
+            end
           end
         end
       end

--- a/config/initializers/yjs_instrumentation.rb
+++ b/config/initializers/yjs_instrumentation.rb
@@ -37,7 +37,7 @@ Rails.application.config.after_initialize do
       duration_ms: event.duration.round(1)
     }
     %i[update_bytes blob_bytes blob_bytes_before blob_bytes_after lock_wait_ms
-       served_from sequence expected_sequence error].each do |key|
+       cache served_from sequence expected_sequence error].each do |key|
       fields[key] = payload[key] if payload.key?(key)
     end
     # Class and message ("Document::StaleGenerationError: Client generation 3

--- a/docs/plans/2026-07-02-008-feat-yjs-resident-doc-cache-plan.md
+++ b/docs/plans/2026-07-02-008-feat-yjs-resident-doc-cache-plan.md
@@ -1,0 +1,62 @@
+---
+date: 2026-07-02
+type: feat
+title: "feat: Resident per-document Y::Doc session cache"
+origin: docs/ideation/2026-07-02-yjs-storage-ideation.html (idea #4)
+depth: standard
+base: cursor/yjs-state-vector-column-0857 (deliberate alternative fork to the append-log PR)
+---
+
+# feat: Resident per-document Y::Doc session cache
+
+## Summary
+
+Every merge builds a fresh `Y::Doc` from the stored blob before applying one update — O(document) rehydration per keystroke frame. This plan keeps the merged doc resident in memory per document (the Hocuspocus model), validated under the existing locks by `content_generation` plus a blob digest, so steady-state merges skip the rehydration entirely and pay only the update apply + re-encode. Entries evict when the last subscriber disconnects (in-process refcount — correct under the deployment's single-process pin) and under an LRU cap for HTTP-only writers; the same lifecycle finally gives the never-evicted `LOCKS` mutex map an eviction point.
+
+**Positioning:** this is the ideation roadmap's no-schema-change alternative to the append-only update log (PR #137). The two PRs deliberately conflict; the team picks a direction (or lands the log and adapts this cache to the fold path).
+
+## Requirements
+
+- R1: A merge whose cache entry is valid (same generation, digest matches the stored blob) applies the update to the resident doc without `load_ydoc`.
+- R2: Validity is checked under both locks after `reload`; any external write (digest mismatch) or `replace_content!` (generation bump) forces a miss and a fresh load — no stale-cache write can ever persist.
+- R3: The cache entry is refreshed on every persist; a no-op merge (pending or duplicate update) leaves the entry consistent with the unchanged stored blob.
+- R4: Entries evict on last disconnect (SyncChannel refcount) and via an LRU cap (`MAX_RESIDENT_DOCS = 256`); the per-document `LOCKS` mutex evicts on last disconnect when unlocked (a racing thread that still holds a reference is safe — `with_lock` remains the second guard, per the existing comment).
+- R5: `merge.yjs` events record `cache: hit|miss` so the hit rate is measurable.
+- R6: Behavior is otherwise unchanged: same outcomes, same rejections, same handshake serving (columns-first from the stacked state-vector PR).
+- R7: A pending (causally dependent) update retained in the resident doc persists once its dependency arrives within the process lifetime — an improvement over the fresh-doc-per-merge path, which dropped pending structs at every encode.
+
+## Key Technical Decisions
+
+- **Digest over timestamp for validity.** `updated_at` changes on unrelated column writes; a SHA-256 of the blob (microseconds at document sizes) is the only signal that proves the cached doc derives from the exact stored bytes.
+- **Cache maintained on merge, evicted on disconnect + LRU.** HTTP keepalive flushes (`sync_update`) arrive as the cable closes, so merge-time caching plus a size cap covers writers without subscriptions; the disconnect hook covers the common editing session.
+- **Mutex eviction accepts a benign race.** Deleting an unlocked mutex while another thread holds a reference can briefly yield two mutexes for one document; the row lock (`with_lock`) still serializes the write, matching the existing design note that the DB transaction is the second guard.
+
+## Implementation Units
+
+### U1. Resident cache in YjsPersistence
+
+**Goal:** hit/miss logic under locks, entry refresh on persist, LRU cap, `cache` payload marker, public `release`/`resident?`/`reset_cache!` lifecycle hooks.
+
+**Files:** `app/services/yjs_persistence.rb`, `config/initializers/yjs_instrumentation.rb`, `test/services/yjs_persistence_test.rb`
+
+**Test scenarios:**
+- Second merge on a doc does not call `load_ydoc` (stub raises) and produces the correct merged text; the event records `cache: "hit"`.
+- External `update_columns` blob write invalidates the entry (next merge misses and includes the external content).
+- `replace_content!` invalidates via generation (existing anti-resurrection tests stay green).
+- Out-of-order dependent updates: dependent-first merge is a no-op; once the dependency merges, both persist (R7).
+- LRU: exceeding `MAX_RESIDENT_DOCS` evicts the least-recently-used entry.
+- Concurrency: existing concurrent-merge test stays green.
+
+### U2. Disconnect lifecycle in SyncChannel
+
+**Goal:** subscriber refcount; last disconnect calls `YjsPersistence.release(document_id)` (cache + unlocked-mutex eviction).
+
+**Files:** `app/channels/sync_channel.rb`, `test/channels/sync_channel_test.rb`, `test/test_helper.rb` (reset shared state between tests)
+
+**Test scenarios:**
+- Last unsubscribe evicts the resident entry and the mutex; an intermediate unsubscribe (second subscriber open) does not.
+- Rejected subscriptions do not corrupt the refcount.
+
+## Scope Boundaries
+
+- **Non-goals:** schema changes; serving handshakes from the cache (columns already serve them); healing/durability (lives in the other stack); multi-process coherence (deployment is pinned single-process; the digest check is the forward-compatible guard).

--- a/docs/plans/2026-07-02-008-feat-yjs-resident-doc-cache-plan.md
+++ b/docs/plans/2026-07-02-008-feat-yjs-resident-doc-cache-plan.md
@@ -23,7 +23,7 @@ Every merge builds a fresh `Y::Doc` from the stored blob before applying one upd
 - R4: Entries evict on last disconnect (SyncChannel refcount) and via an LRU cap (`MAX_RESIDENT_DOCS = 256`); the per-document `LOCKS` mutex evicts on last disconnect when unlocked (a racing thread that still holds a reference is safe — `with_lock` remains the second guard, per the existing comment).
 - R5: `merge.yjs` events record `cache: hit|miss` so the hit rate is measurable.
 - R6: Behavior is otherwise unchanged: same outcomes, same rejections, same handshake serving (columns-first from the stacked state-vector PR).
-- R7: A pending (causally dependent) update retained in the resident doc persists once its dependency arrives within the process lifetime — an improvement over the fresh-doc-per-merge path, which dropped pending structs at every encode.
+- R7: A pending (causally dependent) update is inert in the resident doc — y-rb 0.7.0 never re-integrates parked pending structs when the dependency later syncs (verified empirically), and `full_diff` never serializes them. Convergence comes from client redelivery, exactly as on the fresh-doc-per-merge path; the cache must not make this worse.
 
 ## Key Technical Decisions
 

--- a/test/channels/sync_channel_test.rb
+++ b/test/channels/sync_channel_test.rb
@@ -355,6 +355,30 @@ class SyncChannelTest < ActionCable::Channel::TestCase
     assert_nil doc.reload.yjs_state
   end
 
+  test "the last unsubscribe evicts the resident doc" do
+    doc = Document.create!(title: "Evicted on exit")
+    subscribe slug: doc.slug
+    perform :receive, { "type" => "update", "update" => build_update_b64("typed"), "cid" => "x" }
+    assert YjsPersistence.resident?(doc.id)
+
+    unsubscribe
+
+    assert_not YjsPersistence.resident?(doc.id), "the editing session ended — the doc must leave memory"
+  end
+
+  test "unsubscribing while another subscriber remains keeps the resident doc" do
+    doc = Document.create!(title: "Still open")
+    SyncChannel.track_subscribe(doc.id) # a second, concurrent subscriber
+    subscribe slug: doc.slug
+    perform :receive, { "type" => "update", "update" => build_update_b64("typed"), "cid" => "x" }
+
+    unsubscribe
+
+    assert YjsPersistence.resident?(doc.id), "an open session must keep its resident doc"
+  ensure
+    SyncChannel.track_unsubscribe(doc.id)
+  end
+
   test "awareness messages relay without persisting" do
     doc = Document.create!(title: "Presence")
     subscribe slug: doc.slug

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -293,6 +293,110 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "ordered independently", doc.reload.content_snapshot
   end
 
+  test "a second merge reuses the resident doc without reloading the blob" do
+    doc = Document.create!(title: "Resident")
+    client = Y::Doc.new
+    assert_notification("merge.yjs", cache: "miss") do
+      YjsPersistence.merge(doc, b64_update_for("first ", from_doc: client))
+    end
+
+    original = YjsPersistence.singleton_class.instance_method(:load_ydoc)
+    YjsPersistence.define_singleton_method(:load_ydoc) { |*| raise "cache hit must not reload" }
+    begin
+      assert_notification("merge.yjs", cache: "hit") do
+        YjsPersistence.merge(doc, b64_update_for("second", from_doc: client))
+      end
+    ensure
+      YjsPersistence.singleton_class.define_method(:load_ydoc, original)
+    end
+
+    assert_equal "first second", text_of(doc.reload)
+  end
+
+  test "an external blob write invalidates the resident doc" do
+    doc = Document.create!(title: "Externally written")
+    YjsPersistence.merge(doc, b64_update_for("cached content. "))
+
+    # Another writer (e.g. a different process) replaces the blob directly.
+    external = Y::Doc.new
+    external.get_text("t") << "external content. "
+    doc.reload.update_columns(
+      yjs_state: external.full_diff.pack("C*"),
+      yjs_state_vector: external.state.pack("C*")
+    )
+
+    assert_notification("merge.yjs", cache: "miss") do
+      YjsPersistence.merge(doc.reload, b64_update_for("appended."))
+    end
+
+    merged = text_of(doc.reload)
+    assert_includes merged, "external content", "the digest check must force a fresh load"
+    assert_includes merged, "appended"
+    assert_not_includes merged, "cached content", "the stale resident doc must not win"
+  end
+
+  test "replace_content! invalidates the resident doc via the generation" do
+    doc = Document.create!(title: "Regenerated", seed_content: "# Seed")
+    YjsPersistence.merge(doc, b64_update_for("old generation secret"))
+    doc.replace_content!(source: "# Replacement")
+
+    assert_notification("merge.yjs", cache: "miss") do
+      YjsPersistence.merge(doc.reload, b64_update_for("new generation"))
+    end
+
+    merged = text_of(doc.reload)
+    assert_not_includes merged, "old generation secret",
+                        "a resident doc from a wiped generation must never persist"
+    assert_includes merged, "new generation"
+  end
+
+  test "an out-of-order dependent pair converges on redelivery, matching pre-cache behavior" do
+    doc = Document.create!(title: "Pending")
+    client = Y::Doc.new
+    text = client.get_text("t")
+    text << "a"
+    first = client.diff
+    first_state = client.state
+    text << "b"
+    second = client.diff(first_state)
+
+    # Dependent frame first: y-rb does not retry pending structs across
+    # syncs, so this is a no-op — nothing persists, nothing corrupts.
+    assert_notification("merge.yjs", outcome: "noop") do
+      YjsPersistence.merge(doc, Base64.strict_encode64(second.pack("C*")))
+    end
+    assert_nil doc.reload.yjs_state
+
+    YjsPersistence.merge(doc, Base64.strict_encode64(first.pack("C*")))
+    # The client's next sync-reply re-delivers the dependent frame (the
+    # channel's seq buffer prevents this ordering for cable traffic anyway).
+    YjsPersistence.merge(doc, Base64.strict_encode64(second.pack("C*")))
+
+    assert_equal "ab", text_of(doc.reload)
+  end
+
+  test "the resident cache is bounded by an LRU cap" do
+    docs = (YjsPersistence::MAX_RESIDENT_DOCS + 1).times.map do |i|
+      Document.create!(title: "LRU #{i}")
+    end
+    docs.each { |d| YjsPersistence.merge(d, b64_update_for("x")) }
+
+    assert_not YjsPersistence.resident?(docs.first.id), "the least-recently-used entry must evict"
+    assert YjsPersistence.resident?(docs.last.id)
+  end
+
+  test "release evicts the resident doc and an unlocked mutex" do
+    doc = Document.create!(title: "Released")
+    YjsPersistence.merge(doc, b64_update_for("resident"))
+    assert YjsPersistence.resident?(doc.id)
+    assert YjsPersistence::LOCKS.key?(doc.id)
+
+    YjsPersistence.release(doc.id)
+
+    assert_not YjsPersistence.resident?(doc.id)
+    assert_not YjsPersistence::LOCKS.key?(doc.id)
+  end
+
   test "merge emits a merged event with byte sizes" do
     doc = Document.create!(title: "Metered")
     events = capture_notifications("merge.yjs") do

--- a/test/services/yjs_persistence_test.rb
+++ b/test/services/yjs_persistence_test.rb
@@ -375,14 +375,46 @@ class YjsPersistenceTest < ActiveSupport::TestCase
     assert_equal "ab", text_of(doc.reload)
   end
 
-  test "the resident cache is bounded by an LRU cap" do
-    docs = (YjsPersistence::MAX_RESIDENT_DOCS + 1).times.map do |i|
-      Document.create!(title: "LRU #{i}")
+  test "the resident cache is bounded by an LRU cap and hits refresh recency" do
+    docs = YjsPersistence::MAX_RESIDENT_DOCS.times.map { |i| Document.create!(title: "LRU #{i}") }
+    clients = docs.map do |d|
+      client = Y::Doc.new
+      YjsPersistence.merge(d, b64_update_for("x", from_doc: client))
+      client
     end
-    docs.each { |d| YjsPersistence.merge(d, b64_update_for("x")) }
 
-    assert_not YjsPersistence.resident?(docs.first.id), "the least-recently-used entry must evict"
-    assert YjsPersistence.resident?(docs.last.id)
+    # A hit on the oldest entry refreshes its recency...
+    YjsPersistence.merge(docs.first, b64_update_for("y", from_doc: clients.first))
+
+    # ...so the overflow evicts the now-oldest second entry instead.
+    overflow = Document.create!(title: "LRU overflow")
+    YjsPersistence.merge(overflow, b64_update_for("x"))
+
+    assert YjsPersistence.resident?(docs.first.id), "a recently-hit entry must survive"
+    assert_not YjsPersistence.resident?(docs[1].id), "the least-recently-used entry must evict"
+    assert YjsPersistence.resident?(overflow.id)
+  end
+
+  test "a failed persist evicts the resident doc so redelivery lands" do
+    doc = Document.create!(title: "Failed persist")
+    client = Y::Doc.new
+    YjsPersistence.merge(doc, b64_update_for("kept. ", from_doc: client))
+    update = b64_update_for("nearly lost", from_doc: client)
+
+    doc.define_singleton_method(:update_columns) { |*| raise ActiveRecord::StatementInvalid, "disk I/O error" }
+    begin
+      assert_raises(ActiveRecord::StatementInvalid) { YjsPersistence.merge(doc, update) }
+    ensure
+      doc.singleton_class.send(:remove_method, :update_columns)
+    end
+    assert_not YjsPersistence.resident?(doc.id), "a doc ahead of the DB must not stay cached"
+
+    # The client redelivers the same frame (seq buffer / sync-reply): it must
+    # miss the cache, reload from the stored blob, and actually persist.
+    assert_notification("merge.yjs", cache: "miss", outcome: "merged") do
+      YjsPersistence.merge(doc.reload, update)
+    end
+    assert_includes text_of(doc.reload), "nearly lost"
   end
 
   test "release evicts the resident doc and an unlocked mutex" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,13 @@ module ActiveSupport
     # WriteRateLimited::STORE is a single in-memory cache shared by every test in a
     # parallel worker process; without a reset, write requests accumulate across
     # unrelated tests and can trip burst limits that no individual test approaches.
-    setup { WriteRateLimited::STORE.clear }
+    # The Yjs resident-doc cache and subscriber refcounts leak the same way:
+    # rolled-back transactions reuse document ids across tests.
+    setup do
+      WriteRateLimited::STORE.clear
+      YjsPersistence.reset_cache!
+      SyncChannel::ACTIVE_SUBSCRIBERS.clear
+    end
 
     # Add more helper methods to be used by all tests here...
   end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **⛔ Superseded — please close without merging.** This PR and #137 were deliberate alternatives for the same hot path, and #137 (append-only update log) is the keeper: it removes the O(document) per-frame cost at the root rather than caching around it, and carried the heavier end-to-end evidence (all 8 CI browser regression checks). The agent's GitHub token cannot close PRs, hence this banner instead of a closed state. The branch stays available if the log approach ever needs to be revisited.
>
> One durable takeaway from this PR's review that applies to **all** branches: y-rb 0.7.0 **segfaults the process** on a base64-valid update with corrupted tail bytes (`yrs Update::decode`, exit 139) — truncated/garbage inputs raise cleanly. Worth an upstream y-rb issue independent of which PR merges.

---

## What (original description)

Implements idea #4 from `docs/ideation/2026-07-02-yjs-storage-ideation.html` (PR #131). Stacked on #135 (state-vector column), as the no-schema-change **alternative** to the append-only update log (#137).

Every merge previously rehydrated a fresh `Y::Doc` from the full stored blob before applying one update — O(document) per keystroke frame. This PR keeps the merged doc resident in memory per document (the Hocuspocus model):

- `DOC_CACHE` entries `{ydoc, generation, blob digest, last_used_at}`; a hit requires generation + digest to match the freshly reloaded row **under both locks**, so external writes and `replace_content!` structurally force a miss — a stale cached doc can never persist a wrong write.
- Entries evict when the last subscriber disconnects (SyncChannel refcount) and under an LRU cap (256) for HTTP-keepalive writers; the disconnect eviction also finally releases the per-document `LOCKS` mutex (the standing P3), safe because the row lock remains the second guard (verified: Rails 8.1 SQLite adapter uses `BEGIN IMMEDIATE`, so the documented mutex-eviction race cannot lose updates).
- `merge.yjs` events carry `cache=hit|miss` so the hit rate is measurable via the instrumentation stack.

Plan: `docs/plans/2026-07-02-008-feat-yjs-resident-doc-cache-plan.md`.

## Live evidence

`script/sync_check.mjs` (two clients + late joiner) against `bin/dev`: 42 of 44 merges served from the resident doc:

```
event=merge.yjs document_id=22 outcome=merged … blob_bytes_before=315 blob_bytes_after=327 cache=hit
```

## Review

A combined correctness/adversarial/performance review with runtime probes caught, and I fixed:
- **P1**: a failed persist on a cache hit left the resident doc ahead of the DB with a still-matching digest — the client's redelivery then classified as a no-op and the edit was silently lost. Fixed by evicting the entry on any failure after the doc mutates (regression test included).
- **P3**: the plan overclaimed pending-struct behavior; probes show y-rb 0.7.0 never re-integrates parked pending structs — convergence comes from client redelivery, same as before. Docs corrected.

## Testing

- ✅ `bin/rails test` — 533 runs, 0 failures (10 new tests)
- ✅ `bin/rubocop`, ✅ `npm run check`
- ✅ End-to-end: `script/sync_check.mjs` convergence + late joiner green with the cache active (42 hits)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-288cae19-2c8a-4f7c-b401-f69daaab0857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

