### PR TITLE
feat(native): dropdown menus, FAB, and native login polish

### DIFF
--- a/app/frontend/components/account_control.tsx
+++ b/app/frontend/components/account_control.tsx
@@ -17,7 +17,9 @@ export function AccountControl({ viewer }: Props) {
   return (
     <div className="account-control account-control--signed-in">
       <span title={viewer.account.email}>{viewer.account.name}</span>
-      <Link href="/logout" method="delete" as="button">
+      {/* Stable id: the Ruby Native account menu's Sign out item clicks this
+          button, so sign-out stays on the one DELETE submission path. */}
+      <Link id="account-signout" href="/logout" method="delete" as="button">
         Sign out
       </Link>
     </div>

--- a/app/frontend/pages/auth/show.tsx
+++ b/app/frontend/pages/auth/show.tsx
@@ -18,6 +18,7 @@ const errorText = (error: unknown): string | null => {
 export default function AuthShow({ mode, google_enabled, csrf_token, return_to, nativeApp }: Props) {
   const registering = mode === 'register'
   const title = registering ? 'Create your account' : 'Welcome back'
+  const actionTitle = registering ? 'Create account' : 'Sign in'
   const switchPath = registering ? '/login' : '/signup'
   const switchHref = return_to
     ? `${switchPath}?${new URLSearchParams({ return_to }).toString()}`
@@ -32,9 +33,9 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
           navbar submit button clicks #auth-submit — scoped, because the Google
           OAuth form's submit button appears earlier in the DOM and the default
           [type='submit'] selector would hit it first. */}
-      <NativeNavbar title={registering ? 'Create account' : 'Sign in'} pullToRefresh={false} />
+      <NativeNavbar title={actionTitle} pullToRefresh={false} />
       <NativeForm />
-      <NativeSubmitButton title={registering ? 'Create account' : 'Sign in'} click="#auth-submit" />
+      <NativeSubmitButton title={actionTitle} click="#auth-submit" />
       <main className="auth-page">
         <section className="auth-card" aria-labelledby="auth-heading">
           <Link href="/" className="auth-wordmark" aria-label="Thinkroom home">
@@ -133,7 +134,7 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
                   disabled={processing}
                   {...nativeHaptic('impact')}
                 >
-                  {processing ? 'Working…' : registering ? 'Create account' : 'Sign in'}
+                  {processing ? 'Working…' : actionTitle}
                 </button>
               </div>
             )}

--- a/app/frontend/pages/auth/show.tsx
+++ b/app/frontend/pages/auth/show.tsx
@@ -1,5 +1,5 @@
 import { Form, Head, Link } from '@inertiajs/react'
-import { NativeForm, NativeNavbar, nativeHaptic } from '@ruby-native/react'
+import { NativeForm, NativeNavbar, NativeSubmitButton, nativeHaptic } from '@ruby-native/react'
 import './show.css'
 
 interface Props {
@@ -27,9 +27,14 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
     <>
       <Head title={`${title} · Thinkroom`} />
       {/* Ruby Native chrome: navbar title plus a form marker so native back
-          navigation skips this page after a successful sign-in. */}
-      <NativeNavbar title={registering ? 'Create account' : 'Sign in'} />
+          navigation skips this page after a successful sign-in. Pull-to-refresh
+          is off so a drag inside the form can't reload and discard input. The
+          navbar submit button clicks #auth-submit — scoped, because the Google
+          OAuth form's submit button appears earlier in the DOM and the default
+          [type='submit'] selector would hit it first. */}
+      <NativeNavbar title={registering ? 'Create account' : 'Sign in'} pullToRefresh={false} />
       <NativeForm />
+      <NativeSubmitButton title={registering ? 'Create account' : 'Sign in'} click="#auth-submit" />
       <main className="auth-page">
         <section className="auth-card" aria-labelledby="auth-heading">
           <Link href="/" className="auth-wordmark" aria-label="Thinkroom home">
@@ -73,10 +78,13 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
                 )}
                 <label>
                   <span>Email</span>
+                  {/* "username" on login pairs the field with iOS credential
+                      autofill; register keeps "email" for contact autofill
+                      alongside new-password. */}
                   <input
                     name="email"
                     type="email"
-                    autoComplete="email"
+                    autoComplete={registering ? 'email' : 'username'}
                     required
                     autoFocus={!registering}
                     aria-invalid={Boolean(errors.email)}
@@ -119,6 +127,7 @@ export default function AuthShow({ mode, google_enabled, csrf_token, return_to, 
                   </p>
                 )}
                 <button
+                  id="auth-submit"
                   className="btn btn-primary auth-submit"
                   type="submit"
                   disabled={processing}

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
-import { NativeNavbar, NativeButton, nativeHaptic } from '@ruby-native/react'
+import { NativeNavbar, NativeButton, NativeMenuItem, nativeHaptic } from '@ruby-native/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
 import { userIdentity } from '../../editor/identity'
@@ -294,9 +294,23 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     <>
       <Head title="Thinkroom" />
       {/* Ruby Native chrome: hidden signal elements the iOS/Android shell
-          reads. The plus button clicks the web "New document" button so the
-          native action reuses the exact same submission path. */}
+          reads. Menu items and the plus button click or navigate to existing
+          web controls so every native action reuses the web submission path. */}
       <NativeNavbar title="Thinkroom">
+        <NativeButton position="leading" icon="person.crop.circle">
+          {viewer.account ? (
+            <NativeMenuItem title="Sign out" click="#account-signout" />
+          ) : (
+            <NativeMenuItem title="Sign in" href="/login?return_to=%2F" />
+          )}
+        </NativeButton>
+        <NativeButton position="trailing" icon="ellipsis.circle">
+          <NativeMenuItem title="Have an agent start one" click="#agent-start-trigger" />
+          {recent.some((document) => document.slug === 'demo') && (
+            <NativeMenuItem title="Open the demo" href="/d/demo" />
+          )}
+          {isClient && <NativeMenuItem title="Send feedback" click=".feedback-button button" />}
+        </NativeButton>
         <NativeButton icon="plus" click="#new-document-button" />
       </NativeNavbar>
       <div className="landing">

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -289,6 +289,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
     showAllEarlier || activeTag ? earlier : earlier.slice(0, EARLIER_PREVIEW_LIMIT)
   const hiddenEarlierCount = earlier.length - visibleEarlier.length
   const claimerName = identityName
+  const hasDemo = recent.some((document) => document.slug === 'demo')
 
   return (
     <>
@@ -306,9 +307,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
         </NativeButton>
         <NativeButton position="trailing" icon="ellipsis.circle">
           <NativeMenuItem title="Have an agent start one" click="#agent-start-trigger" />
-          {recent.some((document) => document.slug === 'demo') && (
-            <NativeMenuItem title="Open the demo" href="/d/demo" />
-          )}
+          {hasDemo && <NativeMenuItem title="Open the demo" href="/d/demo" />}
           {isClient && <NativeMenuItem title="Send feedback" click=".feedback-button button" />}
         </NativeButton>
       </NativeNavbar>
@@ -353,7 +352,7 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
               >
                 Have an agent start one
               </button>
-              {recent.some((document) => document.slug === 'demo') && (
+              {hasDemo && (
                 <Link href="/d/demo" className="btn btn-ghost" prefetch>
                   Open the demo
                 </Link>

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import { Head, Link, useForm } from '@inertiajs/react'
-import { NativeNavbar, NativeButton, NativeMenuItem, nativeHaptic } from '@ruby-native/react'
+import { NativeNavbar, NativeButton, NativeMenuItem, NativeFab, nativeHaptic } from '@ruby-native/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
 import { userIdentity } from '../../editor/identity'
@@ -311,8 +311,11 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
           )}
           {isClient && <NativeMenuItem title="Send feedback" click=".feedback-button button" />}
         </NativeButton>
-        <NativeButton icon="plus" click="#new-document-button" />
       </NativeNavbar>
+      {/* Floating action button, sibling of the navbar (its own signal
+          element). While a create is in flight the only feedback is the web
+          hero button's disabled "Creating…" state; repeat taps are no-ops. */}
+      <NativeFab icon="plus" click="#new-document-button" />
       <div className="landing">
         <div className="landing-corner">
           <AccountControl viewer={viewer} />

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -44,12 +44,13 @@ declare module '@ruby-native/react' {
   }): ReactElement
 
   /**
-   * Floating action button. Requires `icon` (or a matching `icons` entry) —
-   * the component throws without one. `href` navigates; `click` clicks a
-   * DOM element by CSS selector.
+   * Floating action button. `icon` is required: on the open web the platform
+   * is unknown, so an `icons`-only usage falls back to `icon` and throws when
+   * it is absent. `href` navigates; `click` clicks a DOM element by CSS
+   * selector.
    */
   export function NativeFab(props: {
-    icon?: string
+    icon: string
     icons?: { ios?: string; android?: string }
     href?: string
     click?: string

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -55,6 +55,16 @@ declare module '@ruby-native/react' {
     click?: string
   }): ReactElement
 
+  /**
+   * Nav-bar submit button for form pages. `click` clicks a DOM element by
+   * CSS selector (defaults to [type='submit'] — pass an explicit scoped
+   * selector when the page has more than one submit button).
+   */
+  export function NativeSubmitButton(props: {
+    title?: string
+    click?: string
+  }): ReactElement
+
   /** Marks the page as a form so native back navigation skips it. */
   export function NativeForm(): ReactElement
 

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -43,6 +43,18 @@ declare module '@ruby-native/react' {
     selected?: boolean
   }): ReactElement
 
+  /**
+   * Floating action button. Requires `icon` (or a matching `icons` entry) —
+   * the component throws without one. `href` navigates; `click` clicks a
+   * DOM element by CSS selector.
+   */
+  export function NativeFab(props: {
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    href?: string
+    click?: string
+  }): ReactElement
+
   /** Marks the page as a form so native back navigation skips it. */
   export function NativeForm(): ReactElement
 

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -30,6 +30,19 @@ declare module '@ruby-native/react' {
     children?: ReactNode
   }): ReactElement
 
+  /**
+   * Dropdown menu entry inside a NativeButton. `href` navigates; `click`
+   * clicks a DOM element by CSS selector.
+   */
+  export function NativeMenuItem(props: {
+    title: string
+    href?: string
+    click?: string
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    selected?: boolean
+  }): ReactElement
+
   /** Marks the page as a form so native back navigation skips it. */
   export function NativeForm(): ReactElement
 

--- a/docs/plans/2026-07-02-009-feat-native-navigation-menus-fab-plan.md
+++ b/docs/plans/2026-07-02-009-feat-native-navigation-menus-fab-plan.md
@@ -1,0 +1,206 @@
+---
+title: Native Navigation Menus, FAB, and Native Login Polish - Plan
+type: feat
+date: 2026-07-02
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Native Navigation Menus, FAB, and Native Login Polish - Plan
+
+## Goal Capsule
+
+Extend the Ruby Native iOS shell (landed in PR #132) with the navigation affordances the gem provides but Thinkroom does not yet use: a native dropdown menu on the top-left (leading) and top-right (trailing) of the home nav bar, a native floating action button (FAB) that creates a new document, and a more native login experience (nav-bar submit button, no pull-to-refresh on the form). All native chrome is signal-element based — hidden `data-native-*` divs rendered by `@ruby-native/react` components — and inert on the open web.
+
+Authority: this plan; then `docs/plans/2026-07-02-004-feat-ruby-native-ios-app-plan.md` (the #132 decisions this extends); then the installed `ruby_native` 0.10.11 gem and `@ruby-native/react` 0.10.11 package sources, which are the authoritative signal-element contract.
+
+Stop conditions: stop if the `@ruby-native/react` package lacks a component this plan names (it does not — verified against `node_modules/@ruby-native/react/index.js`); stop if making a menu item work requires changing web-visible behavior (native chrome must never alter the web UI).
+
+---
+
+## Product Contract
+
+### Summary
+
+The home page nav bar gains two native dropdown menus — leading (account: sign in / sign out) and trailing (actions: agent start, demo, feedback) — and a native FAB replaces the current nav-bar plus button for creating a document. The login page becomes more native: a nav-bar submit button, pull-to-refresh disabled so a half-filled form can't be accidentally wiped, and autofill-friendly field hints. The document page keeps its web header (a #132 decision this plan preserves).
+
+### Problem Frame
+
+PR #132 wired the shell but used only a fraction of the gem's navigation surface: one plus button on home, a bare navbar on auth. The FAB was explicitly deferred in that plan. Meanwhile the home page's real navigation (account control, agent start, demo, feedback) is web-only chrome that feels foreign inside the native app, and the login form still behaves like a web page (pull-to-refresh can discard input, submit lives only below the fold of the form).
+
+### Requirements
+
+**Home navigation**
+
+- R1. In the native shell, the home nav bar shows a leading (top-left) dropdown menu with account actions: "Sign in" for guests (navigates to `/login?return_to=%2F`), "Sign out" for signed-in users (triggers the existing web sign-out).
+- R2. In the native shell, the home nav bar shows a trailing (top-right) dropdown menu with: "Have an agent start one" (triggers the existing `#agent-start-trigger`), "Open the demo" (navigates to `/d/demo`, only when the demo document exists in the list), and "Send feedback" (triggers the existing feedback button).
+- R3. A native FAB with a plus icon creates a new document by clicking the existing `#new-document-button`, reusing the exact web submission path. The previous nav-bar plus button is removed (the FAB replaces it, not duplicates it).
+
+**Native login**
+
+- R4. The auth nav bar shows a native submit button titled "Sign in" (or "Create account" when registering) that submits the credentials form via a click selector scoped to the form's own submit button — never the Google OAuth submit button that appears earlier in the DOM.
+- R5. Pull-to-refresh is disabled on the auth page so a drag inside the form cannot reload and discard input.
+- R6. The login email field carries `autoComplete="username"` so iOS credential autofill pairs it with the password field; the register flow keeps `name`/`email`/`new-password` hints.
+
+**Invariants**
+
+- R7. No web-visible behavior changes: all new chrome is hidden signal elements plus stable `id` attributes on existing web controls; the web UI renders and behaves identically outside the native shell.
+- R8. `npm run check`, `bin/rubocop`, `bin/rails test`, and `script/native_shell_check.mjs` pass; the native shell check asserts every new signal element that renders in its unauthenticated session. The signed-in account-menu variant (`#account-signout`) and actual native rendering of menus/FAB are verified by a manual device pass (`bundle exec ruby_native preview`), not by the browser check.
+
+### Scope Boundaries
+
+Out of scope: web UI redesign; Android-specific icons beyond the gem's `icons:` fallback behavior; any server-side auth changes (native remember-me landed in #130/#132).
+
+#### Deferred to Follow-Up Work
+
+- Native navbar on the document page (native share sheet via `NativeShareButton`, native menu mirroring `HeaderMenu`). #132's KTD keeps the doc page's web header because mode control, presence, and Accept-all have no native-navbar equivalent; revisiting that is its own piece of work.
+- Hiding the web submit button on auth inside the native shell (`native-hidden`). Kept visible this round so submission never depends on the shell rendering the nav-bar button.
+- Push notifications, badges, IAP, App Store submission config — carried forward from #132's deferred list.
+
+### Assumptions
+
+Recorded because this plan was scoped headlessly (pipeline run):
+
+- The FAB replaces the nav-bar plus button rather than coexisting with it — one affordance per action, per iOS convention.
+- Menu contents are inferred from the existing home-page web chrome: leading = account, trailing = secondary actions. Nothing new is invented; every item maps to an existing web control or route.
+- The document page keeps its web header, preserving #132's recorded decision.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **Use `NativeMenuItem` children inside `NativeButton` for dropdowns.** The gem contract (`ruby_native-0.10.11` helper + `@ruby-native/react` `index.js`) turns a `NativeButton` with children into a native dropdown menu. `href` items navigate; `click` items click a DOM selector. No new bridge code.
+- **`NativeFab` with `click: '#new-document-button'`.** Same delegation pattern #132 established for the nav-bar plus: native affordances trigger the existing web control so there is exactly one submission path. The web button keeps its `nativeHaptic('impact')`.
+- **Sign-out via click selector, sign-in via href.** Sign-out is a DELETE (Inertia `Link method="delete"` rendered as a button) — a menu `href` would issue a GET. Give the existing `AccountControl` sign-out button a stable `id` and use `click:`. Sign-in is a plain GET link, so `href` is correct.
+- **Scope the auth submit selector.** `NativeSubmitButton`'s default `click` selector is `[type='submit']`, which on the auth page would match the Google OAuth form's submit button first. Give the credentials submit button `id="auth-submit"` and pass `click: '#auth-submit'` explicitly.
+- **Stable selectors are the native-bridge contract with the web UI.** New ids (`#account-signout`, `#auth-submit`) join the existing `#new-document-button` / `#agent-start-trigger` as click targets; they are inert attributes on the web. The feedback trigger cannot take an id — `feedback_button.tsx` delegates to the third-party `RiffrecRecorder`, whose props accept only `className` (forwarded to a wrapper, not the inner button) — so the feedback menu item uses the scoped CSS selector `.feedback-button button` instead.
+- **Type the new components in the local `.d.ts`.** `@ruby-native/react` ships untyped JS; `app/frontend/types/ruby_native.d.ts` deliberately types only the surface Thinkroom uses. Extend it with `NativeMenuItem`, `NativeFab`, and `NativeSubmitButton` (props exactly as implemented in the package's `index.js`).
+- **Verification lives in the browser check, not Rails integration tests.** Signal elements are client-rendered React; server-side tests cannot see them. `script/native_shell_check.mjs` (already in CI's `browser_checks` job) is the contract test surface and gets assertions for every new element.
+
+### High-Level Technical Design
+
+Native affordance → web target mapping (all signal elements are hidden divs the shell reads; nothing renders visibly on the web):
+
+```mermaid
+flowchart LR
+  subgraph home ["Home (documents/index)"]
+    LM["Leading menu\n(person icon)"] -->|guest: href| LOGIN["/login?return_to=%2F"]
+    LM -->|"signed in: click"| SO["#account-signout\n(AccountControl sign-out)"]
+    TM["Trailing menu\n(ellipsis icon)"] -->|click| AS["#agent-start-trigger"]
+    TM -->|"href (when demo exists)"| DEMO["/d/demo"]
+    TM -->|click| FB[".feedback-button button"]
+    FAB["NativeFab (plus)"] -->|click| ND["#new-document-button"]
+  end
+  subgraph auth ["Auth (auth/show)"]
+    NSB["NativeSubmitButton\n'Sign in' / 'Create account'"] -->|click| SUB["#auth-submit"]
+  end
+```
+
+### Execution direction
+
+This is signal-element wiring with no server-side logic: verify smoke-first by running the app and the native shell check rather than writing unit tests first. The browser check proves the DOM signal contract (the elements the shell reads exist with the right attributes); it cannot prove native rendering — whether the shell actually draws a dropdown from `NativeMenuItem` children, or where the FAB floats. That is only observable on a device via `bundle exec ruby_native preview`, which is the required final pass before deploy (same limitation #132 recorded).
+
+---
+
+## Implementation Units
+
+### U1. Home nav-bar dropdown menus
+
+**Goal:** Leading account menu and trailing actions menu on the home page's native nav bar.
+
+**Requirements:** R1, R2, R7.
+
+**Dependencies:** none.
+
+**Files:**
+- `app/frontend/pages/documents/index.tsx` — add `NativeMenuItem` children under two new `NativeButton`s (leading + trailing) inside the existing `NativeNavbar`.
+- `app/frontend/components/account_control.tsx` — stable `id="account-signout"` on the signed-in sign-out button (Inertia `Link method="delete" as="button"` forwards `id` onto the rendered button).
+- `app/frontend/types/ruby_native.d.ts` — declare `NativeMenuItem`.
+
+**Approach:** The leading button (icon `person.crop.circle`, `position: 'leading'`) renders one menu item chosen by the `viewer` prop already on the page: guest → "Sign in" with `href`, signed-in → "Sign out" with `click: '#account-signout'`. The trailing button (icon `ellipsis.circle`, default trailing position) carries "Have an agent start one" (`click: '#agent-start-trigger'`), "Open the demo" (`href: '/d/demo'`, rendered only under the same `recent.some(slug === 'demo')` condition the web link uses), and "Send feedback" (`click: '.feedback-button button'` — the RiffrecRecorder wrapper's inner trigger; rendered under the same `isClient` condition as the web button). Menu contents are static per page load — sign-in state is server-known at render, matching how the shell reads signal elements.
+
+**Patterns to follow:** the existing `NativeNavbar`/`NativeButton` usage in `documents/index.tsx`; comment style from #132's "Ruby Native chrome" block.
+
+**Test scenarios:** covered by U4's browser check (menus present with expected items and targets in native context; ids present but chrome absent in web context). Test expectation here: none beyond U4 — pure signal-element markup.
+
+**Verification:** `npm run check` passes; U4 assertions pass.
+
+### U2. Native FAB for new document
+
+**Goal:** A floating action button creates a document; the nav-bar plus is removed.
+
+**Requirements:** R3, R7.
+
+**Dependencies:** none (parallel with U1; touches the same `NativeNavbar` block, so land after U1 to avoid churn).
+
+**Files:**
+- `app/frontend/pages/documents/index.tsx` — add `NativeFab icon="plus" click="#new-document-button"`; remove the `NativeButton icon="plus"` from the navbar.
+- `app/frontend/types/ruby_native.d.ts` — declare `NativeFab` (note: it throws without an icon; type `icon`/`icons` accordingly).
+
+**Approach:** direct swap; the FAB delegates to the same web button, so processing/disabled state and haptics stay in one place. Place `NativeFab` as a sibling of `NativeNavbar`, not nested inside it — it is its own signal element. Accepted in-flight behavior for this round: while a create is processing, the only feedback is the web hero button's "Creating…" state (which may be off-screen when tapping a bottom FAB); the disabled web button makes repeat taps no-ops.
+
+**Test scenarios:** covered by U4 (FAB signal present with icon + click target in native context; exactly zero nav-bar plus buttons remain). Test expectation here: none beyond U4.
+
+**Verification:** `npm run check` passes; U4 assertions pass.
+
+### U3. Native login polish
+
+**Goal:** Auth page submits from the native nav bar, can't be wiped by pull-to-refresh, and pairs with iOS credential autofill.
+
+**Requirements:** R4, R5, R6, R7.
+
+**Dependencies:** none.
+
+**Files:**
+- `app/frontend/pages/auth/show.tsx` — `id="auth-submit"` on the credentials submit button; `NativeSubmitButton` with mode-dependent title and `click: '#auth-submit'`; `pullToRefresh={false}` on the existing `NativeNavbar`; `autoComplete="username"` on the login-mode email input (register keeps `email`).
+- `app/frontend/types/ruby_native.d.ts` — declare `NativeSubmitButton`.
+
+**Approach:** the web submit button stays visible (see Scope Boundaries) — the native button is additive. The submit button's disabled state during `processing` still guards double-submit because the native button clicks the same DOM element.
+
+**Test scenarios (via U4 plus one manual check):**
+- Native context, `/login`: `data-native-submit-button` present with `data-native-title="Sign in"` and `data-native-click="#auth-submit"`; navbar signal carries `data-native-pull-to-refresh="false"`; email input has `autocomplete="username"`.
+- Native context, `/signup`: submit title is "Create account"; email autocomplete remains `email`.
+- Native context: the Google form's submit button does NOT carry `id="auth-submit"` (selector-scoping guard).
+- Web context: no `data-native-submit-button` behavior change — element may exist but is hidden/inert; the visible form still submits.
+
+**Verification:** `npm run check` passes; U4 assertions pass.
+
+### U4. Extend the native shell contract check
+
+**Goal:** `script/native_shell_check.mjs` proves every new signal element in native context and proves non-leakage in web context.
+
+**Requirements:** R8 (and mechanically verifies R1–R7).
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- `script/native_shell_check.mjs` — new assertions following the existing `check(locator.count(), msg)` style.
+
+**Approach:** In the native context: home has a leading `data-native-button` containing `data-native-menu-item` children with the expected titles/targets, a trailing menu likewise, exactly one `data-native-fab` with `data-native-icon="plus"` and `data-native-click="#new-document-button"`, and zero nav-bar plus buttons; `/login` has the scoped native submit button and `data-native-pull-to-refresh="false"`. In the web (non-native UA) context: the page still renders the stable click targets (`#new-document-button`, `#agent-start-trigger`, `.feedback-button button`, `#auth-submit`, and `#account-signout` or the sign-in link) and no visible native chrome. Update the existing "native plus button targets #new-document-button" assertion, which U2 removes.
+
+**Test scenarios:** the check IS the test; also update any assertion the removal in U2 breaks. Guest vs signed-in menu variants: assert the guest variant (the check runs unauthenticated); assert the signed-in variant only if the check already has a sign-in leg — do not build auth plumbing into the check for this.
+
+**Verification:** `BASE_URL=http://localhost:3005 SLUG=demo node script/native_shell_check.mjs` green locally (run the app with `PORT=3005 bin/dev`; 3000/3001 are taken by other local apps); the CI `browser_checks` job stays green.
+
+---
+
+## Verification Contract
+
+- `npm run check` — TypeScript, including the extended `ruby_native.d.ts`.
+- `bin/rubocop` — no Ruby changes expected, but the gate runs regardless.
+- `bin/rails test` — full Minitest suite (~600 runs); nothing here should change server behavior.
+- `PORT=3005 bin/dev` + `BASE_URL=http://localhost:3005 SLUG=demo node script/native_shell_check.mjs` — the native contract check, extended in U4.
+- CI (`.github/workflows/ci.yml` `browser_checks` job) runs `native_shell_check` and the rest of the browser suite on the PR.
+- Manual device pass before deploy: `bundle exec ruby_native preview` — confirm the leading/trailing dropdowns actually render as native menus, the FAB floats without obscuring the footer or the "Show N more" control, the signed-in menu shows Sign out and it works, and the auth nav-bar submit button submits the credentials form.
+
+## Definition of Done
+
+- R1–R8 implemented and traced through U1–U4.
+- All Verification Contract gates green locally and in CI.
+- No web-visible diff: a non-native browser renders the same UI and behavior as `main`.
+- No leftover experiments: the nav-bar plus button is gone (not commented out), and the `.d.ts` types match exactly what `@ruby-native/react@0.10.11` implements.
+- PR merged to `main` after CI passes; production deploy via Kamal follows the merge (manual step, per `DEPLOYING.md`). The `ruby_native preview` device pass is the post-deploy acceptance check for the native-rendering behavior the browser check cannot see.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brainstorm-riffrec-to-pr-pipeline",
+  "name": "thinkroom",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -39,34 +39,8 @@ try {
   })
   const page = await native.newPage()
 
-  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
-  await mounted(page)
-  check(
-    (await page.locator('[data-native-navbar="Thinkroom"]').count()) === 1,
-    'home: native navbar signal present',
-  )
-  check(
-    (await page.locator('[data-native-button][data-native-click="#new-document-button"]').count()) === 1,
-    'home: native plus button targets #new-document-button',
-  )
-  check(
-    (await page.locator('#new-document-button[data-native-haptic="impact"]').count()) === 1,
-    'home: New document button carries an impact haptic',
-  )
-
-  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
-  await mounted(page)
-  check((await page.locator('[data-native-navbar="Sign in"]').count()) === 1, 'login: native navbar signal present')
-  check((await page.locator('[data-native-form]').count()) === 1, 'login: NativeForm marker present (back skips the form)')
-  check(
-    (await page.locator('input[name="remember_me"]').count()) === 0,
-    'login: remember-me checkbox hidden (native sessions are always remembered)',
-  )
-  check(
-    (await page.locator('button[type="submit"][data-native-haptic="impact"]').count()) >= 1,
-    'login: submit carries an impact haptic',
-  )
-
+  // Doc page first: opening it records the slug in the session's recents,
+  // which the home trailing menu's "Open the demo" item renders from.
   await page.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
   await mounted(page)
   check(
@@ -89,16 +63,116 @@ try {
     return paddingTop >= 47
   })
   check(headerClearsNotch, 'doc: header padding-top honors the shell safe-area variable at phone width')
+
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check(
+    (await page.locator('[data-native-navbar="Thinkroom"]').count()) === 1,
+    'home: native navbar signal present',
+  )
+  const leading = page.locator('[data-native-button][data-native-position="leading"]')
+  check((await leading.count()) === 1, 'home: leading account menu button present')
+  check(
+    (await leading
+      .locator('[data-native-menu-item][data-native-title="Sign in"][data-native-href="/login?return_to=%2F"]')
+      .count()) === 1,
+    'home: guest account menu offers Sign in',
+  )
+  const trailing = page.locator('[data-native-button][data-native-position="trailing"]')
+  check((await trailing.count()) === 1, 'home: trailing actions menu button present')
+  check(
+    (await trailing
+      .locator('[data-native-menu-item][data-native-title="Have an agent start one"][data-native-click="#agent-start-trigger"]')
+      .count()) === 1,
+    'home: actions menu triggers the agent start reveal',
+  )
+  check(
+    (await trailing
+      .locator('[data-native-menu-item][data-native-title="Open the demo"][data-native-href="/d/demo"]')
+      .count()) === 1,
+    'home: actions menu links the demo once it is in recents',
+  )
+  check(
+    (await trailing
+      .locator('[data-native-menu-item][data-native-title="Send feedback"][data-native-click=".feedback-button button"]')
+      .count()) === 1,
+    'home: actions menu triggers feedback recording',
+  )
+  check(
+    (await page.locator('.feedback-button button').count()) === 1,
+    'home: feedback menu click target resolves to exactly one button',
+  )
+  check(
+    (await page.locator('[data-native-fab][data-native-icon="plus"][data-native-click="#new-document-button"]').count()) === 1,
+    'home: FAB creates a new document via #new-document-button',
+  )
+  check(
+    (await page.locator('[data-native-button][data-native-click="#new-document-button"]').count()) === 0,
+    'home: navbar plus button removed (the FAB replaces it)',
+  )
+  check(
+    (await page.locator('#new-document-button[data-native-haptic="impact"]').count()) === 1,
+    'home: New document button carries an impact haptic',
+  )
+
+  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check(
+    (await page.locator('[data-native-navbar="Sign in"][data-native-pull-to-refresh="false"]').count()) === 1,
+    'login: native navbar present with pull-to-refresh disabled',
+  )
+  check((await page.locator('[data-native-form]').count()) === 1, 'login: NativeForm marker present (back skips the form)')
+  check(
+    (await page.locator('input[name="remember_me"]').count()) === 0,
+    'login: remember-me checkbox hidden (native sessions are always remembered)',
+  )
+  check(
+    (await page.locator('button[type="submit"][data-native-haptic="impact"]').count()) >= 1,
+    'login: submit carries an impact haptic',
+  )
+  check(
+    (await page.locator('[data-native-submit-button][data-native-title="Sign in"][data-native-click="#auth-submit"]').count()) === 1,
+    'login: native navbar submit button scoped to #auth-submit',
+  )
+  check(
+    (await page.locator('#auth-submit[type="submit"]').count()) === 1,
+    'login: #auth-submit is the credentials submit button',
+  )
+  check(
+    (await page.locator('input[type="email"][autocomplete="username"]').count()) === 1,
+    'login: email field pairs with iOS credential autofill',
+  )
+
+  await page.goto(`${BASE}/signup`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  check(
+    (await page.locator('[data-native-submit-button][data-native-title="Create account"][data-native-click="#auth-submit"]').count()) === 1,
+    'signup: native submit button titled Create account',
+  )
+  check(
+    (await page.locator('input[type="email"][autocomplete="email"]').count()) === 1,
+    'signup: email field keeps contact autofill',
+  )
   await native.close()
 
   const web = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true })
   const webPage = await web.newPage()
+  await webPage.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(webPage)
+  check(await webPage.locator('#new-document-button').isVisible(), 'web home: New document button visible')
+  check((await webPage.locator('#agent-start-trigger').count()) === 1, 'web home: agent start trigger present')
+  check(!(await webPage.locator('[data-native-fab]').isVisible()), 'web home: FAB signal never visible')
+  check(
+    (await webPage.locator('[data-native-menu-item]:visible').count()) === 0,
+    'web home: native menu items never visible',
+  )
   await webPage.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
   await mounted(webPage)
   check(
     (await webPage.locator('input[name="remember_me"]').count()) === 1,
     'web login: remember-me checkbox still present',
   )
+  check(await webPage.locator('#auth-submit').isVisible(), 'web login: credentials submit button still visible')
   await webPage.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
   await mounted(webPage)
   check(

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -139,6 +139,10 @@ try {
     'login: #auth-submit is the credentials submit button',
   )
   check(
+    (await page.locator('form[action="/auth/google_oauth2"] #auth-submit').count()) === 0,
+    'login: Google OAuth submit button does not collide with #auth-submit',
+  )
+  check(
     (await page.locator('input[type="email"][autocomplete="username"]').count()) === 1,
     'login: email field pairs with iOS credential autofill',
   )


### PR DESCRIPTION
## Summary

Inside the Ruby Native iOS app, the home screen now has real native navigation: a top-left account menu (Sign in / Sign out), a top-right actions menu (Have an agent start one, Open the demo, Send feedback), and a native floating action button that creates a document — replacing the lone nav-bar plus button from #132. The login screen behaves like a native form: a nav-bar Sign in / Create account button submits the credentials form, pull-to-refresh can no longer wipe a half-filled form, and the email field pairs with iOS credential autofill.

Nothing changes on the open web: every native affordance is a hidden signal element that delegates to an existing web control by stable selector, so each action keeps exactly one submission path.

## Design decisions

- The FAB replaces the nav-bar plus (one affordance per action) and delegates to `#new-document-button`, keeping disabled/processing state and haptics in one place.
- The native submit button is scoped to `#auth-submit` because the Google OAuth form's submit button appears earlier in the DOM — the gem's default `[type='submit']` selector would post the wrong form. CI now asserts the collision guard.
- Sign-out delegates via a click target (not `href`) so it stays on the Inertia DELETE path with CSRF protection intact.
- The feedback menu item targets `.feedback-button button` because the third-party RiffrecRecorder accepts only `className` — no id can reach its inner trigger.
- `NativeFab`'s local typing requires `icon`: on the open web the platform is unknown, so an `icons`-only usage would throw on every render.

## Validation

- `script/native_shell_check.mjs` gained 13 assertions (32 total), written first and observed red before implementation, green after. Runs in CI's `browser_checks` job.
- `npm run check`, `bin/rubocop`, and `bin/rails test` (579 runs) all green. Browser-tested `/`, `/login`, `/signup`: the web UI is unchanged, and the FAB's exact delegation path (a programmatic `#new-document-button` click) created a document end-to-end.
- Native rendering — the menus actually drawing as dropdowns, FAB placement over the footer, the signed-in Sign out item — is invisible to the DOM check. The post-deploy `bundle exec ruby_native preview` device pass covers it, per the plan's Verification Contract.

Related: docs/plans/2026-07-02-009-feat-native-navigation-menus-fab-plan.md

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only native signal wiring and stable DOM ids; no server or auth logic changes, with CI browser checks covering the DOM contract.
> 
> **Overview**
> Extends the Ruby Native shell with **hidden signal-element** navigation on home and auth while keeping the open web UI unchanged—every native action **clicks or navigates to existing web controls**.
> 
> On **home**, the nav-bar plus is **replaced** by a **`NativeFab`** that delegates to `#new-document-button`. **Leading** and **trailing** **`NativeButton`** dropdowns mirror account (Sign in / Sign out via `#account-signout`) and secondary actions (agent start, demo, feedback). **`AccountControl`** gains **`id="account-signout"`** so native sign-out stays on the Inertia DELETE path.
> 
> On **auth**, **`NativeSubmitButton`** targets **`#auth-submit`** (avoids the Google OAuth submit), **`pullToRefresh={false}`**, and login email uses **`autoComplete="username"`** for iOS autofill.
> 
> **`ruby_native.d.ts`** types **`NativeMenuItem`**, **`NativeFab`**, and **`NativeSubmitButton`**. **`script/native_shell_check.mjs`** adds assertions for menus, FAB, auth submit scoping, and web non-leakage; it visits the demo doc first so the trailing “Open the demo” item is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5933fce4b91b347ae98233f09915500962cb39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->