### PR TITLE
fix(native): keep same-origin page links inside the iOS shell webview

### DIFF
--- a/app/frontend/editor/milkdown_editor.tsx
+++ b/app/frontend/editor/milkdown_editor.tsx
@@ -162,6 +162,16 @@ interface ActiveSketch {
 
 const SNAPSHOT_DEBOUNCE_MS = 900
 const OPENABLE_LINK_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+// Signed Active Storage paths (blob redirect/proxy and the disk service).
+// These URLs authenticate through their own signature, not the session, so
+// they load fine in an external browser context.
+const FILE_PATH_PREFIX = '/rails/active_storage/'
+
+// Server-rendered on first paint when the request came from the Ruby Native
+// iOS/Android shell (see app/views/layouts/application.html.erb).
+function inNativeShell(): boolean {
+  return document.documentElement.hasAttribute('data-native-app')
+}
 
 function openEditorLink(view: EditorView, event: Event): boolean {
   if (!(event instanceof MouseEvent) || event.button !== 0 || event.defaultPrevented) {
@@ -187,6 +197,21 @@ function openEditorLink(view: EditorView, event: Event): boolean {
   if (!OPENABLE_LINK_PROTOCOLS.has(url.protocol)) return false
 
   event.preventDefault()
+  // Inside the Ruby Native shell, window.open leaves the WKWebView for an
+  // external browser context that carries none of the app's cookies — a
+  // same-origin page link would land the signed-in user on a logged-out
+  // session. Navigate the webview itself instead: the session carries and
+  // the target page renders its own native chrome (including back).
+  // Signed file URLs are deliberately excluded — they work externally via
+  // their signature, while an in-place raw-file page would strand the user
+  // with no back affordance in the shell's Normal Mode.
+  const sameOriginPage =
+    url.origin === window.location.origin && !url.pathname.startsWith(FILE_PATH_PREFIX)
+  if (inNativeShell() && sameOriginPage) {
+    if (typeof window.RubyNative?.visit === 'function') window.RubyNative.visit(url.href)
+    else window.location.assign(url.href)
+    return true
+  }
   window.open(url.href, '_blank', 'noopener,noreferrer')
   return true
 }

--- a/docs/ruby-native-shell-link-handling-request.md
+++ b/docs/ruby-native-shell-link-handling-request.md
@@ -1,0 +1,87 @@
+# Ruby Native shell request: session-aware link handling in Normal Mode
+
+Ready-to-file issue for [`ruby-native/gem`](https://github.com/ruby-native/gem) (Joe Masilotti).
+Copy everything below the rule into a new GitHub issue.
+
+Origin: Thinkroom feedback ts `1783097011` — on iOS, tapping a PDF link inside a
+document punted to an external browser with no session and hit a login wall
+(the reporter's PDF lived behind Cora's auth). Thinkroom's app-side mitigation
+landed alongside this document (same-origin page links now navigate the
+webview), but the cross-origin and file-viewer parts need shell support.
+
+---
+
+**Title:** Normal Mode: new-window links open in a cookie-less browser context, causing login walls — need session-aware link routing
+
+## Setup
+
+- App: Thinkroom (Rails 8 + Inertia/React, `ruby_native` 0.10.11 + `@ruby-native/react` 0.10.11)
+- Mode: Normal Mode, no tabs, iOS shell
+- Our documents contain arbitrary user links. The web editor opens them with
+  `window.open(url, '_blank', 'noopener,noreferrer')`.
+
+## What our users hit
+
+A signed-in user taps a link to a PDF inside the app. The tap leaves the
+WKWebView and lands in an external browser context that has **none of their
+cookies**, so instead of the file they get a login wall:
+
+- Links back into our own app land on a **logged-out session** (the WKWebView's
+  cookies don't travel).
+- Links to third-party services the user is signed into **in real Safari**
+  (the reported case: a PDF attachment behind another product's auth) also hit
+  a login wall, which strongly suggests the context is an isolated
+  `SFSafariViewController` / fresh data store rather than the Safari app —
+  since iOS 11, `SFSafariViewController` shares no cookies with Safari.
+
+We've shipped a JS-side mitigation for the first case (our editor now routes
+same-origin *page* links through `window.location.assign` when
+`html[data-native-app]` is present). The rest needs the shell.
+
+## What we need
+
+1. **Document current behavior.** What does the shell's `WKUIDelegate` do with
+   new-window navigations (`window.open` / `target="_blank"`) today —
+   `SFSafariViewController`, `UIApplication.shared.open`, or something else?
+   The docs cover OAuth (`auth.oauth_paths`) and push-notification `url`
+   handling, but not in-page link taps.
+
+2. **Same-origin new-window requests should stay in the app.** Load them in
+   the current webview (or push a second webview) sharing the same
+   `WKWebsiteDataStore`, so the app session carries. Our JS mitigation only
+   covers links that flow through our own click handler; any other
+   `target="_blank"` same-origin link still punts out of the app.
+
+3. **Cross-origin `http(s)` links should open where the user's sessions live —
+   the real Safari app** (`UIApplication.shared.open`), not an isolated
+   in-app browser context. That is the only way "the session carries" for
+   third-party auth-protected links (email attachments, dashboards, etc.).
+   If you want to keep `SFSafariViewController` for UX, please make it
+   configurable, e.g.:
+
+   ```yaml
+   # config/ruby_native.yml
+   links:
+     external: safari_app   # or: safari_view_controller (current behavior?)
+   ```
+
+4. **Nice-to-have: an in-app file viewer.** When a navigation response is a
+   file (PDF and friends), download it with the webview's cookie store and
+   present QuickLook/PDFKit with the share sheet. In Normal Mode we cannot
+   just navigate the webview to a raw file URL ourselves: a raw-file page
+   renders no DOM, so none of the gem's back affordances
+   (`native_back_button_tag`, navbar signals) exist and the user is stranded.
+   A native viewer is the ideal end state for "tap a PDF in a document,
+   read it, come back".
+
+## Repro sketch
+
+1. Rails app with `ruby_native` 0.10.11, Normal Mode; sign in inside the iOS app.
+2. Render a page with `<a href="https://<any-site-you-are-signed-into-in-safari>/some.pdf" target="_blank">PDF</a>`
+   (or `window.open` on tap).
+3. Tap it: the file opens in a browser context with no cookies → login wall,
+   despite an active session in Safari itself. Same story for
+   same-origin links: the app session doesn't carry.
+
+Happy to test builds — this is the main friction point for our document-heavy
+app, where users constantly tap attachment links.

--- a/docs/ruby-native-shell-link-handling-request.md
+++ b/docs/ruby-native-shell-link-handling-request.md
@@ -1,7 +1,7 @@
 # Ruby Native shell request: session-aware link handling in Normal Mode
 
-Ready-to-file issue for [`ruby-native/gem`](https://github.com/ruby-native/gem) (Joe Masilotti).
-Copy everything below the rule into a new GitHub issue.
+Filed as [ruby-native/gem#75](https://github.com/ruby-native/gem/issues/75)
+(Joe Masilotti's repo). The text below the rule is the issue body as filed.
 
 Origin: Thinkroom feedback ts `1783097011` — on iOS, tapping a PDF link inside a
 document punted to an external browser with no session and hit a login wall

--- a/script/native_shell_check.mjs
+++ b/script/native_shell_check.mjs
@@ -8,6 +8,7 @@
 //   BASE_URL=http://localhost:3000 SLUG=demo node script/native_shell_check.mjs
 //
 import { chromium } from 'playwright'
+import { waitForLive } from './lib/check_helpers.mjs'
 
 const BASE = process.env.BASE_URL ?? 'http://localhost:3000'
 const SLUG = process.env.SLUG ?? 'demo'
@@ -304,6 +305,55 @@ try {
   )
   ok('home: second throwaway cleaned up via swipe delete')
 
+  // Editor link routing inside the shell: same-origin page links must
+  // navigate the webview itself (the external browser context has none of
+  // the app's cookies — a signed-in user would land on a logged-out
+  // session), while cross-origin links and signed Active Storage file URLs
+  // keep opening in a new browsing context (files self-authenticate via
+  // their signature; external pages need the user's own browser sessions).
+  const linkDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'native-shell-check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Native link routing check',
+        content:
+          '# Native link routing\n\n' +
+          `[Same-origin page](${BASE}/d/${SLUG})\n\n` +
+          '[External page](https://example.com/native-link-check)\n\n' +
+          `[Stored file](${BASE}/rails/active_storage/blobs/redirect/native-check/file.pdf)\n`,
+      }),
+    })
+  ).json()
+  await page.goto(`${BASE}/d/${linkDoc.slug}`, { waitUntil: 'networkidle' })
+  await waitForLive(page)
+
+  await page.locator('.milkdown .ProseMirror a', { hasText: 'Same-origin page' }).click()
+  await page.waitForURL(`${BASE}/d/${SLUG}`, { timeout: 10000 })
+  ok('doc: same-origin page link navigates the webview (session carries)')
+
+  await page.goto(`${BASE}/d/${linkDoc.slug}`, { waitUntil: 'networkidle' })
+  await waitForLive(page)
+  const externalPopup = native.waitForEvent('page', { timeout: 10000 })
+  await page.locator('.milkdown .ProseMirror a', { hasText: 'External page' }).click()
+  const externalPage = await externalPopup
+  check(
+    externalPage.url().startsWith('https://example.com/native-link-check') &&
+      new URL(page.url()).pathname === `/d/${linkDoc.slug}`,
+    'doc: cross-origin link still opens in a new browsing context',
+  )
+  await externalPage.close()
+
+  const filePopup = native.waitForEvent('page', { timeout: 10000 })
+  await page.locator('.milkdown .ProseMirror a', { hasText: 'Stored file' }).click()
+  const filePage = await filePopup
+  check(
+    new URL(filePage.url()).pathname.startsWith('/rails/active_storage/') &&
+      new URL(page.url()).pathname === `/d/${linkDoc.slug}`,
+    'doc: signed file URL still opens in a new browsing context (self-authenticating)',
+  )
+  await filePage.close()
+
   await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
   await mounted(page)
   check(
@@ -384,6 +434,20 @@ try {
     return rect.width <= 1 && rect.height <= 1
   })
   check(bridgeFootprint, 'web doc: bridge strip occupies no visible space')
+
+  // Web link routing is unchanged: same-origin page links keep opening in a
+  // new tab outside the native shell.
+  await webPage.goto(`${BASE}/d/${linkDoc.slug}`, { waitUntil: 'networkidle' })
+  await waitForLive(webPage)
+  const webPopup = web.waitForEvent('page', { timeout: 10000 })
+  await webPage.locator('.milkdown .ProseMirror a', { hasText: 'Same-origin page' }).click()
+  const webPopupPage = await webPopup
+  check(
+    new URL(webPopupPage.url()).pathname === `/d/${SLUG}` &&
+      new URL(webPage.url()).pathname === `/d/${linkDoc.slug}`,
+    'web doc: same-origin page link still opens a new tab',
+  )
+  await webPopupPage.close()
   await web.close()
 } finally {
   await browser.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Feedback ts `1783097011`: on iOS, tapping a PDF link inside a document punts to an external browser and hits a login wall.

**Trace.** Every link tap in the editor goes through `openEditorLink` (`app/frontend/editor/milkdown_editor.tsx`), which unconditionally calls `window.open(url, '_blank', 'noopener,noreferrer')`. Inside the Ruby Native shell, that new-window request leaves the WKWebView for an external browser context that carries **none of the app's cookies** — and since iOS 11, `SFSafariViewController` also shares nothing with real Safari. So:

- same-origin links land the signed-in user on a **logged-out session**, and
- cross-origin links behind third-party auth (the reported PDF lived behind Cora's login) hit that product's login wall even when the user is signed in to it in Safari.

## What this PR fixes (app side)

In the native shell (`html[data-native-app]`, server-rendered on first paint), **same-origin page links now navigate the webview itself** — via `window.RubyNative.visit()` when the bridge is present, `window.location.assign` otherwise. The session carries and the target page renders its own native chrome, including back.

Deliberately unchanged:
- **Signed Active Storage file URLs** (`/rails/active_storage/…`) keep opening externally — they self-authenticate via their signature (verified sessionless in `test/integration/agent_upload_test.rb`), and navigating the webview to a raw file page would strand the user with no back affordance in Normal Mode.
- **Cross-origin links** keep opening externally — carrying a third-party session is shell territory (below).
- **Web behavior** is untouched (links still open a new tab), asserted in the check.

## Shell-side asks — filed as [ruby-native/gem#75](https://github.com/ruby-native/gem/issues/75)

The cross-origin session carry and a real in-app file viewer can't be fixed from JS, so the request is now filed in Joe Masilotti's repo (mirrored at `docs/ruby-native-shell-link-handling-request.md`):

1. Document what the shell's `WKUIDelegate` does with `window.open`/`target="_blank"` today.
2. Same-origin new-window requests should stay in-app (same `WKWebsiteDataStore`), covering links that don't flow through our click handler.
3. Cross-origin `http(s)` links should open in the **real Safari app** (`UIApplication.shared.open`) where the user's own sessions live — or make the choice configurable in `ruby_native.yml`.
4. Nice-to-have: QuickLook/PDFKit viewer for file responses downloaded with the webview's cookie store.

## Demo

Simulated shell (native UA): tapping a same-origin document link navigates the same window — no external browser, session intact:

<a href="https://cursor.com/agents/bc-8575d355-89dc-4048-8f2e-e59ca686d7db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_shell_same_origin_link_stays_in_app.mp4"><img src="https://cursor.com/artifacts/c/art-2062f6ef-abb9-4d84-a1c8-e5a6c6478da4" alt="native_shell_same_origin_link_stays_in_app.mp4" /></a>

## Testing

- `script/native_shell_check.mjs` extended with four link-routing assertions (same-origin navigates the webview; cross-origin and signed file URLs still open a new context; web same-origin still opens a new tab) — full check green against `bin/dev`, native and web contexts.
- `script/link_check.mjs` (web link contract) still green.
- `npm run check` (tsc + CLI tests), `bin/rubocop`, `bin/rails test` (590 runs) all green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8575d355-89dc-4048-8f2e-e59ca686d7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8575d355-89dc-4048-8f2e-e59ca686d7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

