### PR TITLE
feat(og): add Open Graph image and metadata for the landing page

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -505,16 +505,17 @@ class DocumentsController < InertiaController
   end
 
   # The landing page's static site card. page_title stays exactly "Thinkroom"
-  # so the browser tab title is unchanged; copy mirrors the landing hero.
+  # so the browser tab title is unchanged; copy comes from SiteOgImage so the
+  # meta tags can't drift from the rendered card.
   def site_open_graph
     {
       title: "Thinkroom",
       page_title: "Thinkroom",
-      description: "Where deeper thinking compounds. From the creator of Compound Engineering.",
+      description: "#{SiteOgImage::TAGLINE} #{SiteOgImage::BYLINE}",
       url: root_url,
       type: "website",
-      image_url: site_og_image_url(v: SiteOgImage::VERSION),
-      image_alt: "Thinkroom — where deeper thinking compounds."
+      image_url: site_og_image_url(v: SiteOgImage.url_version),
+      image_alt: "Thinkroom — #{SiteOgImage::TAGLINE.downcase}"
     }
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -17,6 +17,7 @@ class DocumentsController < InertiaController
   inertia_config ssr_enabled: -> { %w[show index].include?(action_name) }
 
   def index
+    @open_graph = site_open_graph
     # Date labels and the THIS WEEK bucket follow the viewer's timezone via
     # the pruf_tz cookie (set client-side from Intl); unknown or absent zones
     # fall back to the app default.
@@ -500,6 +501,20 @@ class DocumentsController < InertiaController
       mode:,
       document_width: document_width&.clamp(MIN_DOCUMENT_WIDTH, MAX_DOCUMENT_WIDTH),
       rich_content_width: rich_content_width&.clamp(MIN_RICH_CONTENT_WIDTH, MAX_RICH_CONTENT_WIDTH)
+    }
+  end
+
+  # The landing page's static site card. page_title stays exactly "Thinkroom"
+  # so the browser tab title is unchanged; copy mirrors the landing hero.
+  def site_open_graph
+    {
+      title: "Thinkroom",
+      page_title: "Thinkroom",
+      description: "Where deeper thinking compounds. From the creator of Compound Engineering.",
+      url: root_url,
+      type: "website",
+      image_url: site_og_image_url(v: SiteOgImage::VERSION),
+      image_alt: "Thinkroom — where deeper thinking compounds."
     }
   end
 

--- a/app/controllers/site_og_images_controller.rb
+++ b/app/controllers/site_og_images_controller.rb
@@ -1,0 +1,16 @@
+class SiteOgImagesController < ActionController::Base
+  # This GET-only public asset must not run Inertia's XSRF after-action: those
+  # cookies make otherwise public image responses private to intermediary caches.
+  self.allow_forgery_protection = false
+
+  def show
+    expires_in 1.day, public: true, stale_while_revalidate: 1.hour
+
+    return unless stale?(etag: SiteOgImage.cache_key, public: true)
+
+    send_data SiteOgImage.call,
+              type: "image/png",
+              disposition: "inline",
+              filename: "thinkroom-preview.png"
+  end
+end

--- a/app/services/document_og_image.rb
+++ b/app/services/document_og_image.rb
@@ -13,6 +13,10 @@ class DocumentOgImage
   RULE_X = 44
 
   HEADER_BASELINE = 96
+  # Wordmark text position: MARGIN_X + the "T." glyph advance at 34px serif
+  # (visual_width("T.") == 1.0 → 34px) + a 14px gap. Shared with SiteOgImage
+  # so both cards keep the same header geometry.
+  WORDMARK_TEXT_X = MARGIN_X + 48
 
   # Title/excerpt live in the band between the header and the footer hairline
   # and are vertically centered within it.
@@ -23,6 +27,9 @@ class DocumentOgImage
   # Widths are in "visual width" units (~1 em per unit), so max line px / size.
   TITLE_SIZE = 72
   TITLE_LINE_HEIGHT = 78
+  # Distance from the title block's top to its first baseline. Shared with
+  # SiteOgImage so both cards center their title blocks identically.
+  TITLE_FIRST_BASELINE_OFFSET = 58
   TITLE_LINE_WIDTH = 13.5
   TITLE_MAX_LINES = 3
 
@@ -89,11 +96,9 @@ class DocumentOgImage
       block_height += DESCRIPTION_GAP + description_lines.length * DESCRIPTION_LINE_HEIGHT if description_lines.any?
       block_top = REGION_CENTER - (block_height / 2.0)
 
-      title_baseline = block_top + 58
+      title_baseline = block_top + TITLE_FIRST_BASELINE_OFFSET
       title_bottom = block_top + title_lines.length * TITLE_LINE_HEIGHT
       description_baseline = title_bottom + DESCRIPTION_GAP + 27
-
-      wordmark_x = MARGIN_X + (visual_width("T.") * 34) + 14
 
       <<~SVG
         <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
@@ -101,7 +106,7 @@ class DocumentOgImage
           <line x1="#{RULE_X}" y1="0" x2="#{RULE_X}" y2="#{HEIGHT}" stroke="#{accent}" stroke-width="1" opacity="0.28"/>
 
           <text x="#{MARGIN_X}" y="#{HEADER_BASELINE}" fill="#{accent}" font-family="#{SERIF}" font-size="34" font-weight="600">T.</text>
-          <text x="#{wordmark_x.round(1)}" y="#{HEADER_BASELINE}" fill="#{INK}" font-family="#{SANS}" font-size="21" font-weight="600" letter-spacing="-0.2">Thinkroom</text>
+          <text x="#{WORDMARK_TEXT_X}" y="#{HEADER_BASELINE}" fill="#{INK}" font-family="#{SANS}" font-size="21" font-weight="600" letter-spacing="-0.2">Thinkroom</text>
           <text x="#{CONTENT_RIGHT}" y="#{HEADER_BASELINE}" text-anchor="end" fill="#{EYEBROW_INK}" font-family="#{SANS}" font-size="16" font-weight="500" letter-spacing="2.2">SHARED DOCUMENT</text>
 
           <text x="#{MARGIN_X}" y="#{title_baseline.round(1)}" fill="#{INK}" font-family="#{SERIF}" font-size="#{TITLE_SIZE}" font-weight="500" letter-spacing="-1">

--- a/app/services/site_og_image.rb
+++ b/app/services/site_og_image.rb
@@ -5,13 +5,15 @@ class SiteOgImage
   # og:image URL invalidate.
   VERSION = "1"
 
-  # Same editorial "document cover" language as DocumentOgImage, but fully
-  # static: the landing card carries the product tagline as its title and the
-  # byline in the footer, so no wrapping or per-document projection is needed.
+  # All copy is trusted static product copy (no user input), so the wrapping,
+  # escaping, and truncation machinery in DocumentOgImage is intentionally
+  # omitted. Geometry and palette come from DocumentOgImage so the two cards
+  # stay in the same family.
   MARGIN_X = DocumentOgImage::MARGIN_X
   CONTENT_RIGHT = DocumentOgImage::CONTENT_RIGHT
   RULE_X = DocumentOgImage::RULE_X
   HEADER_BASELINE = DocumentOgImage::HEADER_BASELINE
+  WORDMARK_TEXT_X = DocumentOgImage::WORDMARK_TEXT_X
   HAIRLINE_Y = DocumentOgImage::HAIRLINE_Y
   FOOTER_CENTER = DocumentOgImage::FOOTER_CENTER
 
@@ -23,17 +25,20 @@ class SiteOgImage
   SERIF = DocumentOgImage::SERIF
   SANS = DocumentOgImage::SANS
 
-  # Hand-set split of the tagline: both lines fit the document cards' title
-  # measure (13.5 visual-width units at 72px), verified with
-  # DocumentOgImage.visual_width.
+  TAGLINE = "Where deeper thinking compounds."
+  BYLINE = "From the creator of Compound Engineering."
+
+  # Hand-set split of TAGLINE: both lines fit the document cards' title
+  # measure (13.5 visual-width units at 72px), verified in the service test
+  # with DocumentOgImage.visual_width.
   TITLE_LINES = [ "Where deeper thinking", "compounds." ].freeze
   TITLE_SIZE = DocumentOgImage::TITLE_SIZE
   TITLE_LINE_HEIGHT = DocumentOgImage::TITLE_LINE_HEIGHT
-  # Two title lines centered in the band between header and footer hairline,
-  # using the same block math as DocumentOgImage (region center 306).
-  TITLE_BASELINE = 286
-
-  BYLINE = "From the creator of Compound Engineering."
+  # Title block centered in the band between header and footer hairline,
+  # matching DocumentOgImage's block math.
+  TITLE_BASELINE = DocumentOgImage::REGION_CENTER -
+    (TITLE_LINES.length * TITLE_LINE_HEIGHT / 2) +
+    DocumentOgImage::TITLE_FIRST_BASELINE_OFFSET
 
   class << self
     def call
@@ -44,8 +49,15 @@ class SiteOgImage
       end
     end
 
+    # The card renders from DocumentOgImage's shared geometry/palette, so its
+    # identity chains both versions: a document-template bump that reshapes the
+    # shared constants also invalidates the site card without a manual bump.
     def cache_key
-      [ "site-og-image", VERSION ]
+      [ "site-og-image", url_version ]
+    end
+
+    def url_version
+      "#{VERSION}-#{DocumentOgImage::VERSION}"
     end
 
     private
@@ -57,7 +69,7 @@ class SiteOgImage
           <line x1="#{RULE_X}" y1="0" x2="#{RULE_X}" y2="#{HEIGHT}" stroke="#{ACCENT}" stroke-width="1" opacity="0.28"/>
 
           <text x="#{MARGIN_X}" y="#{HEADER_BASELINE}" fill="#{ACCENT}" font-family="#{SERIF}" font-size="34" font-weight="600">T.</text>
-          <text x="120" y="#{HEADER_BASELINE}" fill="#{INK}" font-family="#{SANS}" font-size="21" font-weight="600" letter-spacing="-0.2">Thinkroom</text>
+          <text x="#{WORDMARK_TEXT_X}" y="#{HEADER_BASELINE}" fill="#{INK}" font-family="#{SANS}" font-size="21" font-weight="600" letter-spacing="-0.2">Thinkroom</text>
 
           <text x="#{MARGIN_X}" y="#{TITLE_BASELINE}" fill="#{INK}" font-family="#{SERIF}" font-size="#{TITLE_SIZE}" font-weight="500" letter-spacing="-1">
             <tspan x="#{MARGIN_X}" dy="0">#{TITLE_LINES.first}</tspan>

--- a/app/services/site_og_image.rb
+++ b/app/services/site_og_image.rb
@@ -1,0 +1,73 @@
+class SiteOgImage
+  WIDTH = DocumentOgImage::WIDTH
+  HEIGHT = DocumentOgImage::HEIGHT
+  # Bump when the artwork changes so the cached PNG and the versioned
+  # og:image URL invalidate.
+  VERSION = "1"
+
+  # Same editorial "document cover" language as DocumentOgImage, but fully
+  # static: the landing card carries the product tagline as its title and the
+  # byline in the footer, so no wrapping or per-document projection is needed.
+  MARGIN_X = DocumentOgImage::MARGIN_X
+  CONTENT_RIGHT = DocumentOgImage::CONTENT_RIGHT
+  RULE_X = DocumentOgImage::RULE_X
+  HEADER_BASELINE = DocumentOgImage::HEADER_BASELINE
+  HAIRLINE_Y = DocumentOgImage::HAIRLINE_Y
+  FOOTER_CENTER = DocumentOgImage::FOOTER_CENTER
+
+  ACCENT = DocumentOgImage::ACCENTS.first
+  BACKGROUND = DocumentOgImage::BACKGROUND
+  INK = DocumentOgImage::INK
+  EYEBROW_INK = DocumentOgImage::EYEBROW_INK
+  HAIRLINE_INK = DocumentOgImage::HAIRLINE_INK
+  SERIF = DocumentOgImage::SERIF
+  SANS = DocumentOgImage::SANS
+
+  # Hand-set split of the tagline: both lines fit the document cards' title
+  # measure (13.5 visual-width units at 72px), verified with
+  # DocumentOgImage.visual_width.
+  TITLE_LINES = [ "Where deeper thinking", "compounds." ].freeze
+  TITLE_SIZE = DocumentOgImage::TITLE_SIZE
+  TITLE_LINE_HEIGHT = DocumentOgImage::TITLE_LINE_HEIGHT
+  # Two title lines centered in the band between header and footer hairline,
+  # using the same block math as DocumentOgImage (region center 306).
+  TITLE_BASELINE = 286
+
+  BYLINE = "From the creator of Compound Engineering."
+
+  class << self
+    def call
+      Rails.cache.fetch(cache_key) do
+        Vips::Image
+          .svgload_buffer(svg, access: :sequential)
+          .write_to_buffer(".png", compression: 6, strip: true)
+      end
+    end
+
+    def cache_key
+      [ "site-og-image", VERSION ]
+    end
+
+    private
+
+    def svg
+      <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
+          <rect width="#{WIDTH}" height="#{HEIGHT}" fill="#{BACKGROUND}"/>
+          <line x1="#{RULE_X}" y1="0" x2="#{RULE_X}" y2="#{HEIGHT}" stroke="#{ACCENT}" stroke-width="1" opacity="0.28"/>
+
+          <text x="#{MARGIN_X}" y="#{HEADER_BASELINE}" fill="#{ACCENT}" font-family="#{SERIF}" font-size="34" font-weight="600">T.</text>
+          <text x="120" y="#{HEADER_BASELINE}" fill="#{INK}" font-family="#{SANS}" font-size="21" font-weight="600" letter-spacing="-0.2">Thinkroom</text>
+
+          <text x="#{MARGIN_X}" y="#{TITLE_BASELINE}" fill="#{INK}" font-family="#{SERIF}" font-size="#{TITLE_SIZE}" font-weight="500" letter-spacing="-1">
+            <tspan x="#{MARGIN_X}" dy="0">#{TITLE_LINES.first}</tspan>
+            <tspan x="#{MARGIN_X}" dy="#{TITLE_LINE_HEIGHT}">#{TITLE_LINES.last}</tspan>
+          </text>
+
+          <line x1="#{MARGIN_X}" y1="#{HAIRLINE_Y}" x2="#{CONTENT_RIGHT}" y2="#{HAIRLINE_Y}" stroke="#{HAIRLINE_INK}" stroke-width="1"/>
+          <text x="#{MARGIN_X}" y="#{FOOTER_CENTER + 6}" fill="#{EYEBROW_INK}" font-family="#{SANS}" font-size="19" font-weight="400">#{BYLINE}</text>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <% if @open_graph.present? %>
       <%= tag.meta name: "description", content: @open_graph[:description] %>
       <%= tag.link rel: "canonical", href: @open_graph[:url] %>
-      <%= tag.meta property: "og:type", content: "article" %>
+      <%= tag.meta property: "og:type", content: @open_graph[:type] || "article" %>
       <%= tag.meta property: "og:site_name", content: "Thinkroom" %>
       <%= tag.meta property: "og:locale", content: "en_US" %>
       <%= tag.meta property: "og:title", content: @open_graph[:title] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   match "/auth/:provider/callback", to: "oauth_callbacks#create", via: %i[get post]
   get "/auth/failure", to: "oauth_callbacks#failure"
 
+  get "og.png", to: "site_og_images#show", as: :site_og_image
   get "d/:slug/og.png", to: "document_og_images#show", as: :document_og_image
   get "d/:slug/:mode", to: "documents#show", as: :document_mode,
                        constraints: { mode: /edit|suggest|comment|read/ }

--- a/docs/plans/2026-07-03-001-feat-main-page-og-image-plan.md
+++ b/docs/plans/2026-07-03-001-feat-main-page-og-image-plan.md
@@ -1,0 +1,125 @@
+---
+title: "feat: Open Graph image and metadata for the main page"
+type: feat
+date: 2026-07-03
+---
+
+# feat: Open Graph image and metadata for the main page
+
+## Outcome
+
+Sharing the Thinkroom landing page (`/`) in Slack, iMessage, X, etc. unfurls
+with a branded 1200×630 preview card in the same warm editorial design as the
+document previews, plus complete Open Graph / Twitter metadata. Today the root
+page ships no OG tags at all — the layout only emits them when `@open_graph`
+is set, and only `documents#show` sets it.
+
+## Problem frame
+
+The per-document OG pipeline already exists and works well: `DocumentOgImage`
+renders a hand-positioned SVG (cream field, `Newsreader` serif title,
+`Instrument Sans` sans, `T. Thinkroom` wordmark, left margin rule, hairline
+footer) and rasterizes it through ruby-vips/librsvg, with fonts vendored under
+`vendor/fonts` and registered via `config/initializers/og_image_fonts.rb`. The
+PNG is served by a dedicated CSRF-free controller with public caching, ETag,
+and a versioned `?v=` URL. The main page needs the same treatment with static
+site-level copy instead of document-derived copy.
+
+## Key decisions
+
+- **KTD1 — Dedicated `SiteOgImage` service + controller, mirroring the
+  document pipeline.** A static file in `public/` would bypass the vendored
+  fonts and drift from the document cards; rendering through the existing
+  SVG→libvips path keeps typography and palette identical and reuses the
+  fontconfig setup. Content is fixed, so the PNG caches under
+  `["site-og-image", VERSION]` alone and the URL is versioned with `?v=VERSION`.
+- **KTD2 — Fixed, hand-positioned copy; no wrapping engine.** The card's copy
+  is static product copy that already exists in the repo: the serif title is
+  the tagline "Where deeper thinking compounds." (split across two hand-set
+  lines) and the hairline footer carries the byline "From the creator of
+  Compound Engineering." (both from the landing hero in
+  `app/frontend/pages/documents/index.tsx`). Header keeps the `T. Thinkroom`
+  wordmark; no eyebrow, no pills, default maroon accent. No text is dynamic,
+  so `DocumentOgImage`'s wrap/ellipsize helpers are not needed.
+- **KTD3 — Root metadata rides the existing `@open_graph` layout block.**
+  `DocumentsController#index` sets `@open_graph` with site copy; the layout
+  gains a `type` key (default `"article"`) so the root can declare
+  `og:type=website` while document pages are unchanged. `page_title` stays
+  exactly "Thinkroom" so the `<title>` asserted by `test/integration/branding_test.rb`
+  does not change. Both images are the standard 1200×630, so the layout's
+  width/height tags remain sourced from `DocumentOgImage::WIDTH/HEIGHT`.
+- **KTD4 — Endpoint semantics copied from `DocumentOgImagesController`:**
+  GET-only public inline PNG at `/og.png`, `allow_forgery_protection = false`
+  (no Set-Cookie), `expires_in 1.day, public: true, stale_while_revalidate:
+  1.hour`, ETag from the cache key for conditional 304s.
+
+## Requirements
+
+1. `GET /og.png` returns a 1200×630 PNG in the editorial design with the
+   tagline title and byline footer; publicly cacheable, inline, ETag/304,
+   no ownership or session cookie minted.
+2. `GET /` (browser) emits `og:title`, `og:description`, `og:url`,
+   `og:image` (versioned URL), `og:type=website`, `og:site_name`,
+   image dimensions/alt, `twitter:card=summary_large_image` and twitter
+   title/description/image, a meta description, and a canonical link.
+3. Document pages keep `og:type=article` and their existing metadata
+   unchanged.
+4. The `<title>` on `/` remains exactly "Thinkroom".
+
+## Implementation units
+
+### U1. `SiteOgImage` renderer service
+
+**Goal:** Render the landing card PNG.
+**Files:** `app/services/site_og_image.rb`, `test/services/site_og_image_test.rb`
+**Approach:** Constants mirror `DocumentOgImage` (WIDTH/HEIGHT/VERSION,
+palette, font stacks — palette/font constants may reference
+`DocumentOgImage`'s to avoid divergence). `call` fetches from `Rails.cache`
+keyed on `cache_key` = `["site-og-image", VERSION]`; SVG is fully static.
+**Test scenarios:**
+- Renders a PNG at 1200×630 (subprocess `bin/rails runner` pattern from
+  `test/services/document_og_image_test.rb`, which isolates fontconfig env).
+- SVG contains the wordmark "Thinkroom", the tagline lines, and the byline;
+  no unexpanded interpolation.
+- `cache_key` embeds `VERSION`.
+
+### U2. Route, controller, and root metadata
+
+**Goal:** Serve the image and emit root OG tags.
+**Files:** `config/routes.rb`, `app/controllers/site_og_images_controller.rb`,
+`app/controllers/documents_controller.rb`,
+`app/views/layouts/application.html.erb`
+**Dependencies:** U1
+**Approach:** Route `get "og.png" => "site_og_images#show", as: :site_og_image`
+next to the document OG route. Controller mirrors
+`DocumentOgImagesController` minus the document lookup / `last_modified`.
+`DocumentsController#index` sets `@open_graph` (title "Thinkroom",
+page_title "Thinkroom", description "Where deeper thinking compounds.",
+url `root_url`, image `site_og_image_url(v: SiteOgImage::VERSION)`, alt text,
+`type: "website"`). Layout renders `@open_graph[:type] || "article"`.
+**Test scenarios:** covered by U3.
+
+### U3. Integration tests
+
+**Goal:** Lock in endpoint semantics and root metadata.
+**Files:** `test/integration/site_og_image_test.rb`,
+`test/integration/site_open_graph_test.rb`
+**Dependencies:** U1, U2
+**Test scenarios:**
+- `/og.png` responds 200 `image/png`, PNG magic bytes, `inline` disposition,
+  `public` cache-control, ETag present, no `Set-Cookie` (stubbed renderer,
+  mirroring `test/integration/document_og_image_test.rb`).
+- Second request with `If-None-Match` → 304 with empty body.
+- Root page (browser UA): `og:type` is `website`, `og:title` "Thinkroom",
+  `og:description`/meta description are the tagline, `og:image` path is
+  `/og.png` with a `v=` query, twitter card tags present, canonical link is
+  the root URL, `<title>` still exactly "Thinkroom".
+- A document page still emits `og:type=article` (regression guard for the
+  layout change; may live in `test/integration/document_open_graph_test.rb`).
+
+## Verification
+
+- New service + integration tests pass; full `bin/rails test` stays green
+  (including `branding_test.rb` and `document_open_graph_test.rb`).
+- `bin/rubocop` clean; `npm run check` clean (no TS changes expected).
+- Visual inspection of the generated `/og.png` in a browser via `bin/dev`.

--- a/test/integration/document_open_graph_test.rb
+++ b/test/integration/document_open_graph_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class DocumentOpenGraphTest < ActionDispatch::IntegrationTest
+  include OpenGraphHelpers
+
   setup do
     @document = Document.create!(
       title: "Stored title",
@@ -51,22 +53,5 @@ class DocumentOpenGraphTest < ActionDispatch::IntegrationTest
     second_url = property(Nokogiri::HTML5(response.body), "og:image")
 
     refute_equal first_url, second_url
-  end
-
-  private
-
-  def browser
-    {
-      "User-Agent" => "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36",
-      "Accept" => "text/html"
-    }
-  end
-
-  def property(page, name)
-    page.at_css(%(meta[property="#{name}"]))&.[]("content")
-  end
-
-  def named(page, name)
-    page.at_css(%(meta[name="#{name}"]))&.[]("content")
   end
 end

--- a/test/integration/site_og_image_test.rb
+++ b/test/integration/site_og_image_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class SiteOgImageIntegrationTest < ActionDispatch::IntegrationTest
+  PNG_BYTES = "\x89PNG\r\n\x1A\nstub".b
+
+  test "serves a public inline PNG without minting a cookie" do
+    with_stubbed_image do
+      get site_og_image_path, headers: { "User-Agent" => "Twitterbot/1.0" }
+    end
+
+    assert_response :success
+    assert_equal "image/png", response.media_type
+    assert response.body.b.start_with?("\x89PNG\r\n\x1A\n".b)
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Cache-Control"], "public"
+    assert response.headers["ETag"].present?
+    assert response.headers["Set-Cookie"].blank?
+    assert_not SiteOgImagesController.allow_forgery_protection
+  end
+
+  test "honors the image ETag" do
+    with_stubbed_image do
+      get site_og_image_path
+      etag = response.headers.fetch("ETag")
+
+      get site_og_image_path, headers: { "If-None-Match" => etag }
+    end
+
+    assert_response :not_modified
+    assert_empty response.body
+  end
+
+  private
+
+  def with_stubbed_image
+    original = SiteOgImage.method(:call)
+    SiteOgImage.define_singleton_method(:call) { PNG_BYTES }
+    yield
+  ensure
+    SiteOgImage.define_singleton_method(:call, original)
+  end
+end

--- a/test/integration/site_open_graph_test.rb
+++ b/test/integration/site_open_graph_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class SiteOpenGraphTest < ActionDispatch::IntegrationTest
+  test "the landing page exposes site-level Open Graph and Twitter metadata" do
+    host! "thinkroom.kieranklaassen.com"
+    https!
+    get root_path, headers: browser
+
+    assert_response :success
+    page = Nokogiri::HTML5(response.body)
+    image_url = property(page, "og:image")
+
+    assert_equal "website", property(page, "og:type")
+    assert_equal "Thinkroom", property(page, "og:site_name")
+    assert_equal "Thinkroom", property(page, "og:title")
+    assert_includes property(page, "og:description"), "Where deeper thinking compounds."
+    assert_equal property(page, "og:description"), named(page, "description")
+    assert_equal "https://thinkroom.kieranklaassen.com/", property(page, "og:url")
+    assert_equal "1200", property(page, "og:image:width")
+    assert_equal "630", property(page, "og:image:height")
+    assert_equal "summary_large_image", named(page, "twitter:card")
+    assert_equal property(page, "og:title"), named(page, "twitter:title")
+    assert_equal image_url, named(page, "twitter:image")
+    assert_equal URI(image_url).path, site_og_image_path
+    assert_equal "v=#{SiteOgImage::VERSION}", URI(image_url).query
+    assert_includes property(page, "og:image:alt"), "Thinkroom"
+    assert_equal "Thinkroom", page.at_css("title").text
+    assert_equal property(page, "og:url"), page.at_css('link[rel="canonical"]')["href"]
+  end
+
+  test "document pages keep the article og:type" do
+    document = Document.create!(title: "Doc", seed_content: "# Doc\n\nBody")
+    get document_page_path(document.slug), headers: browser
+
+    assert_response :success
+    assert_equal "article", property(Nokogiri::HTML5(response.body), "og:type")
+  end
+
+  private
+
+  def browser
+    {
+      "User-Agent" => "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36",
+      "Accept" => "text/html"
+    }
+  end
+
+  def property(page, name)
+    page.at_css(%(meta[property="#{name}"]))&.[]("content")
+  end
+
+  def named(page, name)
+    page.at_css(%(meta[name="#{name}"]))&.[]("content")
+  end
+end

--- a/test/integration/site_open_graph_test.rb
+++ b/test/integration/site_open_graph_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class SiteOpenGraphTest < ActionDispatch::IntegrationTest
+  include OpenGraphHelpers
+
   test "the landing page exposes site-level Open Graph and Twitter metadata" do
     host! "thinkroom.kieranklaassen.com"
     https!
@@ -22,34 +24,9 @@ class SiteOpenGraphTest < ActionDispatch::IntegrationTest
     assert_equal property(page, "og:title"), named(page, "twitter:title")
     assert_equal image_url, named(page, "twitter:image")
     assert_equal URI(image_url).path, site_og_image_path
-    assert_equal "v=#{SiteOgImage::VERSION}", URI(image_url).query
+    assert_equal "v=#{SiteOgImage.url_version}", URI(image_url).query
     assert_includes property(page, "og:image:alt"), "Thinkroom"
     assert_equal "Thinkroom", page.at_css("title").text
     assert_equal property(page, "og:url"), page.at_css('link[rel="canonical"]')["href"]
-  end
-
-  test "document pages keep the article og:type" do
-    document = Document.create!(title: "Doc", seed_content: "# Doc\n\nBody")
-    get document_page_path(document.slug), headers: browser
-
-    assert_response :success
-    assert_equal "article", property(Nokogiri::HTML5(response.body), "og:type")
-  end
-
-  private
-
-  def browser
-    {
-      "User-Agent" => "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36",
-      "Accept" => "text/html"
-    }
-  end
-
-  def property(page, name)
-    page.at_css(%(meta[property="#{name}"]))&.[]("content")
-  end
-
-  def named(page, name)
-    page.at_css(%(meta[name="#{name}"]))&.[]("content")
   end
 end

--- a/test/services/site_og_image_test.rb
+++ b/test/services/site_og_image_test.rb
@@ -34,14 +34,17 @@ class SiteOgImageServiceTest < ActiveSupport::TestCase
     refute_includes svg, "\#{"
   end
 
+  test "cache identity and URL version track both renderer versions" do
+    assert_includes SiteOgImage.cache_key, SiteOgImage.url_version
+    assert_includes SiteOgImage.url_version, SiteOgImage::VERSION
+    assert_includes SiteOgImage.url_version, DocumentOgImage::VERSION
+  end
+
   test "tagline lines fit the shared title measure" do
+    assert_equal SiteOgImage::TAGLINE, SiteOgImage::TITLE_LINES.join(" ")
     SiteOgImage::TITLE_LINES.each do |line|
       assert_operator DocumentOgImage.send(:visual_width, line),
                       :<=, DocumentOgImage::TITLE_LINE_WIDTH
     end
-  end
-
-  test "cache identity embeds the renderer version" do
-    assert_includes SiteOgImage.cache_key, SiteOgImage::VERSION
   end
 end

--- a/test/services/site_og_image_test.rb
+++ b/test/services/site_og_image_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require "open3"
+
+class SiteOgImageServiceTest < ActiveSupport::TestCase
+  test "renders a social-compatible PNG at the declared dimensions" do
+    script = <<~'RUBY'
+      png = SiteOgImage.call
+      image = Vips::Image.new_from_buffer(png, "")
+      puts JSON.generate(
+        png: png.start_with?("\x89PNG\r\n\x1A\n".b),
+        width: image.width,
+        height: image.height
+      )
+    RUBY
+
+    stdout, stderr, status = Open3.capture3(
+      { "RAILS_ENV" => "test" }, Rails.root.join("bin/rails").to_s, "runner", script
+    )
+    assert status.success?, stderr
+    result = JSON.parse(stdout)
+
+    assert result["png"]
+    assert_equal SiteOgImage::WIDTH, result["width"]
+    assert_equal SiteOgImage::HEIGHT, result["height"]
+  end
+
+  test "renders the wordmark, tagline, and byline" do
+    svg = SiteOgImage.send(:svg)
+
+    assert_includes svg, ">Thinkroom<"
+    assert_includes svg, ">Where deeper thinking</tspan>"
+    assert_includes svg, ">compounds.</tspan>"
+    assert_includes svg, "From the creator of Compound Engineering."
+    refute_includes svg, "\#{"
+  end
+
+  test "tagline lines fit the shared title measure" do
+    SiteOgImage::TITLE_LINES.each do |line|
+      assert_operator DocumentOgImage.send(:visual_width, line),
+                      :<=, DocumentOgImage::TITLE_LINE_WIDTH
+    end
+  end
+
+  test "cache identity embeds the renderer version" do
+    assert_includes SiteOgImage.cache_key, SiteOgImage::VERSION
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require_relative "../config/environment"
 require "rails/test_help"
 require "inertia_rails/minitest"
 require_relative "test_helpers/session_cookie_assertions"
+require_relative "test_helpers/open_graph_helpers"
 
 module ActiveSupport
   class TestCase

--- a/test/test_helpers/open_graph_helpers.rb
+++ b/test/test_helpers/open_graph_helpers.rb
@@ -1,0 +1,20 @@
+# Shared helpers for integration tests that inspect Open Graph / Twitter
+# metadata: a real-browser request header set and Nokogiri meta-tag lookups.
+module OpenGraphHelpers
+  private
+
+  def browser
+    {
+      "User-Agent" => "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36",
+      "Accept" => "text/html"
+    }
+  end
+
+  def property(page, name)
+    page.at_css(%(meta[property="#{name}"]))&.[]("content")
+  end
+
+  def named(page, name)
+    page.at_css(%(meta[name="#{name}"]))&.[]("content")
+  end
+end

--- a/vendor/fonts/README.md
+++ b/vendor/fonts/README.md
@@ -1,7 +1,7 @@
 # Vendored fonts
 
-These TrueType files are used **only** server-side, when `DocumentOgImage`
-rasterizes the document social-preview SVG through `ruby-vips`/librsvg. librsvg
+These TrueType files are used **only** server-side, when `DocumentOgImage` and
+`SiteOgImage` rasterize the social-preview SVGs through `ruby-vips`/librsvg. librsvg
 resolves fonts through fontconfig, so `config/initializers/og_image_fonts.rb`
 registers this directory with fontconfig at boot (via a generated
 `FONTCONFIG_FILE`). They are not part of the Vite frontend bundle.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sharing the Thinkroom landing page (`/`) now unfurls with a branded preview card and complete Open Graph / Twitter metadata. Previously the root page shipped no OG tags at all (the layout only emits them when `@open_graph` is set, and only document pages set it).

![Landing page OG card](https://cursor.com/artifacts/c/art-97b25764-6f22-4095-b163-bdcc0b398df3)

<a href="https://cursor.com/agents/bc-6bc4d421-25d9-4ab3-aad6-9fe073e3c474/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_og_image_and_meta_tags_demo.mp4"><img src="https://cursor.com/artifacts/c/art-08899efb-d18b-4964-82f7-0598ab0f117e" alt="landing_page_og_image_and_meta_tags_demo.mp4" /></a>

## Changes

- **`SiteOgImage`** — new static renderer in the same editorial design family as `DocumentOgImage` (SVG → libvips PNG, vendored `Newsreader`/`Instrument Sans` fonts). Title is the tagline "Where deeper thinking compounds.", footer carries the byline. Geometry/palette constants are shared with `DocumentOgImage`; its cache/URL version chains `DocumentOgImage::VERSION` so shared-template bumps invalidate the site card too (`?v=1-4`).
- **`GET /og.png`** — new `SiteOgImagesController` mirroring the document OG endpoint: public inline PNG, `Cache-Control: public, max-age=86400, stale-while-revalidate=3600`, ETag/304, no Inertia XSRF cookie.
- **Root metadata** — `DocumentsController#index` sets `@open_graph` (site copy sourced from `SiteOgImage` constants so meta tags can't drift from the card); the layout's `og:type` now reads `@open_graph[:type] || "article"` so `/` declares `website` while document pages stay `article`. The `<title>` on `/` remains exactly "Thinkroom".
- **Shared code hoists** — `WORDMARK_TEXT_X` and `TITLE_FIRST_BASELINE_OFFSET` hoisted into `DocumentOgImage` (behavior-preserving; document card PNG verified unchanged); duplicated OG test helpers extracted into `test/test_helpers/open_graph_helpers.rb`.

Note: `og:description` is tagline + byline (slightly richer than the plan's tagline-only wording) — both strings come from `SiteOgImage` constants.

Plan: `docs/plans/2026-07-03-001-feat-main-page-og-image-plan.md`

## Testing

- ✅ `bin/rails test` — 590 runs, 0 failures (includes new `SiteOgImage` service tests and `/og.png` + root-metadata integration tests)
- ✅ `bin/rubocop` — no offenses
- ✅ `npm run check` — clean
- ✅ Live verification via `bin/dev`: `/og.png` 200 with correct headers, 304 on `If-None-Match`, full meta tag set on `/` (see video)
- ✅ Code review (correctness, security, testing, maintainability, project-standards personas + validators): 4 findings, all applied in the `fix(review)` commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bc4d421-25d9-4ab3-aad6-9fe073e3c474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bc4d421-25d9-4ab3-aad6-9fe073e3c474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

