### PR TITLE
feat(native): doc editor menu, native home chrome, and swipe-to-delete

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -292,7 +292,12 @@ class DocumentsController < InertiaController
     return redirect_to root_path, status: :see_other if document.nil?
 
     unless document.owned_by?(owner_token, user: current_user)
-      return redirect_back fallback_location: document_page_path(document.slug), status: :see_other,
+      # No explicit :see_other on error redirects: inertia_rails carries the
+      # session errors bag only through 302 responses (its middleware upgrades
+      # Inertia requests to 303 itself). An explicit 303 makes the middleware
+      # wipe the errors on this same response, so the client's onError never
+      # fires and the failure renders nothing.
+      return redirect_back fallback_location: document_page_path(document.slug),
                            inertia: { errors: { document: "Only the owner can delete this document" } }
     end
 
@@ -300,7 +305,7 @@ class DocumentsController < InertiaController
     DocumentMetaChannel.broadcast_event(document, :document_deleted)
     redirect_to root_path, status: :see_other
   rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::StatementInvalid
-    redirect_back fallback_location: document_page_path(params[:slug]), status: :see_other,
+    redirect_back fallback_location: document_page_path(params[:slug]),
                   inertia: { errors: { document: "Delete failed — please try again" } }
   end
 

--- a/app/frontend/components/swipe_row.tsx
+++ b/app/frontend/components/swipe_row.tsx
@@ -43,6 +43,10 @@ export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }
   // Disables the settle transition while the finger is down so the row
   // tracks the drag 1:1.
   const [dragging, setDragging] = useState(false)
+  // Live offset for pointerup: the state value is a render-closure snapshot
+  // and can be stale on a busy main thread (React may not re-render between
+  // the last move and the release), which would snap the row closed.
+  const offsetRef = useRef(0)
   const start = useRef<{ x: number; y: number } | null>(null)
   const axis = useRef<'horizontal' | 'vertical' | null>(null)
   // Sticky "this gesture was a swipe" flag: the click that follows a drag
@@ -52,6 +56,7 @@ export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }
   const close = useCallback(() => {
     setOpen(false)
     setOffset(0)
+    offsetRef.current = 0
   }, [])
 
   useEffect(() => {
@@ -99,14 +104,18 @@ export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }
     }
     if (axis.current !== 'horizontal') return
     const base = open ? -ACTION_WIDTH : 0
-    setOffset(Math.min(0, Math.max(-ACTION_WIDTH, base + dx)))
+    const next = Math.min(0, Math.max(-ACTION_WIDTH, base + dx))
+    offsetRef.current = next
+    setOffset(next)
   }
 
   const endGesture = () => {
     if (axis.current === 'horizontal') {
-      const shouldOpen = offset < -ACTION_WIDTH / 2
+      const shouldOpen = offsetRef.current < -ACTION_WIDTH / 2
       setOpen(shouldOpen)
-      setOffset(shouldOpen ? -ACTION_WIDTH : 0)
+      const settled = shouldOpen ? -ACTION_WIDTH : 0
+      offsetRef.current = settled
+      setOffset(settled)
     }
     start.current = null
     axis.current = null

--- a/app/frontend/components/swipe_row.tsx
+++ b/app/frontend/components/swipe_row.tsx
@@ -1,0 +1,143 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+} from 'react'
+import { nativeHaptic } from '@ruby-native/react'
+
+// Only one row may sit open at a time (the iOS list convention). Opening a
+// row registers its closer here; the next row to open — or a tap anywhere
+// else — invokes it.
+let closeOpenRow: (() => void) | null = null
+
+const ACTION_WIDTH = 88
+// Horizontal movement before we treat the gesture as a swipe (and start
+// suppressing the row's own click/navigation).
+const SLOP = 12
+
+interface Props {
+  slug: string
+  deleting: boolean
+  onDelete: () => void
+  children: ReactNode
+}
+
+/**
+ * iOS-style swipe-to-delete container for the native app's document rows.
+ * Drag left past the threshold to reveal a Delete action; vertical movement
+ * cancels so the list still scrolls; a tap on an open row closes it instead
+ * of navigating. Dependency-free pointer-event implementation (the plan's
+ * "Silk" library is not installed).
+ */
+export function SwipeRow({ slug, deleting, onDelete, children }: Props) {
+  const [offset, setOffset] = useState(0)
+  const [open, setOpen] = useState(false)
+  // Disables the settle transition while the finger is down so the row
+  // tracks the drag 1:1.
+  const [dragging, setDragging] = useState(false)
+  const start = useRef<{ x: number; y: number } | null>(null)
+  const axis = useRef<'horizontal' | 'vertical' | null>(null)
+  // Sticky "this gesture was a swipe" flag: the click that follows a drag
+  // must be suppressed even though pointerup already reset the drag state.
+  const swiped = useRef(false)
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setOffset(0)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    closeOpenRow?.()
+    closeOpenRow = close
+    return () => {
+      if (closeOpenRow === close) closeOpenRow = null
+    }
+  }, [open, close])
+
+  const onPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    start.current = { x: event.clientX, y: event.clientY }
+    axis.current = null
+    swiped.current = false
+  }
+
+  const onPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!start.current) return
+    const dx = event.clientX - start.current.x
+    const dy = event.clientY - start.current.y
+    if (!axis.current) {
+      if (Math.abs(dx) < SLOP && Math.abs(dy) < SLOP) return
+      axis.current = Math.abs(dx) > Math.abs(dy) ? 'horizontal' : 'vertical'
+      if (axis.current === 'horizontal') {
+        swiped.current = true
+        setDragging(true)
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId)
+        } catch {
+          // Synthetic events may carry an unknown pointerId; capture is an
+          // enhancement, not a requirement.
+        }
+      }
+    }
+    if (axis.current !== 'horizontal') return
+    const base = open ? -ACTION_WIDTH : 0
+    setOffset(Math.min(0, Math.max(-ACTION_WIDTH, base + dx)))
+  }
+
+  const endGesture = () => {
+    if (axis.current === 'horizontal') {
+      const shouldOpen = offset < -ACTION_WIDTH / 2
+      setOpen(shouldOpen)
+      setOffset(shouldOpen ? -ACTION_WIDTH : 0)
+    }
+    start.current = null
+    axis.current = null
+    setDragging(false)
+  }
+
+  // A click that follows a swipe (or lands on an open row) closes the row
+  // and never reaches the Inertia link underneath.
+  const onClickCapture = (event: MouseEvent<HTMLDivElement>) => {
+    if (swiped.current) {
+      event.preventDefault()
+      event.stopPropagation()
+      swiped.current = false
+      return
+    }
+    if (open) {
+      event.preventDefault()
+      event.stopPropagation()
+      close()
+    }
+  }
+
+  return (
+    <div className={`swipe-row${open ? ' is-open' : ''}`} data-swipe-row={slug}>
+      <div className="swipe-row-action">
+        <button
+          type="button"
+          disabled={deleting}
+          onClick={onDelete}
+          {...nativeHaptic('warning')}
+        >
+          {deleting ? 'Deleting…' : 'Delete'}
+        </button>
+      </div>
+      <div
+        className={`swipe-row-content${dragging ? ' is-dragging' : ''}`}
+        style={{ transform: offset === 0 ? undefined : `translateX(${offset}px)` }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endGesture}
+        onPointerCancel={endGesture}
+        onClickCapture={onClickCapture}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/components/swipe_row.tsx
+++ b/app/frontend/components/swipe_row.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from 'react'
 import { nativeHaptic } from '@ruby-native/react'
+import { useDismissable } from '../lib/use_dismissable'
 
 // Only one row may sit open at a time (the iOS list convention). Opening a
 // row registers its closer here; the next row to open — or a tap anywhere
@@ -23,6 +24,9 @@ interface Props {
   slug: string
   deleting: boolean
   onDelete: () => void
+  // Bump to force the row closed from the parent (e.g. after a failed
+  // delete, so the error message isn't paired with a still-armed action).
+  closeSignal?: number
   children: ReactNode
 }
 
@@ -33,7 +37,7 @@ interface Props {
  * of navigating. Dependency-free pointer-event implementation (the plan's
  * "Silk" library is not installed).
  */
-export function SwipeRow({ slug, deleting, onDelete, children }: Props) {
+export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }: Props) {
   const [offset, setOffset] = useState(0)
   const [open, setOpen] = useState(false)
   // Disables the settle transition while the finger is down so the row
@@ -58,6 +62,16 @@ export function SwipeRow({ slug, deleting, onDelete, children }: Props) {
       if (closeOpenRow === close) closeOpenRow = null
     }
   }, [open, close])
+
+  // Parent-forced close (failed delete).
+  useEffect(() => {
+    if (closeSignal > 0) close()
+  }, [closeSignal, close])
+
+  // Tapping anywhere outside an open row closes it, per the registry
+  // comment's contract (Escape too, via the shared popover hook).
+  const rootRef = useRef<HTMLDivElement>(null)
+  useDismissable(open, close, [rootRef])
 
   const onPointerDown = (event: PointerEvent<HTMLDivElement>) => {
     start.current = { x: event.clientX, y: event.clientY }
@@ -116,7 +130,7 @@ export function SwipeRow({ slug, deleting, onDelete, children }: Props) {
   }
 
   return (
-    <div className={`swipe-row${open ? ' is-open' : ''}`} data-swipe-row={slug}>
+    <div ref={rootRef} className={`swipe-row${open ? ' is-open' : ''}`} data-swipe-row={slug}>
       <div className="swipe-row-action">
         <button
           type="button"

--- a/app/frontend/components/swipe_row.tsx
+++ b/app/frontend/components/swipe_row.tsx
@@ -82,6 +82,16 @@ export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }
     start.current = { x: event.clientX, y: event.clientY }
     axis.current = null
     swiped.current = false
+    // Capture from the start so the whole gesture — including pointerup —
+    // stays on this element even when the pointer wanders off the row or
+    // layout shifts mid-drag. Capture routes events only; it does not block
+    // native vertical scrolling (touch-action: pan-y governs that).
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // Synthetic events may carry an unknown pointerId; capture is an
+      // enhancement, not a requirement.
+    }
   }
 
   const onPointerMove = (event: PointerEvent<HTMLDivElement>) => {
@@ -94,12 +104,6 @@ export function SwipeRow({ slug, deleting, onDelete, closeSignal = 0, children }
       if (axis.current === 'horizontal') {
         swiped.current = true
         setDragging(true)
-        try {
-          event.currentTarget.setPointerCapture(event.pointerId)
-        } catch {
-          // Synthetic events may carry an unknown pointerId; capture is an
-          // enhancement, not a requirement.
-        }
       }
     }
     if (axis.current !== 'horizontal') return

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -235,6 +235,13 @@ a:focus-visible {
   padding: 2rem;
 }
 
+/* Inside the native shell the web view extends behind the status bar and the
+   native nav bar sits above the page, so the landing needs the shell's
+   safe-area clearance on top. Inert on the open web (attribute absent). */
+[data-native-app] .landing {
+  padding-top: calc(2rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
+}
+
 .account-control {
   display: inline-flex;
   align-items: center;

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -451,6 +451,59 @@ a:focus-visible {
   transition: background 120ms ease;
 }
 
+/* Swipe-to-delete (native app only — the SwipeRow wrapper never renders on
+   the web). The row's padding moves into the sliding content so the revealed
+   action fills the full row height. */
+.document-row--swipe {
+  padding: 0;
+}
+
+.swipe-row {
+  position: relative;
+  overflow: hidden;
+}
+
+.swipe-row-action {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 88px;
+  display: flex;
+}
+
+.swipe-row-action button {
+  flex: 1;
+  border: 0;
+  background: var(--sketch-danger);
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.swipe-row-action button:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.swipe-row-content {
+  position: relative;
+  background: var(--surface-raised);
+  transition: transform 180ms ease;
+  /* Vertical panning stays native so the list scrolls; horizontal drags
+     reach the pointer handlers. */
+  touch-action: pan-y;
+}
+
+.swipe-row-content.is-dragging {
+  transition: none;
+}
+
+.swipe-row-padding {
+  padding: 0.78rem 0.9rem;
+}
+
 .document-row:last-child {
   border-bottom: 0;
 }

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -446,9 +446,18 @@ a:focus-visible {
 }
 
 .document-row {
-  padding: 0.78rem 0.9rem;
+  --document-row-pad: 0.78rem 0.9rem;
+  padding: var(--document-row-pad);
   border-bottom: 1px solid color-mix(in srgb, var(--ink) 16%, var(--line));
   transition: background 120ms ease;
+}
+
+/* Failed swipe-delete message, mirroring .document-tag-error's treatment. */
+.document-delete-error {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: #9b2f27;
 }
 
 /* Swipe-to-delete (native app only — the SwipeRow wrapper never renders on
@@ -501,7 +510,7 @@ a:focus-visible {
 }
 
 .swipe-row-padding {
-  padding: 0.78rem 0.9rem;
+  padding: var(--document-row-pad);
 }
 
 .document-row:last-child {
@@ -1019,26 +1028,6 @@ a:focus-visible {
 
 .doc-home:hover {
   opacity: 1;
-}
-
-/* Native back affordance for the Ruby Native shell. Hidden by default here
- * AND by the gem stylesheet; only the gem's body.can-go-back rule (higher
- * specificity) reveals it, so web users never see it even if the gem
- * stylesheet fails to load. */
-.doc-back {
-  display: none;
-  border: none;
-  background: none;
-  padding: 0 0.25rem 0 0;
-  color: var(--ink);
-  opacity: 0.85;
-  cursor: pointer;
-  line-height: 0;
-}
-
-.doc-back svg {
-  display: inline-block;
-  vertical-align: middle;
 }
 
 .doc-title {

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -324,7 +324,9 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
         </div>
         <main className="landing-main">
           <header className="landing-hero">
-            <h1 className="landing-wordmark">
+            {/* native-hidden: the native nav bar already says Thinkroom, so the
+                hero title would read twice inside the app. */}
+            <h1 className="landing-wordmark native-hidden">
               <Link href="/" className="landing-wordmark-link">
                 Thinkroom
               </Link>

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react'
-import { Head, Link, useForm } from '@inertiajs/react'
+import { Head, Link, router, useForm } from '@inertiajs/react'
 import { NativeNavbar, NativeButton, NativeMenuItem, NativeFab, nativeHaptic } from '@ruby-native/react'
 import { FeedbackButton } from '../../components/feedback_button'
 import { AccountControl } from '../../components/account_control'
+import { SwipeRow } from '../../components/swipe_row'
 import { userIdentity } from '../../editor/identity'
 import { setCookie } from '../../lib/cookies'
 import { useClaim } from '../../lib/use_claim'
@@ -27,6 +28,8 @@ type Props = {
   yours: DocLink[]
   recent: RecentDoc[]
   viewer: ViewerPayload
+  // Shared by RubyNative::InertiaSupport on every page.
+  nativeApp: boolean
 }
 
 const EARLIER_PREVIEW_LIMIT = 8
@@ -139,16 +142,18 @@ function DocumentRow({
   document,
   editable = false,
   claimerName,
+  swipe,
 }: {
   document: DocLink | RecentDoc
   editable?: boolean
   claimerName?: string
+  swipe?: { deleting: boolean; onDelete: () => void }
 }) {
   const [editingTags, setEditingTags] = useState(false)
   const recentDocument = 'claimable' in document ? document : null
 
-  return (
-    <li className="document-row">
+  const body = (
+    <>
       <div className="document-row-summary">
         <div className="document-row-copy">
           <Link className="document-row-title" href={`/d/${document.slug}`} prefetch>
@@ -179,8 +184,20 @@ function DocumentRow({
       </div>
       <DocumentTags tags={document.tags} />
       {editingTags && <TagEditor document={document} onClose={() => setEditingTags(false)} />}
-    </li>
+    </>
   )
+
+  if (swipe) {
+    return (
+      <li className="document-row document-row--swipe">
+        <SwipeRow slug={document.slug} deleting={swipe.deleting} onDelete={swipe.onDelete}>
+          <div className="swipe-row-padding">{body}</div>
+        </SwipeRow>
+      </li>
+    )
+  }
+
+  return <li className="document-row">{body}</li>
 }
 
 function DocumentGroup({
@@ -188,11 +205,15 @@ function DocumentGroup({
   documents,
   editable,
   claimerName,
+  deletingSlug,
+  onDeleteDocument,
 }: {
   title: string
   documents: Array<DocLink | RecentDoc>
   editable?: boolean
   claimerName?: string
+  deletingSlug?: string | null
+  onDeleteDocument?: (slug: string) => void
 }) {
   if (documents.length === 0) return null
   const headingId = `document-group-${title.toLowerCase().replace(/\s+/g, '-')}`
@@ -210,6 +231,14 @@ function DocumentGroup({
             document={document}
             editable={editable}
             claimerName={claimerName}
+            swipe={
+              onDeleteDocument
+                ? {
+                    deleting: deletingSlug === document.slug,
+                    onDelete: () => onDeleteDocument(document.slug),
+                  }
+                : undefined
+            }
           />
         ))}
       </ul>
@@ -217,7 +246,7 @@ function DocumentGroup({
   )
 }
 
-export default function DocumentsIndex({ yours, recent, viewer }: Props) {
+export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Props) {
   const [identityName] = useState(() => userIdentity(viewer.name).name)
   const { post, processing } = useForm(() => ({
     name: identityName,
@@ -290,6 +319,24 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
   const hiddenEarlierCount = earlier.length - visibleEarlier.length
   const claimerName = identityName
   const hasDemo = recent.some((document) => document.slug === 'demo')
+
+  // Native-only swipe-to-delete on owned rows. The server re-checks ownership;
+  // this is just the affordance. WKWebView shows confirm() as a native alert.
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const deleteDocument = useCallback((slug: string) => {
+    if (!window.confirm('Delete this document? This can’t be undone.')) return
+    setDeleteError(null)
+    router.delete(`/d/${slug}`, {
+      preserveScroll: true,
+      onStart: () => setDeletingSlug(slug),
+      onFinish: () => setDeletingSlug(null),
+      onError: (errors) => {
+        const message = typeof errors.document === 'string' ? errors.document : null
+        setDeleteError(message ?? 'Delete failed — please try again')
+      },
+    })
+  }, [])
 
   return (
     <>
@@ -424,8 +471,25 @@ export default function DocumentsIndex({ yours, recent, viewer }: Props) {
               <p className="document-library-empty">No documents use this tag yet.</p>
             ) : (
               <div className="document-groups">
-                <DocumentGroup title="This week" documents={thisWeek} editable />
-                <DocumentGroup title="Earlier" documents={visibleEarlier} editable />
+                {deleteError && (
+                  <p className="document-delete-error" role="alert">
+                    {deleteError}
+                  </p>
+                )}
+                <DocumentGroup
+                  title="This week"
+                  documents={thisWeek}
+                  editable
+                  deletingSlug={deletingSlug}
+                  onDeleteDocument={nativeApp ? deleteDocument : undefined}
+                />
+                <DocumentGroup
+                  title="Earlier"
+                  documents={visibleEarlier}
+                  editable
+                  deletingSlug={deletingSlug}
+                  onDeleteDocument={nativeApp ? deleteDocument : undefined}
+                />
                 {hiddenEarlierCount > 0 && (
                   <button
                     className="document-reveal"

--- a/app/frontend/pages/documents/index.tsx
+++ b/app/frontend/pages/documents/index.tsx
@@ -9,6 +9,7 @@ import { setCookie } from '../../lib/cookies'
 import { useClaim } from '../../lib/use_claim'
 import { useIsClient } from '../../lib/use_is_client'
 import type { OwnershipPayload } from '../../components/ownership_chip'
+import type { SharedProps } from '../../types'
 import type { ViewerPayload } from '../../types/viewer'
 
 type AgeGroup = 'this_week' | 'earlier'
@@ -24,12 +25,10 @@ type DocLink = {
 
 type RecentDoc = DocLink & OwnershipPayload
 
-type Props = {
+type Props = Pick<SharedProps, 'nativeApp'> & {
   yours: DocLink[]
   recent: RecentDoc[]
   viewer: ViewerPayload
-  // Shared by RubyNative::InertiaSupport on every page.
-  nativeApp: boolean
 }
 
 const EARLIER_PREVIEW_LIMIT = 8
@@ -147,7 +146,7 @@ function DocumentRow({
   document: DocLink | RecentDoc
   editable?: boolean
   claimerName?: string
-  swipe?: { deleting: boolean; onDelete: () => void }
+  swipe?: { deleting: boolean; onDelete: () => void; closeSignal: number }
 }) {
   const [editingTags, setEditingTags] = useState(false)
   const recentDocument = 'claimable' in document ? document : null
@@ -190,7 +189,12 @@ function DocumentRow({
   if (swipe) {
     return (
       <li className="document-row document-row--swipe">
-        <SwipeRow slug={document.slug} deleting={swipe.deleting} onDelete={swipe.onDelete}>
+        <SwipeRow
+          slug={document.slug}
+          deleting={swipe.deleting}
+          onDelete={swipe.onDelete}
+          closeSignal={swipe.closeSignal}
+        >
           <div className="swipe-row-padding">{body}</div>
         </SwipeRow>
       </li>
@@ -206,6 +210,7 @@ function DocumentGroup({
   editable,
   claimerName,
   deletingSlug,
+  swipeCloseSignal,
   onDeleteDocument,
 }: {
   title: string
@@ -213,6 +218,7 @@ function DocumentGroup({
   editable?: boolean
   claimerName?: string
   deletingSlug?: string | null
+  swipeCloseSignal?: number
   onDeleteDocument?: (slug: string) => void
 }) {
   if (documents.length === 0) return null
@@ -236,6 +242,7 @@ function DocumentGroup({
                 ? {
                     deleting: deletingSlug === document.slug,
                     onDelete: () => onDeleteDocument(document.slug),
+                    closeSignal: swipeCloseSignal ?? 0,
                   }
                 : undefined
             }
@@ -324,6 +331,9 @@ export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Pro
   // this is just the affordance. WKWebView shows confirm() as a native alert.
   const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  // Bumped on failure so every SwipeRow snaps closed (per R6, the error
+  // message shouldn't sit next to a still-armed Delete).
+  const [swipeCloseSignal, setSwipeCloseSignal] = useState(0)
   const deleteDocument = useCallback((slug: string) => {
     if (!window.confirm('Delete this document? This can’t be undone.')) return
     setDeleteError(null)
@@ -334,6 +344,7 @@ export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Pro
       onError: (errors) => {
         const message = typeof errors.document === 'string' ? errors.document : null
         setDeleteError(message ?? 'Delete failed — please try again')
+        setSwipeCloseSignal((signal) => signal + 1)
       },
     })
   }, [])
@@ -463,6 +474,13 @@ export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Pro
               )}
             </div>
 
+            {/* Above the list branches: a failed delete re-scopes the props,
+                and the message must survive whatever the list becomes. */}
+            {deleteError && (
+              <p className="document-delete-error" role="alert">
+                {deleteError}
+              </p>
+            )}
             {yours.length === 0 ? (
               <p className="document-library-empty">
                 Create a document and it will stay close at hand here.
@@ -471,16 +489,12 @@ export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Pro
               <p className="document-library-empty">No documents use this tag yet.</p>
             ) : (
               <div className="document-groups">
-                {deleteError && (
-                  <p className="document-delete-error" role="alert">
-                    {deleteError}
-                  </p>
-                )}
                 <DocumentGroup
                   title="This week"
                   documents={thisWeek}
                   editable
                   deletingSlug={deletingSlug}
+                  swipeCloseSignal={swipeCloseSignal}
                   onDeleteDocument={nativeApp ? deleteDocument : undefined}
                 />
                 <DocumentGroup
@@ -488,6 +502,7 @@ export default function DocumentsIndex({ yours, recent, viewer, nativeApp }: Pro
                   documents={visibleEarlier}
                   editable
                   deletingSlug={deletingSlug}
+                  swipeCloseSignal={swipeCloseSignal}
                   onDeleteDocument={nativeApp ? deleteDocument : undefined}
                 />
                 {hiddenEarlierCount > 0 && (

--- a/app/frontend/pages/documents/show.css
+++ b/app/frontend/pages/documents/show.css
@@ -40,3 +40,36 @@
 .version-update:hover {
   border-color: var(--accent);
 }
+
+/* ------------------------- Ruby Native shell chrome ---------------------- */
+
+/* Bridge strip: the native nav bar's menu items click these always-mounted
+   controls. Clip-hidden, never display:none — the shell's click dispatch is
+   unspecified and may need a real box to hit. */
+.native-bridge {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* With the web header hidden in the app, the page body takes over the
+   safe-area clearance the header's padding used to provide. */
+[data-native-app] .doc-page::before {
+  content: "";
+  display: block;
+  height: var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top));
+}
+
+/* Floating replacement for the header's update prompt inside the app. */
+.version-update--native {
+  position: fixed;
+  top: calc(0.75rem + var(--ruby-native-safe-area-inset-top, env(safe-area-inset-top)));
+  right: 0.75rem;
+  z-index: 60;
+  box-shadow: 0 2px 10px rgb(0 0 0 / 0.12);
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1316,11 +1316,16 @@ export default function DocumentShow({
             {bridgeMode}
           </button>
         ))}
+        {/* Activity is omitted from the native menu in Read mode and its sheet
+            only renders outside Read; a stale-menu tap during Read is a no-op
+            so activeSheet can't be set with nothing visible. */}
         <button
           id="native-toggle-activity"
           type="button"
           tabIndex={-1}
-          onClick={() => setActiveSheet((current) => (current === 'activity' ? null : 'activity'))}
+          onClick={() => {
+            if (!isReading) setActiveSheet((current) => (current === 'activity' ? null : 'activity'))
+          }}
         >
           Activity
         </button>

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -92,6 +92,7 @@ import { useIsClient } from '../../lib/use_is_client'
 import { useAnchoredPopover } from '../../lib/use_anchored_popover'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import { patchJSON } from '../../lib/csrf'
+import type { SharedProps } from '../../types'
 import type { ViewerPayload } from '../../types/viewer'
 import { setCookie, setCookieFlag } from '../../lib/cookies'
 import {
@@ -145,8 +146,7 @@ export interface DocumentProps {
   comments: CommentPayload[]
   activities: ActivityPayload[]
   presences: AgentPresencePayload[]
-  // Shared by RubyNative::InertiaSupport on every page.
-  nativeApp: boolean
+  nativeApp: SharedProps['nativeApp']
 }
 
 // Floating chrome stores only its anchor identity; geometry is re-derived
@@ -1324,10 +1324,27 @@ export default function DocumentShow({
         >
           Activity
         </button>
-        <button id="native-export-markdown" type="button" tabIndex={-1} onClick={() => void exportMarkdown()}>
+        {/* Gated on the live editor handle — the export helpers throw before
+            it exists, and the web UI disables its export buttons the same way
+            (SharePopover's exportReady). A pre-ready tap is a silent no-op. */}
+        <button
+          id="native-export-markdown"
+          type="button"
+          tabIndex={-1}
+          onClick={() => {
+            if (handle) void exportMarkdown()
+          }}
+        >
           Export Markdown
         </button>
-        <button id="native-export-html" type="button" tabIndex={-1} onClick={() => void exportHtml()}>
+        <button
+          id="native-export-html"
+          type="button"
+          tabIndex={-1}
+          onClick={() => {
+            if (handle) void exportHtml()
+          }}
+        >
           Export HTML
         </button>
       </div>
@@ -1349,24 +1366,9 @@ export default function DocumentShow({
         )}
         <header className="doc-header native-hidden">
           <div className="doc-header-left">
-            {/* Only visible inside the Ruby Native shell (body.can-go-back
-                toggles it); asks the shell to pop the native history. */}
-            <button
-              type="button"
-              className="native-back-button doc-back"
-              aria-label="Back"
-              onClick={() => window.RubyNative?.postMessage({ action: 'back' })}
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path
-                  d="M15.75 19.5L8.25 12l7.5-7.5"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </button>
+            {/* The nav bar's leading button (-> #native-doc-back) owns back in
+                the native shell now that this header hides there; the old
+                header back button had no other consumer. */}
             <Link href="/" className="doc-home" aria-label="Home">
               T.
             </Link>

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { Head, Link, router, usePoll } from '@inertiajs/react'
-import { nativeHaptic } from '@ruby-native/react'
+import {
+  NativeNavbar,
+  NativeButton,
+  NativeMenuItem,
+  NativeShareButton,
+  nativeHaptic,
+} from '@ruby-native/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { TextSelection } from '@milkdown/kit/prose/state'
 import {
@@ -139,6 +145,8 @@ export interface DocumentProps {
   comments: CommentPayload[]
   activities: ActivityPayload[]
   presences: AgentPresencePayload[]
+  // Shared by RubyNative::InertiaSupport on every page.
+  nativeApp: boolean
 }
 
 // Floating chrome stores only its anchor identity; geometry is re-derived
@@ -218,6 +226,7 @@ export default function DocumentShow({
   comments,
   activities,
   presences,
+  nativeApp,
 }: DocumentProps) {
   // SSR/hydration island flag: the live editor and any render-time browser
   // reads are gated on this so the server (and the client's first hydration
@@ -1261,11 +1270,84 @@ export default function DocumentShow({
   return (
     <>
       <Head title={documentTitle} />
+      {/* Ruby Native chrome: the shell reads these hidden signal elements. The
+          nav bar replaces the web doc-header inside the app (hidden below via
+          native-hidden); every action delegates to the bridge strip so targets
+          are always mounted and never display:none. */}
+      <NativeNavbar title={documentTitle}>
+        <NativeButton position="leading" icon="chevron.left" click="#native-doc-back" />
+        <NativeShareButton />
+        <NativeButton position="trailing" icon="ellipsis.circle">
+          {!modeLocked &&
+            availableModes.map((menuMode) => (
+              <NativeMenuItem
+                key={menuMode}
+                title={menuMode.charAt(0).toUpperCase() + menuMode.slice(1)}
+                selected={effectiveMode === menuMode}
+                click={`#native-mode-${menuMode}`}
+              />
+            ))}
+          {!isReading && <NativeMenuItem title="Activity" click="#native-toggle-activity" />}
+          <NativeMenuItem title="Export Markdown" click="#native-export-markdown" />
+          <NativeMenuItem title="Export HTML" click="#native-export-html" />
+          <NativeMenuItem title="Home" href="/" />
+        </NativeButton>
+      </NativeNavbar>
+      {/* Bridge strip: clip-hidden (never display:none — the shell's click
+          dispatch mechanism is unspecified, and coordinate-based synthesis
+          needs a real box). Handlers call the live setters directly. */}
+      <div className="native-bridge" aria-hidden="true">
+        <button
+          id="native-doc-back"
+          type="button"
+          tabIndex={-1}
+          onClick={() => window.RubyNative?.postMessage({ action: 'back' })}
+        >
+          Back
+        </button>
+        {availableModes.map((bridgeMode) => (
+          <button
+            key={bridgeMode}
+            id={`native-mode-${bridgeMode}`}
+            type="button"
+            tabIndex={-1}
+            onClick={() => changeMode(bridgeMode)}
+          >
+            {bridgeMode}
+          </button>
+        ))}
+        <button
+          id="native-toggle-activity"
+          type="button"
+          tabIndex={-1}
+          onClick={() => setActiveSheet((current) => (current === 'activity' ? null : 'activity'))}
+        >
+          Activity
+        </button>
+        <button id="native-export-markdown" type="button" tabIndex={-1} onClick={() => void exportMarkdown()}>
+          Export Markdown
+        </button>
+        <button id="native-export-html" type="button" tabIndex={-1} onClick={() => void exportHtml()}>
+          Export HTML
+        </button>
+      </div>
       <div
         className={`doc-page ${panelOpen ? '' : 'is-panel-hidden'} ${isReading ? 'is-read-mode' : ''}`}
         style={Object.keys(documentStyle).length === 0 ? undefined : documentStyle}
       >
-        <header className="doc-header">
+        {/* The update prompt normally lives in the (native-hidden) header; it
+            is the only trigger for reloading an owner-reset or newly deployed
+            document, so in the app it floats on its own. */}
+        {nativeApp && newVersionAvailable && (
+          <button
+            type="button"
+            className="version-update version-update--native"
+            onClick={() => window.location.reload()}
+          >
+            New version · Update
+          </button>
+        )}
+        <header className="doc-header native-hidden">
           <div className="doc-header-left">
             {/* Only visible inside the Ruby Native shell (body.can-go-back
                 toggles it); asks the shell to pop the native history. */}

--- a/app/frontend/types/ruby_native.d.ts
+++ b/app/frontend/types/ruby_native.d.ts
@@ -57,6 +57,18 @@ declare module '@ruby-native/react' {
   }): ReactElement
 
   /**
+   * Nav-bar share button: opens the platform share sheet. `url` defaults to
+   * the current page on the shell side.
+   */
+  export function NativeShareButton(props: {
+    position?: 'leading' | 'trailing'
+    title?: string
+    icon?: string
+    icons?: { ios?: string; android?: string }
+    url?: string
+  }): ReactElement
+
+  /**
    * Nav-bar submit button for form pages. `click` clicks a DOM element by
    * CSS selector (defaults to [type='submit'] — pass an explicit scoped
    * selector when the page has more than one submit button).

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html data-theme="<%= cookies[:proof_theme].to_s.presence_in(%w[proof whitey]) || "proof" %>">
+<%# data-native-app enables the gem's `[data-native-app] .native-hidden`
+    utility and the app's native-only CSS forks. Rendered server-side so the
+    fork is correct on first paint for both surfaces (no flash). %>
+<html data-theme="<%= cookies[:proof_theme].to_s.presence_in(%w[proof whitey]) || "proof" %>"<%= " data-native-app".html_safe if native_app? %>>
   <head>
     <title data-inertia><%= @open_graph&.dig(:page_title) || content_for(:title) || "Thinkroom" %></title>
     <%# viewport-fit=cover is required by Ruby Native so env(safe-area-inset-*)

--- a/docs/plans/2026-07-02-010-feat-native-editor-menu-swipe-plan.md
+++ b/docs/plans/2026-07-02-010-feat-native-editor-menu-swipe-plan.md
@@ -1,0 +1,221 @@
+---
+title: Native Editor Menu, Native Home Chrome, and Swipe-to-Delete - Plan
+type: feat
+date: 2026-07-02
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Native Editor Menu, Native Home Chrome, and Swipe-to-Delete - Plan
+
+## Goal Capsule
+
+Deepen the Ruby Native iOS experience shipped in PR #132/#140: the document editor gets a native nav bar (title, back, native share sheet, dropdown menu) while its web header hides in the native shell; the home page drops the redundant "Thinkroom" hero title in native with correct top spacing; and owned document rows on home gain iOS-style swipe-to-delete in the native app. The web experience is untouched — forks are keyed on the server-known `nativeApp` prop and the gem's `[data-native-app] .native-hidden` CSS utility.
+
+Authority: this plan; then `docs/plans/2026-07-02-009-feat-native-navigation-menus-fab-plan.md` and `docs/plans/2026-07-02-004-feat-ruby-native-ios-app-plan.md` (prior decisions this extends); then the installed `ruby_native` 0.10.11 gem and `@ruby-native/react` 0.10.11 sources (authoritative signal-element contract).
+
+Stop conditions: stop if hiding the web doc header in native would remove a control that has no native-menu, mobile-dock, or bridge-button replacement for a workflow the app depends on (enumerate before hiding); stop if the swipe interaction cannot be made native-only without touching web behavior.
+
+---
+
+## Product Contract
+
+### Summary
+
+In the native app, the document editor shows a native nav bar — document title, back chevron, a native share-sheet button, and a trailing dropdown (editor modes with checkmarks, focus mode, activity panel, Home) — and the web `doc-header` is hidden via CSS while staying in the DOM as the click-target layer. The home page hides the "Thinkroom" hero title (the nav bar already carries the name) and keeps safe-area spacing below the native bar. Owned documents in the home list can be swipe-revealed and deleted in the native app, with a confirmation dialog, using the existing owner-only `DELETE /d/:slug` endpoint.
+
+### Problem Frame
+
+PR #140 made home and auth feel native, but the editor — where users spend their time — still shows the full web header inside the native shell, duplicating chrome the nav bar should own. The home page reads "Thinkroom" twice (native nav bar + hero H1). And the document list has no touch-native affordances: deleting from the list isn't possible — the owner-only endpoint exists and is already exposed on the document page (`ownership_chip.tsx`, confirm + `router.delete`), but the home list offers no delete at all. The user asked for swipe gestures via "Silk"; that library is not installed (see Assumptions).
+
+### Requirements
+
+**Document editor (native)**
+
+- R1. In the native shell, the document page shows a native nav bar: document title, a leading back button (delegating to the existing shell-back control), a native share button (platform share sheet for the document URL), and a trailing dropdown menu.
+- R2. The trailing menu contains: the editor modes available to the viewer (Read / Suggest / Comment / Edit) with the active one marked selected (omitted entirely on mode-locked docs like the demo), "Activity" (non-read modes only, opening the mobile activity sheet), "Export Markdown", "Export HTML", and "Home". Menu items delegate to an always-mounted bridge-control strip. No "Focus mode" item — focus is already force-enabled at phone width, so the toggle would be inert in the shell.
+- R3. In the native shell, the web `doc-header` is hidden via CSS; suggestion/comment workflows remain available through the existing mobile dock. On the web, the header renders exactly as today. The hide honors the control inventory below (R3a) — every header control is re-homed, explicitly deferred, or an accepted loss; nothing disappears silently.
+- R3a. **Doc-header control inventory** (the Goal Capsule stop condition's enumeration):
+  - Re-homed to native chrome: document title (nav bar), back (leading button -> bridge), share URL (native share sheet), editor modes (menu -> bridge), activity sheet (menu -> bridge, non-read), export Markdown/HTML (menu -> bridge to the existing `exportMarkdown`/`exportHtml` handlers), Home (menu `href`).
+  - Re-homed outside the header: the "New version — Update" prompt is load-bearing (it is the only trigger for reloading an owner-reset or newly deployed document); in native it renders as a small floating control outside the hidden header, reusing the same handler.
+  - Accepted native losses this round (recorded, deferred): presence bar + follow, identity chip (guest rename), connection-status dot, provenance summary, owner link-access control, print, copy-agent-invite. Owners and collaborators retain all of these on the web.
+
+**Home page (native)**
+
+- R4. In the native shell, the "Thinkroom" hero title is hidden (the native nav bar already names the app); the page keeps correct top spacing below the native bar using the gem's safe-area utilities. The hero action buttons stay visible.
+- R5. The hiding is CSS-based via the gem's `.native-hidden` utility, enabled by rendering `data-native-app` on the `<html>` element server-side (`native_app?` helper), so the fork is SSR-correct with no flash on either surface.
+
+**Swipe-to-delete (native)**
+
+- R6. In the native app, rows in "Your documents" (owned docs only) support iOS-style swipe: dragging left reveals a red Delete action; tapping it asks for confirmation, then issues the existing `DELETE /d/:slug`. The action shows a pending state while in flight; on failure the row re-closes and an error is surfaced (the document stays listed); only a confirmed success removes the row.
+- R7. Swipe affordances do not exist on the open web and never appear for non-owned rows; the server's owner-only authorization remains the enforcement point.
+- R8. Delete carries haptic feedback in the shell, and the interaction does not break normal tap/scroll on the list. Row titles are Inertia links: once horizontal movement passes the slop threshold, the trailing click on the link is suppressed (no accidental navigation), and tapping an open row closes it instead of navigating.
+
+**Invariants**
+
+- R9. Zero web-visible changes: a non-native browser renders and behaves identically to `main`.
+- R10. `npm run check`, `bin/rubocop`, `bin/rails test`, and `script/native_shell_check.mjs` pass; the shell check asserts each new signal element and the native-hidden forks in both native and web contexts. Native rendering (menus drawing, share sheet, swipe feel) is verified by the `bundle exec ruby_native preview` device pass.
+
+### Scope Boundaries
+
+Out of scope: Advanced Mode (native push/pop transitions); swipe actions other than delete (archive, tag); web-side delete affordances; deleting from the document page itself; changes to the destroy endpoint.
+
+#### Deferred to Follow-Up Work
+
+- Swipe actions on the "Recent" list (non-owned docs have no deletable action; a "remove from recents" action would need a new endpoint).
+- Live-updating the native nav-bar title when the document is renamed mid-session, and the editor-mode checkmark when the mode switches without a page load (both depend on the shell's signal re-read cadence, unverifiable locally — check on-device, then decide).
+- Native surfaces for the accepted R3a losses: presence/follow, guest rename, connection status, owner link-access, print, copy-agent-invite.
+- Undo after delete.
+
+### Assumptions
+
+Recorded because this plan was scoped headlessly (pipeline run):
+
+- **Silk is not installed.** The user believed a swipe library ("Silk") was already in the project; `package.json` has no such dependency. The npm `@silk-hq/components` is proprietary-licensed ("SEE LICENSE FILE") and centers on sheet/dialog primitives, not list-row swipe. The plan implements a small dependency-free pointer-event swipe row instead. If the user prefers Silk, swapping the row internals later is contained to one component.
+- Delete confirms via `window.confirm` — WKWebView presents JS confirm as a native alert dialog, which is the cheapest native-feeling guard for a destructive action.
+- The hero action buttons ("New document", "Have an agent start one") stay visible in native; only the title hides. The user named the title specifically.
+- Editor-mode menu items may show a stale checkmark after switching modes without a page load (the shell's re-read cadence for signal elements is not locally verifiable); switching itself always works because items click live bridge buttons.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **Set `data-native-app` on `<html>` server-side.** The gem ships `[data-native-app] .native-hidden { display:none !important }` but nothing in the app or gem sets the attribute today. `native_app?` is exposed as a view helper (`RubyNative::NativeDetection`), so the layout can render the attribute on first paint — SSR-correct, no flash, and it unlocks the gem's own utility plus any custom `[data-native-app]` CSS. Harmless if the shell also sets it.
+- **All native click targets live in one clip-hidden bridge strip — never inside the hidden header.** The shell's click dispatch against `display:none` targets is not locally verifiable (it may synthesize coordinate-based events rather than `HTMLElement.click()`). So the doc page renders one always-mounted strip, visually hidden by clipping (`position:absolute; width/height:1px; clip-path`, never `display:none` or the `hidden` attribute), containing every control the native chrome clicks: `#native-doc-back` (posts the shell back message), `#native-mode-read|suggest|comment|edit` (call `changeMode`), `#native-toggle-activity` (opens the **mobile activity sheet** via `setActiveSheet('activity')` — NOT `setPanelOpen`, whose desktop rail never renders at phone width), `#native-export-markdown`, `#native-export-html` (the existing handlers). `aria-hidden` + `tabIndex={-1}` keep it invisible to web users and screen readers. The `doc-header` itself can then hide by any mechanism with zero native dependencies on it.
+- **Native share via `NativeShareButton`.** The share sheet needs no URL argument — it defaults to the current page. It replaces only URL sharing; export/print/agent-invite are handled per the R3a inventory, not by the share sheet.
+- **The version-update prompt escapes the hidden header.** When native and a new version is available, render the update control outside `doc-header` (floating, reusing the same handler) so stale native clients can always reload — this is the one header control whose loss would strand users (it is the sole `onVersionAvailable` trigger).
+- **Custom swipe row, no new dependency.** A `SwipeRow` component wrapping owned rows: pointer events translate the row horizontally, past a threshold it snaps open to reveal a Delete button; vertical movement cancels (scroll wins); only one row open at a time; `router.delete('/d/'+slug)` on confirm. Rendered only when `nativeApp` (server-known prop), so the web DOM is unchanged.
+- **Haptics per #132's declarative pattern** — `nativeHaptic('warning')` data attribute on the Delete button; no imperative bridge calls.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart LR
+  subgraph doc ["Document page (native)"]
+    NB["NativeNavbar\n(doc title)"] -->|leading click| BK["#native-doc-back"]
+    SH["NativeShareButton"] -->|share sheet| URL["current doc URL"]
+    TM2["Trailing menu"] -->|click, selected| M1["#native-mode-*"]
+    TM2 -->|"click (non-read)"| T1["#native-toggle-activity\n(mobile sheet)"]
+    TM2 -->|click| EX["#native-export-markdown / -html"]
+    TM2 -->|href| HOME2["/"]
+    STRIP["clip-hidden bridge strip\n(never display:none)"] --- BK & M1 & T1 & EX
+    CSS1["[data-native-app] hides .doc-header;\nnative-inset-top keeps notch clearance"] -.-> NB
+    UPD["version-update prompt\n(floats outside header)"] -.-> NB
+  end
+  subgraph home ["Home (native)"]
+    CSS2["native-hidden on hero title"] -.-> WT["h1 Thinkroom"]
+    SR["SwipeRow (owned docs)"] -->|"confirm + DELETE /d/:slug"| DEL["documents#destroy\n(owner-only)"]
+  end
+  HTML["<html data-native-app>\n(server-side via native_app?)"] --> CSS1 & CSS2
+```
+
+### Execution direction
+
+Same as #140: signal-element and CSS wiring verified smoke-first through the extended `script/native_shell_check.mjs` (write assertions, observe red, implement, observe green). The swipe row is the one piece with real client logic — exercise it in the browser check with synthesized pointer events for the reveal, and verify the delete round-trip once (creating a throwaway doc in the check session). Native feel (gesture physics, share sheet, menus) is on-device only.
+
+---
+
+## Implementation Units
+
+### U1. Native-app CSS foundation and home chrome
+
+**Goal:** `data-native-app` rendered server-side; home hero title hidden in native with correct top spacing.
+
+**Requirements:** R4, R5, R9.
+
+**Dependencies:** none.
+
+**Files:**
+- `app/views/layouts/application.html.erb` — `data-native-app` attribute on `<html>` when `native_app?`.
+- `app/frontend/pages/documents/index.tsx` — `native-hidden` class on the hero wordmark heading; safe-area/top-spacing class on the landing container for native.
+- `app/frontend/entrypoints/application.css` — any `[data-native-app]` spacing rule the landing needs beyond the gem's `native-inset-top`.
+
+**Approach:** the layout change is one ERB conditional attribute. Hide only the `h1.landing-wordmark`; the tagline under it is small — hide it too only if it reads orphaned without the title (implementer judgment, note the choice). Top spacing: prefer the gem's `native-inset-top` utility over hand-rolled padding.
+
+**Patterns to follow:** #132's layout comments style; the gem stylesheet's utility classes.
+
+**Test scenarios:** via U4 — native context: `html[data-native-app]` present, wordmark not visible, landing top padding ≥ safe-area variable when set; web context: no `data-native-app` attribute, wordmark visible.
+
+**Verification:** U4 assertions; `npm run check`.
+
+### U2. Document editor native nav bar, menu, and hidden web header
+
+**Goal:** Native chrome owns the doc page top in the shell; web header hides but keeps serving as the click-target layer.
+
+**Requirements:** R1, R2, R3, R9.
+
+**Dependencies:** U1 (needs `data-native-app` for the CSS hide).
+
+**Files:**
+- `app/frontend/pages/documents/show.tsx` — `NativeNavbar` (doc title) with leading back `NativeButton`, `NativeShareButton`, trailing menu of `NativeMenuItem`s; the clip-hidden bridge strip (back, modes, activity, exports); the native-floating version-update control; `native-hidden` on the `doc-header`.
+- `app/frontend/pages/documents/show.css` (or the page's existing style home) — bridge-strip clip styling; `native-inset-top` (or equivalent) on the doc body so content clears the notch/nav bar once the header — today the page's only safe-area inset carrier (`.doc-header` padding-top rule in `application.css`) — is hidden.
+- `app/frontend/types/ruby_native.d.ts` — declare `NativeShareButton` (props per `@ruby-native/react` `index.js`).
+
+**Approach:** menu items per R2 — modes filtered by `availableModes` with `selected` on the current mode and omitted on mode-locked docs; "Activity" only in non-read modes, wired to the mobile sheet; exports; Home (`href: '/'`). Bridge handlers call the live setters/handlers directly (`changeMode`, `setActiveSheet`, `exportMarkdown`, `exportHtml`) — no duplicated logic. Keep `pullToRefresh` default on the doc page. The document title feeding the navbar is the same prop the web header shows; a mid-session rename may leave the native bar stale until reload (recorded in Deferred).
+
+**Patterns to follow:** the home-page `NativeNavbar` block from #140; the shell-back `postMessage` from #132.
+
+**Test scenarios:** via U4 — native context on `/d/demo` (structural): navbar signal with the doc title, leading button targeting `#native-doc-back`, share signal (`data-native-share`), no mode menu items (demo is mode-locked), export/home items, doc-header not visible, doc body top inset ≥ the shell safe-area variable when set, bridge strip present and clip-hidden (not `display:none`); native context on the throwaway doc U3 creates (behavioral): mode menu items present with exactly one `data-native-selected`, clicking `#native-mode-read` via JS switches the mode control's state (the demo doc is mode-locked, so this assertion must not target it); web context: doc-header visible, bridge strip not visible, page renders as on `main`.
+
+**Verification:** U4 assertions; `npm run check`.
+
+### U3. Swipe-to-delete on owned home rows
+
+**Goal:** iOS-style swipe-reveal-delete for owned documents in the native app.
+
+**Requirements:** R6, R7, R8, R9.
+
+**Dependencies:** U1 (uses the `nativeApp` fork conventions).
+
+**Files:**
+- `app/frontend/components/swipe_row.tsx` — new; pointer-event swipe container (translate, threshold snap, scroll-cancel, single-open, reveal slot).
+- `app/frontend/pages/documents/index.tsx` — wrap owned (`yours`) rows in `SwipeRow` when `nativeApp`; Delete action → `window.confirm` → `router.delete('/d/'+slug, { preserveScroll: true })`.
+- `app/frontend/entrypoints/application.css` — swipe-row styles (rendered only in native, but plain classes are fine since the component itself is native-gated).
+
+**Approach:** pointer events (`pointerdown/move/up` + `setPointerCapture`); horizontal intent detected after a small slop; vertical movement cancels so scrolling wins; open state max-translate reveals a fixed-width Delete button with `nativeHaptic('warning')`; tapping elsewhere closes. Row titles are Inertia `Link`s: once the slop threshold is crossed, suppress the trailing click (capture-phase) so releasing a swipe never navigates; a tap on an already-open row closes it without navigating. Delete flow: confirm -> pending state on the button -> `router.delete` (the controller 303-redirects to root, which Inertia follows, refreshing the list) -> on error, snap the row closed and surface the existing inline error pattern; the row is removed only by the refreshed props. The existing owner delete affordance in `ownership_chip.tsx` (confirm + `router.delete` on the same endpoint) is the client pattern to mirror. No full-swipe-commits-delete this round — reveal + confirm only. Non-owned recent rows and all web rows render exactly as today.
+
+**Test scenarios:** via U4 — native context: owned row wrapped with the swipe container attribute/class, Delete button present with haptic data and correct target slug; synthesized pointer sequence reveals the button (element gains the open state); swipe-then-release does not navigate to the document (URL unchanged); delete round-trip: create a doc in the check session, swipe-reveal, accept the dialog (`page.on('dialog')`), assert the row disappears and `GET /d/:slug` no longer 200s; web context: no swipe container in DOM.
+- Edge: vertical drag on a row does not open it (list scrolls).
+- Edge: opening a second row closes the first.
+
+**Verification:** U4 assertions; `npm run check`.
+
+### U4. Extend the native shell contract check
+
+**Goal:** Every new signal element, CSS fork, and the swipe round-trip proven in the browser check.
+
+**Requirements:** R10 (mechanically verifies R1–R9).
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- `script/native_shell_check.mjs` — assertions per the unit scenarios above, following the existing `check()` style; the delete round-trip uses a doc created inside the check (never the demo doc).
+
+**Approach:** native context gains doc-page chrome assertions and the swipe scenario; web context gains non-leak assertions (`data-native-app` absent, doc-header visible, no swipe container, wordmark visible). Keep the existing 32 assertions green — except the "header padding-top honors the shell safe-area variable" assertion, which after U2 would measure a `display:none` element; repoint it at the doc body's new inset (the thing that actually clears the notch now). Flake guard: if synthesized pointer sequences prove unreliable in headless CI, keep the structural assertions and drive the row's open state through a programmatic path (e.g. dispatching the component's own handlers via evaluate) rather than deleting the scenario or retrying blind — record which path the check uses.
+
+**Test scenarios:** the check is the test; keep runtime reasonable (one extra doc create + delete).
+
+**Verification:** `BASE_URL=http://localhost:3005 SLUG=demo node script/native_shell_check.mjs` green locally (`PORT=3005 bin/dev`; 3000/3001 are taken); CI `browser_checks` green.
+
+---
+
+## Verification Contract
+
+- `npm run check` — TypeScript including the extended `ruby_native.d.ts`.
+- `bin/rubocop` — the layout ERB change is the only Ruby-adjacent edit; gate runs regardless.
+- `bin/rails test` — full suite; destroy behavior is already covered server-side, nothing server-side changes.
+- `PORT=3005 bin/dev` + `BASE_URL=http://localhost:3005 SLUG=demo node script/native_shell_check.mjs` — extended in U4.
+- CI `browser_checks` job on the PR.
+- Manual device pass before/after deploy: `bundle exec ruby_native preview` — **first**: a nav-bar menu item tap actually fires its clip-hidden bridge target (the shell's click-dispatch mechanism is the assumption everything rests on), and `window.confirm` presents a native alert whose acceptance completes the delete round-trip (a WKWebView without a confirm-panel delegate silently returns false). Then: doc-page nav bar renders with working back/share/menu, mode switching works from the menu, content clears the notch with the header hidden, the version-update control appears and reloads when a new version broadcasts, home shows no double title and correct spacing, swipe reveal feels right, delete removes the doc, scroll is not hijacked.
+
+## Definition of Done
+
+- R1–R10 implemented and traced through U1–U4.
+- All Verification Contract gates green locally and in CI.
+- No web-visible diff anywhere: web context assertions in the shell check plus a manual browser pass on `/` and `/d/demo`.
+- No leftover experiments; the bridge-button strip exists only on the doc page and only the controls the menu needs.
+- PR merged to `main` after CI passes; Kamal deploy follows; the device pass is the post-deploy acceptance check.

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -251,6 +251,7 @@ try {
     'home: vertical drag scrolls instead of opening the row',
   )
   await swipeOpen(row)
+  await page.waitForSelector(`[data-swipe-row="${throwawaySlug}"].is-open`, { timeout: 10000 })
   page.once('dialog', (dialog) => void dialog.dismiss())
   await row.locator('button[data-native-haptic="warning"]').click()
   await page.waitForTimeout(500)
@@ -274,6 +275,7 @@ try {
   const savedCookies = (await native.cookies()).filter((cookie) => cookie.name === 'owner_token')
   await native.clearCookies({ name: 'owner_token' })
   await swipeOpen(rowB)
+  await page.waitForSelector(`[data-swipe-row="${secondSlug}"].is-open`, { timeout: 10000 })
   page.once('dialog', (dialog) => void dialog.accept())
   await rowB.locator('button[data-native-haptic="warning"]').click()
   await page.waitForSelector('.document-delete-error[role="alert"]', { timeout: 15000 })
@@ -292,6 +294,7 @@ try {
   await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
   await mounted(page)
   await swipeOpen(rowB)
+  await page.waitForSelector(`[data-swipe-row="${secondSlug}"].is-open`, { timeout: 10000 })
   page.once('dialog', (dialog) => void dialog.accept())
   await rowB.locator('button[data-native-haptic="warning"]').click()
   await page.waitForFunction(

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -44,25 +44,55 @@ try {
   await page.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
   await mounted(page)
   check(
-    (await page.locator('.doc-header .native-back-button').count()) === 1,
-    'doc: native back button rendered in the header',
+    (await page.locator('html[data-native-app]').count()) === 1,
+    'native: html carries data-native-app (server-rendered)',
   )
   check(
-    !(await page.locator('.native-back-button').isVisible()),
-    'doc: back button hidden until the shell signals history',
+    (await page.locator('[data-native-navbar]').count()) === 1 &&
+      (await page.locator('[data-native-navbar]').getAttribute('data-native-navbar')) !== '',
+    'doc: native navbar signal present with the document title',
   )
-  await page.evaluate(() => document.body.classList.add('can-go-back'))
   check(
-    await page.locator('.native-back-button').isVisible(),
-    'doc: back button appears once body.can-go-back is set',
+    (await page.locator('[data-native-button][data-native-position="leading"][data-native-click="#native-doc-back"]').count()) === 1,
+    'doc: leading navbar button delegates to the back bridge',
   )
-  const headerClearsNotch = await page.evaluate(() => {
-    document.documentElement.style.setProperty('--ruby-native-safe-area-inset-top', '47px')
-    const paddingTop = parseFloat(getComputedStyle(document.querySelector('.doc-header')).paddingTop)
-    document.documentElement.style.removeProperty('--ruby-native-safe-area-inset-top')
-    return paddingTop >= 47
+  check(
+    (await page.locator('[data-native-button][data-native-share]').count()) === 1,
+    'doc: native share button present (share sheet for the doc URL)',
+  )
+  check(
+    (await page.locator('[data-native-menu-item][data-native-click^="#native-mode-"]').count()) === 0,
+    'doc: demo is mode-locked, so the menu offers no mode items',
+  )
+  check(
+    (await page.locator('[data-native-menu-item][data-native-click^="#native-export-"]').count()) === 2,
+    'doc: menu offers Export Markdown and Export HTML',
+  )
+  check(
+    (await page.locator('[data-native-menu-item][data-native-href="/"]').count()) === 1,
+    'doc: menu offers Home',
+  )
+  const bridgeUsable = await page.evaluate(() => {
+    const back = document.querySelector('#native-doc-back')
+    if (!back) return false
+    const style = getComputedStyle(back)
+    return style.display !== 'none' && style.visibility !== 'hidden'
   })
-  check(headerClearsNotch, 'doc: header padding-top honors the shell safe-area variable at phone width')
+  check(bridgeUsable, 'doc: back bridge control is clip-hidden, never display:none')
+  check(
+    !(await page.locator('.doc-header').isVisible()),
+    'doc: web header hidden inside the native shell',
+  )
+  // The navbar's leading button owns back in native now (the web header is
+  // hidden), so the old header back-button visibility checks are superseded.
+  const bodyClearsNotch = await page.evaluate(() => {
+    document.documentElement.style.setProperty('--ruby-native-safe-area-inset-top', '47px')
+    const before = getComputedStyle(document.querySelector('.doc-page'), '::before')
+    const height = parseFloat(before.height)
+    document.documentElement.style.removeProperty('--ruby-native-safe-area-inset-top')
+    return height >= 47
+  })
+  check(bodyClearsNotch, 'doc: body inset honors the shell safe-area variable with the header hidden')
 
   await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
   await mounted(page)
@@ -114,6 +144,69 @@ try {
     (await page.locator('#new-document-button[data-native-haptic="impact"]').count()) === 1,
     'home: New document button carries an impact haptic',
   )
+  check(
+    !(await page.locator('.landing-wordmark').isVisible()),
+    'home: hero title hidden in native (the nav bar already says Thinkroom)',
+  )
+  const landingClearsBar = await page.evaluate(() => {
+    document.documentElement.style.setProperty('--ruby-native-safe-area-inset-top', '47px')
+    const paddingTop = parseFloat(getComputedStyle(document.querySelector('.landing')).paddingTop)
+    document.documentElement.style.removeProperty('--ruby-native-safe-area-inset-top')
+    return paddingTop >= 47
+  })
+  check(landingClearsBar, 'home: landing keeps top spacing below the native bar')
+
+  // Behavioral leg on a throwaway doc (the demo is mode-locked): create one,
+  // prove the mode bridge works, then swipe-to-delete it from home.
+  await page.evaluate(() => document.querySelector('#new-document-button')?.click())
+  await page.waitForURL(/\/d\/[A-Za-z0-9]+\/edit/, { timeout: 30000 })
+  await mounted(page)
+  const throwawaySlug = await page.evaluate(() => window.location.pathname.split('/')[2])
+  check(
+    (await page.locator('[data-native-menu-item][data-native-click^="#native-mode-"]').count()) >= 2,
+    'doc: unlocked doc offers mode menu items',
+  )
+  check(
+    (await page.locator('[data-native-menu-item][data-native-click^="#native-mode-"][data-native-selected]').count()) === 1,
+    'doc: exactly one mode menu item is marked selected',
+  )
+  await page.evaluate(() => document.querySelector('#native-mode-read')?.click())
+  await page.waitForFunction(() => document.querySelector('.doc-page')?.classList.contains('is-read-mode'))
+  ok('doc: mode bridge button switches the editor to Read mode')
+
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  const row = page.locator(`[data-swipe-row="${throwawaySlug}"]`)
+  check((await row.count()) === 1, 'home: owned row is swipe-enabled in native')
+  check(
+    (await row.locator('button[data-native-haptic="warning"]').count()) === 1,
+    'home: swipe row carries a haptic Delete action',
+  )
+  const box = await row.boundingBox()
+  if (box) {
+    const y = box.y + box.height / 2
+    await page.mouse.move(box.x + box.width - 40, y)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width - 160, y, { steps: 8 })
+    await page.mouse.up()
+  }
+  await page.waitForTimeout(300)
+  check(
+    (await page.locator(`[data-swipe-row="${throwawaySlug}"].is-open`).count()) === 1,
+    'home: horizontal swipe reveals the Delete action',
+  )
+  check(
+    new URL(page.url()).pathname === '/',
+    'home: releasing a swipe does not navigate into the document',
+  )
+  page.once('dialog', (dialog) => void dialog.accept())
+  await row.locator('button[data-native-haptic="warning"]').click()
+  await page.waitForFunction(
+    (slug) => !document.querySelector(`[data-swipe-row="${slug}"]`),
+    throwawaySlug,
+    { timeout: 15000 },
+  )
+  ok('home: confirmed delete removes the document row')
 
   await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
   await mounted(page)
@@ -170,6 +263,12 @@ try {
     (await webPage.locator('[data-native-menu-item]:visible').count()) === 0,
     'web home: native menu items never visible',
   )
+  check(
+    (await webPage.locator('html[data-native-app]').count()) === 0,
+    'web: html never carries data-native-app',
+  )
+  check(await webPage.locator('.landing-wordmark').isVisible(), 'web home: hero title still visible')
+  check((await webPage.locator('[data-swipe-row]').count()) === 0, 'web home: no swipe rows in the DOM')
   await webPage.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
   await mounted(webPage)
   check(
@@ -183,6 +282,16 @@ try {
     !(await webPage.locator('.native-back-button').isVisible()),
     'web doc: native back button never visible',
   )
+  check(await webPage.locator('.doc-header').isVisible(), 'web doc: header renders as on main')
+  // Clip-hidden by design (1px box, clipped) — Playwright's :visible counts
+  // any non-empty box, so measure the footprint instead.
+  const bridgeFootprint = await webPage.evaluate(() => {
+    const el = document.querySelector('.native-bridge')
+    if (!el) return true
+    const rect = el.getBoundingClientRect()
+    return rect.width <= 1 && rect.height <= 1
+  })
+  check(bridgeFootprint, 'web doc: bridge strip occupies no visible space')
   await web.close()
 } finally {
   await browser.close()

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -170,27 +170,48 @@ try {
     (await page.locator('[data-native-menu-item][data-native-click^="#native-mode-"][data-native-selected]').count()) === 1,
     'doc: exactly one mode menu item is marked selected',
   )
+  check(
+    (await page.locator('[data-native-menu-item][data-native-click="#native-toggle-activity"]').count()) === 1,
+    'doc: menu offers Activity outside Read mode',
+  )
   await page.evaluate(() => document.querySelector('#native-mode-read')?.click())
   await page.waitForFunction(() => document.querySelector('.doc-page')?.classList.contains('is-read-mode'))
   ok('doc: mode bridge button switches the editor to Read mode')
+  await page.waitForFunction(
+    () => !document.querySelector('[data-native-menu-item][data-native-click="#native-toggle-activity"]'),
+  )
+  ok('doc: Activity menu item drops out in Read mode')
 
+  // Second throwaway doc for the multi-row swipe scenarios.
   await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
   await mounted(page)
+  await page.evaluate(() => document.querySelector('#new-document-button')?.click())
+  await page.waitForURL(/\/d\/[A-Za-z0-9]+\/edit/, { timeout: 30000 })
+  const secondSlug = await page.evaluate(() => window.location.pathname.split('/')[2])
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(page)
+
   const row = page.locator(`[data-swipe-row="${throwawaySlug}"]`)
-  check((await row.count()) === 1, 'home: owned row is swipe-enabled in native')
+  const rowB = page.locator(`[data-swipe-row="${secondSlug}"]`)
+  check(
+    (await row.count()) === 1 && (await rowB.count()) === 1,
+    'home: owned rows are swipe-enabled in native',
+  )
   check(
     (await row.locator('button[data-native-haptic="warning"]').count()) === 1,
     'home: swipe row carries a haptic Delete action',
   )
-  const box = await row.boundingBox()
-  if (box) {
+  const swipeOpen = async (target) => {
+    const box = await target.boundingBox()
+    if (!box) return
     const y = box.y + box.height / 2
     await page.mouse.move(box.x + box.width - 40, y)
     await page.mouse.down()
     await page.mouse.move(box.x + box.width - 160, y, { steps: 8 })
     await page.mouse.up()
+    await page.waitForTimeout(280)
   }
-  await page.waitForTimeout(300)
+  await swipeOpen(row)
   check(
     (await page.locator(`[data-swipe-row="${throwawaySlug}"].is-open`).count()) === 1,
     'home: horizontal swipe reveals the Delete action',
@@ -198,6 +219,44 @@ try {
   check(
     new URL(page.url()).pathname === '/',
     'home: releasing a swipe does not navigate into the document',
+  )
+  await swipeOpen(rowB)
+  check(
+    (await page.locator(`[data-swipe-row="${secondSlug}"].is-open`).count()) === 1 &&
+      (await page.locator(`[data-swipe-row="${throwawaySlug}"].is-open`).count()) === 0,
+    'home: opening a second row closes the first',
+  )
+  // Tap the visible body of the open row (left of the revealed Delete
+  // button): the capture-phase handler must close the row, not navigate.
+  const openBox = await rowB.boundingBox()
+  if (openBox) {
+    await page.mouse.click(openBox.x + openBox.width - 140, openBox.y + openBox.height / 2)
+  }
+  await page.waitForTimeout(280)
+  check(
+    (await page.locator(`[data-swipe-row="${secondSlug}"].is-open`).count()) === 0 &&
+      new URL(page.url()).pathname === '/',
+    'home: tapping an open row closes it without navigating',
+  )
+  const vBox = await row.boundingBox()
+  if (vBox) {
+    await page.mouse.move(vBox.x + vBox.width / 2, vBox.y + vBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(vBox.x + vBox.width / 2, vBox.y + vBox.height / 2 + 80, { steps: 8 })
+    await page.mouse.up()
+    await page.waitForTimeout(280)
+  }
+  check(
+    (await page.locator(`[data-swipe-row="${throwawaySlug}"].is-open`).count()) === 0,
+    'home: vertical drag scrolls instead of opening the row',
+  )
+  await swipeOpen(row)
+  page.once('dialog', (dialog) => void dialog.dismiss())
+  await row.locator('button[data-native-haptic="warning"]').click()
+  await page.waitForTimeout(500)
+  check(
+    (await page.locator(`[data-swipe-row="${throwawaySlug}"]`).count()) === 1,
+    'home: declining the confirm keeps the document',
   )
   page.once('dialog', (dialog) => void dialog.accept())
   await row.locator('button[data-native-haptic="warning"]').click()
@@ -207,6 +266,40 @@ try {
     { timeout: 15000 },
   )
   ok('home: confirmed delete removes the document row')
+
+  // Failure path: drop the signed owner_token cookie (context-level API
+  // reaches the httponly cookie) so the server's real owned_by? check fails
+  // on an existing doc — the genuine onError path: error renders, the row
+  // snaps closed, the document stays listed.
+  const savedCookies = (await native.cookies()).filter((cookie) => cookie.name === 'owner_token')
+  await native.clearCookies({ name: 'owner_token' })
+  await swipeOpen(rowB)
+  page.once('dialog', (dialog) => void dialog.accept())
+  await rowB.locator('button[data-native-haptic="warning"]').click()
+  await page.waitForSelector('.document-delete-error[role="alert"]', { timeout: 15000 })
+  ok('home: failed delete surfaces the error message')
+  // The dropped-cookie trigger also re-scopes the yours list on the refused
+  // redirect (the row vanishes as a trigger artifact, not product behavior),
+  // so row persistence/re-close is device-pass territory; the server-side
+  // survival is what this trigger can honestly prove.
+  const survivedDelete = await page.evaluate(
+    async (slug) => (await fetch(`/d/${slug}`, { method: 'HEAD' })).ok,
+    secondSlug,
+  )
+  check(survivedDelete, 'home: failed delete leaves the document alive on the server')
+  if (savedCookies.length > 0) await native.addCookies(savedCookies)
+
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await mounted(page)
+  await swipeOpen(rowB)
+  page.once('dialog', (dialog) => void dialog.accept())
+  await rowB.locator('button[data-native-haptic="warning"]').click()
+  await page.waitForFunction(
+    (slug) => !document.querySelector(`[data-swipe-row="${slug}"]`),
+    secondSlug,
+    { timeout: 15000 },
+  )
+  ok('home: second throwaway cleaned up via swipe delete')
 
   await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
   await mounted(page)
@@ -278,10 +371,6 @@ try {
   check(await webPage.locator('#auth-submit').isVisible(), 'web login: credentials submit button still visible')
   await webPage.goto(`${BASE}/d/${SLUG}`, { waitUntil: 'networkidle' })
   await mounted(webPage)
-  check(
-    !(await webPage.locator('.native-back-button').isVisible()),
-    'web doc: native back button never visible',
-  )
   check(await webPage.locator('.doc-header').isVisible(), 'web doc: header renders as on main')
   // Clip-hidden by design (1px box, clipped) — Playwright's :visible counts
   // any non-empty box, so measure the footprint instead.

--- a/test/integration/ownership_flow_test.rb
+++ b/test/integration/ownership_flow_test.rb
@@ -170,7 +170,9 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
 
     delete destroy_document_path(@document.slug)
 
-    assert_response :see_other
+    # Refusals answer 302, not 303: inertia_rails carries the error bag only
+    # through 302 redirects (its middleware upgrades Inertia clients to 303).
+    assert_response :found
     assert_not_nil Document.find_by(slug: @document.slug)
   end
 
@@ -179,7 +181,7 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
 
     delete destroy_document_path(@document.slug)
 
-    assert_response :see_other
+    assert_response :found
     assert_not_nil Document.find_by(slug: @document.slug)
   end
 
@@ -278,7 +280,7 @@ class OwnershipFlowTest < ActionDispatch::IntegrationTest
     cookies[:owner_token] = old_cookie
     delete destroy_document_path(@document.slug)
 
-    assert_response :see_other
+    assert_response :found
     assert Document.exists?(@document.id)
   end
 


### PR DESCRIPTION
## Summary

Inside the iOS app, the document editor now has real native chrome: a nav bar with the document title, a back chevron, a native share sheet, and a dropdown menu (editor modes with a checkmark, Activity, Export Markdown/HTML, Home) — while the web header hides in the shell. The home screen stops saying "Thinkroom" twice (the hero title hides under the native bar, with safe-area spacing preserved), and owned documents can now be swipe-to-deleted, iOS-style: drag left, confirm in a native dialog, with pending and failure states.

Nothing changes on the open web. The foundation is a server-rendered `data-native-app` attribute on `<html>` (the gem ships the `[data-native-app] .native-hidden` utility but nothing set the attribute until now), plus one design rule: every control the native chrome clicks lives in a clip-hidden bridge strip that is never `display:none`, so the shell's click dispatch — whose mechanism is not locally verifiable — always has a real box to hit.

## Design decisions

- The web `doc-header` hides in native per an explicit control inventory (plan R3a): modes/activity/exports/home re-home into the native menu, share becomes the platform share sheet, the load-bearing "New version · Update" prompt floats outside the hidden header (it is the only trigger for reloading an owner-reset document), and presence/identity/link-access are recorded as accepted native losses for now.
- The Activity menu item wires to the mobile activity sheet (`setActiveSheet`), not the desktop rail toggle — the rail never renders at phone width. It only appears outside Read mode; there is no Focus item because focus is already force-enabled on phones.
- Swipe-to-delete is a dependency-free pointer-event component ("Silk" was requested but is not installed; the npm package is proprietary-licensed and sheet-focused). Vertical drags scroll, a swipe past the slop suppresses the row link's click, only one row opens at a time, outside taps and Escape dismiss, and a failed delete re-closes the row and shows an error. The server's owner-only check remains the enforcement point.
- Deleting was possible on the doc page (`ownership_chip`) but never from the list; this reuses the same endpoint and confirm-then-`router.delete` pattern.

## Fixed along the way

Refused deletes never showed their error anywhere: the controller's error redirects carried an explicit `status: :see_other`, but inertia_rails keeps the session error bag only through 302 responses (its middleware upgrades Inertia clients to 303 itself). The explicit 303 made the middleware wipe the errors on the same response that set them. Fixed for `destroy` (other call sites share the latent bug — follow-up candidate).

## Validation

- `script/native_shell_check.mjs` grew from 32 to 61 assertions, written red-first: doc-page chrome structure on the mode-locked demo, behavioral legs on throwaway docs (mode bridge switches to Read, Activity item drops out in Read mode, swipe reveal via real pointer gestures, second-row-closes-first, tap-to-close without navigating, vertical-drag cancel, confirm-decline keeps the doc, confirmed delete removes it), and a genuine end-to-end failure path — the signed owner cookie is dropped via Playwright's context API so the real server-side `owned_by?` refusal fires, proving the error renders and the document survives.
- `npm run check`, `bin/rubocop`, `bin/rails test` (579 runs) all green. Web contexts assert zero leakage: no `data-native-app`, hero visible, header intact, no swipe rows, bridge strip occupies no visible space.
- Native rendering (menus drawing, share sheet, `window.confirm` as a native alert, swipe feel, notch clearance) needs the `bundle exec ruby_native preview` device pass — the plan's Verification Contract lists the exact checklist, starting with whether a menu tap actually fires its clip-hidden bridge target.

## Residual Review Findings

- P2 `app/frontend/pages/documents/show.tsx:1277` — Extract the native chrome block into a component: kieranklaassen/thinkroom#141
- P2 `app/frontend/pages/documents/show.tsx` — Cold-start deep links may show a dead back chevron; resolution depends on shell behavior only observable on-device: kieranklaassen/thinkroom#142

Related: docs/plans/2026-07-02-010-feat-native-editor-menu-swipe-plan.md

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document destroy redirects (Inertia error delivery) and native-only UI forks; server-side ownership checks remain authoritative for delete.
> 
> **Overview**
> **Native shell (web unchanged)** — The layout sets `data-native-app` on `<html>` when `native_app?`, enabling gem `.native-hidden` and native-only CSS without a flash. Home hides the duplicate Thinkroom hero and adds safe-area top padding; owned rows get iOS-style **swipe-to-delete** (`SwipeRow`, confirm, `router.delete`, haptics, row close + alert on failure) only when `nativeApp` is true.
> 
> **Document editor in the app** — `NativeNavbar` (title, back, share sheet, menu) replaces visible web header chrome; a **clip-hidden bridge strip** (never `display:none`) wires menu taps to back, mode changes, activity sheet, exports. The version-update control floats outside the hidden header so reload still works.
> 
> **Server fix for list delete errors** — `documents#destroy` error redirects drop explicit `:see_other` (303) so **inertia_rails** keeps the session errors bag on 302; integration tests now expect `:found` for refused deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1e34f49b939f2a29a0c60462305db04d07b4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->