### PR TITLE
fix(header): people cluster order + condensed mode menu (alpha riffrec feedback)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -144,8 +144,8 @@
  * Header presence-bar reserved lane (on-load layout stability)
  *
  * The document header's people cluster (.doc-header-people in
- * app/frontend/pages/documents/show.tsx) holds: identity chip · provenance
- * chip · PresenceBar. Human peers join via Yjs awareness over the websocket,
+ * app/frontend/pages/documents/show.tsx) holds: PresenceBar · provenance
+ * chip · identity chip. Human peers join via Yjs awareness over the websocket,
  * so they CANNOT be server-rendered — they fade in a beat after first paint.
  * Before this, the empty bar took zero width, so the first peer (0→N avatars +
  * "N here") widened the cluster and shoved the Edit/Share/⋯ controls left.
@@ -155,6 +155,11 @@
  * paint. Avatars then appear WITHIN the lane (acceptable) instead of pushing
  * the neighbouring controls (a layout shift, not acceptable). The bar always
  * renders now (even empty, data-empty) so the lane exists from the first frame.
+ *
+ * The lane sits on the cluster's open LEFT edge — beside the header's flexible
+ * middle space — so while empty it reads as ordinary whitespace instead of a
+ * dead gap between the viewer's name and Share. Contents right-align so
+ * arriving avatars hug the identity chip.
  *
  * Scoped to .presence-bar in the header; the editor body is untouched. The
  * Vite stylesheet (app/frontend/entrypoints/application.css) styles the bar's
@@ -167,6 +172,7 @@
   min-width: 7.5rem;
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.45rem;
 }
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2752,23 +2752,23 @@ a:focus-visible {
 }
 
 .mode-control-popover {
-  width: 16rem;
-  padding: 0.35rem;
+  width: 13.5rem;
+  padding: 0.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.1rem;
 }
 
 .mode-control-option {
   display: grid;
-  grid-template-columns: 1rem minmax(0, 1fr) auto;
+  grid-template-columns: 0.85rem minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.4rem;
   width: 100%;
   border: none;
   background: transparent;
-  border-radius: 7px;
-  padding: 0.45rem 0.55rem;
+  border-radius: 6px;
+  padding: 0.32rem 0.45rem;
   text-align: left;
   cursor: pointer;
 }
@@ -2786,17 +2786,18 @@ a:focus-visible {
   background: transparent;
 }
 
+/* Selected = soft tint + checkmark. No accent bars or outlines — the check
+   column already carries the state. */
 .mode-control-option.is-active {
-  background: color-mix(in srgb, var(--accent) 14%, var(--surface-raised));
-  box-shadow: inset 2px 0 0 var(--accent);
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface-raised));
 }
 
 .mode-control-option-check {
   align-self: start;
   color: var(--accent);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 700;
-  line-height: 1.25rem;
+  line-height: 1.15rem;
 }
 
 .mode-control-option-copy {
@@ -2804,30 +2805,32 @@ a:focus-visible {
   min-width: 0;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.1rem;
+  gap: 0.05rem;
 }
 
 .mode-control-option-label {
-  font-size: 0.8rem;
+  font-size: 0.76rem;
   font-weight: 550;
   color: var(--ink);
+  line-height: 1.15rem;
 }
 
 .mode-control-option-hint {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
+  line-height: 1.3;
   color: var(--ink-faint);
 }
 
 .mode-control-shortcut {
   align-self: center;
-  min-width: 2rem;
+  min-width: 1.6rem;
   border: 1px solid var(--line);
-  border-radius: 5px;
+  border-radius: 4px;
   background: var(--surface);
   color: var(--ink-faint);
   font-family: var(--font-mono);
-  font-size: 0.62rem;
-  line-height: 1.35rem;
+  font-size: 0.58rem;
+  line-height: 1.15rem;
   text-align: center;
 }
 
@@ -3563,6 +3566,12 @@ a:focus-visible {
   .share-copy {
     min-height: 44px;
     padding: 0.3rem 0.8rem;
+  }
+
+  /* The condensed desktop rows are too tight for touch — the mode sheet
+   * keeps 44px-friendly rows. */
+  .mode-control-option {
+    padding: 0.55rem 0.6rem;
   }
 }
 

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1315,15 +1315,11 @@ export default function DocumentShow({
             )}
           </div>
           <div className="doc-header-right">
-            {/* ≤3 groups: identity/presence · Share · ⋯ menu */}
+            {/* ≤3 groups: presence/identity · Share · ⋯ menu. Presence sits on
+                the cluster's open left edge (its reserved lane blends into the
+                header's free middle space) and your own identity chip anchors
+                the right, next to Share. */}
             <div className="doc-header-people">
-              <IdentityChip
-                identity={identity}
-                guest={guest}
-                authenticated={Boolean(viewer.account)}
-                onRenamed={handleRenamed}
-              />
-              {!isReading && <ProvenanceSummaryChip spans={spans} />}
               <PresenceBar
                 humans={peers}
                 agents={presences}
@@ -1332,6 +1328,13 @@ export default function DocumentShow({
                 onFollow={(clientId) => {
                   setFollowingClientId((current) => current === clientId ? null : clientId)
                 }}
+              />
+              {!isReading && <ProvenanceSummaryChip spans={spans} />}
+              <IdentityChip
+                identity={identity}
+                guest={guest}
+                authenticated={Boolean(viewer.account)}
+                onRenamed={handleRenamed}
               />
             </div>
             {!isReading && pendingSuggestionCount > 1 && (

--- a/docs/plans/2026-07-02-008-fix-doc-header-polish-plan.md
+++ b/docs/plans/2026-07-02-008-fix-doc-header-polish-plan.md
@@ -1,0 +1,71 @@
+---
+title: "fix: Doc header polish — people cluster order, condensed mode menu"
+type: fix
+date: 2026-07-02
+origin: Riffrec feedback bundle (session 383e3ef4, 2026-07-02, recorded on /d/huaxDEEFdc)
+---
+
+# fix: Doc header polish — people cluster order, condensed mode menu
+
+## Summary
+
+Alpha feedback (Riffrec recording, 2026-07-02) flagged three visual problems in the doc header:
+
+1. The header right side reads `[• Kieran Klaassen] … big empty gap … [Share] [⋯]`. The gap is the PresenceBar's reserved lane (`min-width: 7.5rem`) sitting between the identity chip and Share whenever no other collaborator is present. Requested: active collaborators on the left, the viewer's own name on the right, no dead gap.
+2. The mode dropdown (Edit / Suggest / Comment / Read) is "kind of big" — make it more condensed and refined.
+3. The active mode option carries a left accent bar (`inset 2px 0 0` box-shadow) that "looks a little AI" — replace with a subtler selected treatment.
+
+## Problem Frame
+
+All three issues live in the doc page header chrome. No behavior changes — pure presentation: element order within one flex cluster, and CSS sizing/selected-state styling for the mode popover. The PresenceBar reserved-lane mechanism (layout stability on websocket-late presence arrival) must be preserved; only its position changes.
+
+## Requirements
+
+- R1: In `doc-header-right`, presence (active collaborators) renders to the left and the viewer's identity chip renders rightmost within the people cluster, adjacent to Share. The empty presence lane must no longer produce a visible gap between the viewer's name and Share.
+- R2: The mode dropdown becomes visibly more compact: narrower popover, tighter paddings/gaps, smaller hint text and shortcut badges. Same four options, hints, and shortcuts remain.
+- R3: The active mode option loses the left accent bar; keep a subtle tint + checkmark as the selected indicator.
+
+## Key Technical Decisions
+
+- **Reorder, don't remove, the reserved lane.** The `min-width: 7.5rem` lane in `app/assets/stylesheets/application.css` exists so late-arriving peers don't shove Share/⋯ (see comment block there). Moving PresenceBar to the cluster's left edge makes the empty lane border the flexible header middle, so it is visually indistinguishable from ordinary whitespace, while growth still happens within/into free space instead of pushing controls. `ProvenanceSummaryChip` stays between presence and identity (edit-mode only; not visible in the recording).
+- **Condense via CSS only.** Keep hint copy in `mode_control.tsx` unchanged — browser check scripts assert on option labels and the trigger text, and tooltips reuse the hints. Shrink `.mode-control-popover` width (16rem → ~13.5rem), option padding, inter-option gap, hint font size, and `kbd` badge metrics.
+- **Selected state = tint + checkmark.** Drop the `box-shadow: inset 2px 0 0 var(--accent)`; keep (slightly soften) the background tint. The checkmark column already communicates selection.
+
+## Implementation Units
+
+### U1. Reorder the header people cluster
+
+**Goal:** Presence on the left, identity chip rightmost next to Share; kill the visible gap.
+**Requirements:** R1
+**Files:** `app/frontend/pages/documents/show.tsx`, `app/assets/stylesheets/application.css` (comment update only)
+**Approach:** In `doc-header-people`, render order becomes `PresenceBar` → `ProvenanceSummaryChip` → `IdentityChip`. Update the reserved-lane comment in the Rails-pipeline stylesheet to reflect the lane now sitting on the cluster's open left edge.
+**Test scenarios:** Visual: with zero peers in read mode, no visible gap between the viewer's name and Share; identity chip is immediately left of Share. Existing `script/browser_check.mjs` still passes (no selectors assert cluster order).
+**Verification:** Screenshot of read-mode header with a signed-in user shows `[avatars?][name][Share][⋯]` with no dead gap.
+
+### U2. Condense the mode dropdown
+
+**Goal:** Smaller, tighter mode popover.
+**Requirements:** R2
+**Files:** `app/frontend/entrypoints/application.css`
+**Approach:** Reduce `.mode-control-popover` width and padding; tighten `.mode-control-option` padding/gap; shrink `.mode-control-option-hint` and `.mode-control-shortcut` sizes. No TSX changes.
+**Test expectation:** none — pure styling; verified visually and by existing Playwright checks that click options by label.
+**Verification:** Screenshot of the open menu is visibly more compact than the recording, all four options readable, shortcuts intact.
+
+### U3. Refine the active option treatment
+
+**Goal:** Remove the left accent bar on the selected mode option.
+**Requirements:** R3
+**Files:** `app/frontend/entrypoints/application.css`
+**Approach:** Delete the inset box-shadow from `.mode-control-option.is-active`; keep a soft background tint. Checkmark remains the primary indicator.
+**Test expectation:** none — pure styling.
+**Verification:** Screenshot of the open menu shows the active row with tint + checkmark only, no left bar.
+
+## Scope Boundaries
+
+- No changes to presence behavior, identity editing, share popover, or mobile sheet layout beyond what the shared CSS rules inherit.
+- Hint copy and keyboard shortcuts unchanged.
+- Deferred: none.
+
+## Verification Strategy
+
+`npm run check` (TypeScript), `bin/rubocop`, `bin/rails test`, plus manual GUI verification against the dev server (`bin/dev`): header layout with signed-in user, open mode menu before/after screenshots, and a second browser window to confirm presence avatars appear left of the identity chip without shifting Share.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements the three doc-header polish items from the 2026-07-02 Riffrec alpha feedback recording (session `383e3ef4`, captured on `/d/huaxDEEFdc`):

1. **People cluster order** — the header right previously read `[• Your name] … dead gap … [Share] [⋯]`; the gap was the PresenceBar's reserved layout-stability lane (`min-width: 7.5rem`) sitting between the identity chip and Share. The cluster now renders `PresenceBar · provenance chip · identity chip`, so active collaborators appear on the left and your own name anchors the right beside Share. The reserved lane is preserved (no first-paint layout shift) but now borders the header's flexible middle space, where it reads as ordinary whitespace; lane contents right-align so arriving avatars hug the identity chip.
2. **Condensed mode menu** — the Edit / Suggest / Comment / Read dropdown is narrower (16rem → 13.5rem) with tighter row padding, smaller hints and shortcut badges. Copy and shortcuts unchanged. The mobile bottom sheet keeps roomier touch-friendly rows via a media-query override.
3. **Refined active state** — the selected mode row loses the `inset 2px 0 0` left accent bar; selection is now a softer tint + the existing checkmark.

Plan: `docs/plans/2026-07-02-008-fix-doc-header-polish-plan.md`

## Before → After

**Header right (from the feedback recording → after):**

![Before: name, dead gap, Share](https://cursor.com/artifacts/c/art-bbdec1ef-09e3-4060-a27a-334100ace047)
![After: name immediately beside Share](https://cursor.com/artifacts/c/art-1815ce93-46a1-41c0-9084-ccc7cfd44a27)

With a second collaborator present, their avatar lands left of your name and Share stays put:

![After: collaborator avatar left of the identity chip](https://cursor.com/artifacts/c/art-a4ef19ff-eec8-4793-a009-6f6b6b03feaa)

**Mode menu (before → after):**

![Before: large menu with left accent bar on active row](https://cursor.com/artifacts/c/art-c3aac8ab-1a9b-4d7e-a5be-1b70dff20440)
![After: condensed menu, active row is tint + checkmark only](https://cursor.com/artifacts/c/art-c23f2584-6399-49c2-9619-5b35a6a3a794)

**Demo video** (mode switching + a second collaborator joining via incognito window):

<a href="https://cursor.com/agents/bc-94b19ae8-403b-4b90-879c-9e68ba9d2895/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_polish_mode_menu_and_presence_demo.mp4"><img src="https://cursor.com/artifacts/c/art-febb7bae-d7da-4755-a62e-f020e50982ca" alt="header_polish_mode_menu_and_presence_demo.mp4" /></a>

## Testing

- `npm run check` — pass
- `bin/rubocop` — 160 files, no offenses
- `bin/rails test` — 579 runs, 0 failures
- `node script/browser_check.mjs` against `bin/dev` — all 150 checks passed locally
- Manual GUI verification (screenshots/video above), including two-window presence
- CI: all checks green. The first CI run failed on `browser_checks` at "task toggle was lost during an immediate reload" — a pre-existing websocket-durability flake unrelated to this diff (the same check passed twice locally on this branch and passed on CI rerun with no code change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94b19ae8-403b-4b90-879c-9e68ba9d2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94b19ae8-403b-4b90-879c-9e68ba9d2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

