### PR TITLE
feat(comments): connect rail comment cards to their anchored text

### DIFF
--- a/app/frontend/components/comments_panel.tsx
+++ b/app/frontend/components/comments_panel.tsx
@@ -6,19 +6,25 @@ import type { CommentPayload } from '../types/payloads'
 interface Props {
   comments: CommentPayload[]
   composerAnchor: string | null
+  /** Ids of open comments whose anchor text resolves in the document; null
+   *  while unmeasured (editor not mounted yet) — no linked/stale states then. */
+  anchoredIds: Set<number> | null
   onSubmit: (body: string, anchorText: string | null) => void
   onCancelComposer: () => void
   onResolve: (comment: CommentPayload) => void
-  onJumpTo: (anchorText: string) => void
+  onJumpTo: (comment: CommentPayload) => void
+  onHover?: (comment: CommentPayload | null) => void
 }
 
 export function CommentsPanel({
   comments,
   composerAnchor,
+  anchoredIds,
   onSubmit,
   onCancelComposer,
   onResolve,
   onJumpTo,
+  onHover,
 }: Props) {
   const [body, setBody] = useState('')
   const [showResolved, setShowResolved] = useState(false)
@@ -79,39 +85,64 @@ export function CommentsPanel({
       )}
 
       <ul className="comment-list">
-        {open.map((comment) => (
-          <li key={comment.id} className="comment-card">
-            <div className="comment-meta">
-              <span className={`author-chip author-chip--${comment.author_kind}`}>
-                {comment.author_name}
-              </span>
-              {/* timeAgo depends on Date.now(); a bucket flip between SSR and
+        {open.map((comment) => {
+          // Three anchor states once measured: linked (text found — the whole
+          // card jumps to it), stale (quoted text edited away), unanchored
+          // (comment was never tied to text). Unmeasured renders plain.
+          const linked = anchoredIds !== null && anchoredIds.has(comment.id)
+          const stale =
+            anchoredIds !== null && Boolean(comment.anchor_text) && !linked
+          return (
+            <li
+              key={comment.id}
+              className={`comment-card ${linked ? 'comment-card--linked' : ''}`}
+              onClick={linked ? () => onJumpTo(comment) : undefined}
+              onMouseEnter={linked && onHover ? () => onHover(comment) : undefined}
+              onMouseLeave={linked && onHover ? () => onHover(null) : undefined}
+              title={linked ? 'Show in document' : undefined}
+            >
+              <div className="comment-meta">
+                <span className={`author-chip author-chip--${comment.author_kind}`}>
+                  {comment.author_name}
+                </span>
+                {/* timeAgo depends on Date.now(); a bucket flip between SSR and
                  hydration would otherwise regenerate the whole tree. */}
-              <span className="comment-time" suppressHydrationWarning>
-                {timeAgo(comment.created_at)}
-              </span>
-            </div>
-            {comment.anchor_text && (
-              <blockquote
-                className="comment-quote comment-quote--link"
-                onClick={() => onJumpTo(comment.anchor_text!)}
-                title="Jump to text"
-              >
-                {truncate(comment.anchor_text, 90)}
-              </blockquote>
-            )}
-            <p className="comment-body">{comment.body}</p>
-            {/* Optimistic placeholders (negative id) have no server row yet —
+                <span className="comment-time" suppressHydrationWarning>
+                  {timeAgo(comment.created_at)}
+                </span>
+              </div>
+              {comment.anchor_text ? (
+                <blockquote className={`comment-quote ${stale ? 'comment-quote--stale' : ''}`}>
+                  {truncate(comment.anchor_text, 90)}
+                </blockquote>
+              ) : (
+                anchoredIds !== null && (
+                  <span className="comment-scope">On the whole document</span>
+                )
+              )}
+              {stale && (
+                <span className="comment-scope">Quoted text is no longer in the document</span>
+              )}
+              <p className="comment-body">{comment.body}</p>
+              {/* Optimistic placeholders (negative id) have no server row yet —
                 a resolve PATCH against them would 404. The button appears
                 when the reload delivers the real id (same gate as the
                 suggestion cards' accept/reject). */}
-            {comment.id > 0 && (
-              <button className="comment-resolve" onClick={() => onResolve(comment)}>
-                Resolve
-              </button>
-            )}
-          </li>
-        ))}
+              {comment.id > 0 && (
+                <button
+                  className="comment-resolve"
+                  onClick={(event) => {
+                    // The linked card's own click would also fire and jump.
+                    event.stopPropagation()
+                    onResolve(comment)
+                  }}
+                >
+                  Resolve
+                </button>
+              )}
+            </li>
+          )
+        })}
       </ul>
 
       {resolved.length > 0 && (

--- a/app/frontend/components/comments_panel.tsx
+++ b/app/frontend/components/comments_panel.tsx
@@ -34,6 +34,12 @@ export function CommentsPanel({
     if (composerAnchor !== null) textareaRef.current?.focus()
   }, [composerAnchor])
 
+  // The panel can unmount under the cursor (mode switch, layout collapse) —
+  // mouseleave never fires then, so the hover spotlight must clear here.
+  useEffect(() => {
+    return () => onHover?.(null)
+  }, [onHover])
+
   const open = comments.filter((c) => !c.resolved)
   const resolved = comments.filter((c) => c.resolved)
 
@@ -88,10 +94,15 @@ export function CommentsPanel({
         {open.map((comment) => {
           // Three anchor states once measured: linked (text found — the whole
           // card jumps to it), stale (quoted text edited away), unanchored
-          // (comment was never tied to text). Unmeasured renders plain.
+          // (comment was never tied to text). Unmeasured renders plain, and
+          // so does an unresolved multi-block anchor — its matcher can miss
+          // text that is still present, and the card must not claim it gone.
           const linked = anchoredIds !== null && anchoredIds.has(comment.id)
           const stale =
-            anchoredIds !== null && Boolean(comment.anchor_text) && !linked
+            anchoredIds !== null &&
+            Boolean(comment.anchor_text) &&
+            !comment.anchor_text!.includes('\n') &&
+            !linked
           return (
             <li
               key={comment.id}

--- a/app/frontend/editor/comment_anchors.ts
+++ b/app/frontend/editor/comment_anchors.ts
@@ -1,0 +1,36 @@
+import type { Node } from '@milkdown/kit/prose/model'
+import { findTextRange } from './suggestions'
+
+/**
+ * Selection-toolbar comments over multiple paragraphs store the anchor as
+ * `textBetween(from, to, '\n')`, which the within-block matcher can never
+ * find. Locate the first and last lines separately and accept the span only
+ * when the text between them reproduces the anchor exactly — a false hit on
+ * a duplicated first line fails that check and resolves to nothing.
+ */
+function findMultiBlockRange(
+  doc: Node,
+  anchor: string,
+): { from: number; to: number } | null {
+  const lines = anchor.split('\n').filter((line) => line.length > 0)
+  if (lines.length < 2) return null
+  const first = findTextRange(doc, lines[0])
+  const last = findTextRange(doc, lines[lines.length - 1])
+  if (!first || !last || last.to <= first.from) return null
+  if (doc.textBetween(first.from, last.to, '\n') !== anchor) return null
+  return { from: first.from, to: last.to }
+}
+
+/**
+ * Where a comment's anchor text lives in the doc: first within-block
+ * occurrence (the historical comment behavior), else the multi-block span
+ * a cross-paragraph selection produced. Used for composer placement, the
+ * draft highlight, and the rail cards' anchor tint/hover/jump.
+ */
+export const findCommentAnchorRange = (
+  doc: Node,
+  anchor: string | null,
+): { from: number; to: number } | null => {
+  if (!anchor) return null
+  return findTextRange(doc, anchor) ?? findMultiBlockRange(doc, anchor)
+}

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -591,6 +591,12 @@ export default function DocumentShow({
     tintAll: effectiveMode === 'comment',
   })
 
+  // ⌘\ hides the rail with CSS while the panel stays mounted, so a card
+  // hovered at that moment never gets its mouseleave — drop the spotlight.
+  useEffect(() => {
+    if (!panelOpen) hoverAnchor(null)
+  }, [panelOpen, hoverAnchor])
+
   // The comment composer lives in the comments panel — on mobile that means
   // opening its sheet when a selection chooses "Comment".
   useEffect(() => {

--- a/app/frontend/pages/documents/show.tsx
+++ b/app/frontend/pages/documents/show.tsx
@@ -48,6 +48,7 @@ import { useSuggestionReview } from './use_suggestion_review'
 import { useDocumentIdentity } from './use_document_identity'
 import { useFollowPresence } from './use_follow_presence'
 import { useComments } from './use_comments'
+import { useCommentAnchors } from './use_comment_anchors'
 import { useFloatingChrome, type TextTarget } from './use_floating_chrome'
 import { NativeDocBridge } from './native_doc_bridge'
 import { StagedDocumentEditor } from './staged_document_editor'
@@ -572,7 +573,6 @@ export default function DocumentShow({
     submitComment,
     submitAnchoredComment,
     resolveComment,
-    jumpToAnchor,
   } = useComments({
     slug: doc.slug,
     identityName: identity.name,
@@ -580,6 +580,15 @@ export default function DocumentShow({
     effectiveMode,
     isMobile,
     docTick,
+  })
+
+  // Rail cards ↔ document text: every open anchor stays tinted in Comment
+  // mode, and hovering/clicking a card highlights/jumps to its text.
+  const { anchoredIds, hoverAnchor, jumpToComment } = useCommentAnchors({
+    comments,
+    handle,
+    docTick,
+    tintAll: effectiveMode === 'comment',
   })
 
   // The comment composer lives in the comments panel — on mobile that means
@@ -819,10 +828,12 @@ export default function DocumentShow({
                 // The desktop composer is the anchored card next to the
                 // selection — the rail keeps the list only.
                 composerAnchor={null}
+                anchoredIds={anchoredIds}
                 onSubmit={submitComment}
                 onCancelComposer={closeComposer}
                 onResolve={resolveComment}
-                onJumpTo={jumpToAnchor}
+                onJumpTo={jumpToComment}
+                onHover={hoverAnchor}
               />
               <ActivityPanel activities={activities} />
             </aside>
@@ -905,11 +916,12 @@ export default function DocumentShow({
             <CommentsPanel
               comments={comments}
               composerAnchor={composerAnchor}
+              anchoredIds={anchoredIds}
               onSubmit={submitComment}
               onCancelComposer={cancelComposer}
               onResolve={resolveComment}
-              onJumpTo={(anchorText) => {
-                jumpToAnchor(anchorText)
+              onJumpTo={(comment) => {
+                jumpToComment(comment)
                 setActiveSheet(null)
               }}
             />

--- a/app/frontend/pages/documents/use_comment_anchors.ts
+++ b/app/frontend/pages/documents/use_comment_anchors.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { editorViewCtx } from '@milkdown/kit/core'
+import type { EditorView } from '@milkdown/kit/prose/view'
+import type { EditorHandle } from '../../editor/milkdown_editor'
+import { findTextRange } from '../../editor/suggestions'
+import { clearHighlight, domRange, setHighlight } from '../../lib/highlights'
+import type { CommentPayload } from '../../types/payloads'
+
+interface Options {
+  comments: CommentPayload[]
+  handle: EditorHandle | null
+  /** Re-resolves anchors on local and remote document changes. */
+  docTick: number
+  /** Comment mode keeps every open anchor tinted in the copy; other modes
+   *  only highlight on hover/jump. */
+  tintAll: boolean
+}
+
+export interface CommentAnchors {
+  /** Ids of open comments whose anchor text currently resolves in the doc.
+   *  Null until the editor has mounted and the first measure ran — the panel
+   *  must not show "text is gone" states it hasn't verified. */
+  anchoredIds: Set<number> | null
+  /** Strong-tint the hovered card's anchor (null clears). */
+  hoverAnchor: (comment: CommentPayload | null) => void
+  /** Scroll the comment's anchor into view and pulse it. */
+  jumpToComment: (comment: CommentPayload) => void
+}
+
+/**
+ * Connects rail comment cards to the text they discuss. Anchors are the
+ * same string-match resolution the composer highlight uses (first
+ * within-block occurrence); ranges are re-resolved per doc version so
+ * highlights track edits around them, mirroring MarginSuggestions'
+ * anchor tinting.
+ */
+export function useCommentAnchors({
+  comments,
+  handle,
+  docTick,
+  tintAll,
+}: Options): CommentAnchors {
+  const rangesRef = useRef(new Map<number, Range>())
+  const [anchoredIds, setAnchoredIds] = useState<Set<number> | null>(null)
+
+  useEffect(() => {
+    if (!handle) return
+
+    let view: EditorView
+    try {
+      view = handle.editor.action((ctx) => ctx.get(editorViewCtx))
+    } catch {
+      return // editor torn down mid-navigation
+    }
+
+    const ranges = new Map<number, Range>()
+    for (const comment of comments) {
+      if (comment.resolved || !comment.anchor_text) continue
+      const range = findTextRange(view.state.doc, comment.anchor_text)
+      const dom = range ? domRange(view, range.from, range.to) : null
+      if (dom) ranges.set(comment.id, dom)
+    }
+    rangesRef.current = ranges
+
+    setHighlight('comment-anchor', tintAll ? [...ranges.values()] : [])
+    setAnchoredIds((prev) => {
+      const next = new Set(ranges.keys())
+      if (prev && prev.size === next.size && [...next].every((id) => prev.has(id))) {
+        return prev
+      }
+      return next
+    })
+    // docTick re-resolves anchors after document changes.
+  }, [comments, handle, tintAll, docTick])
+
+  useEffect(() => {
+    return () => {
+      clearHighlight('comment-anchor')
+      clearHighlight('comment-anchor-hot')
+      clearHighlight('comment-anchor-flash')
+      clearHighlight('comment-anchor-flash-soft')
+    }
+  }, [])
+
+  const hoverAnchor = useCallback((comment: CommentPayload | null) => {
+    const range = comment === null ? null : rangesRef.current.get(comment.id)
+    if (range) setHighlight('comment-anchor-hot', [range])
+    else clearHighlight('comment-anchor-hot')
+  }, [])
+
+  const flashTimers = useRef<ReturnType<typeof setTimeout>[]>([])
+  useEffect(() => {
+    const timers = flashTimers.current
+    return () => timers.forEach(clearTimeout)
+  }, [])
+
+  const jumpToComment = useCallback((comment: CommentPayload) => {
+    const range = rangesRef.current.get(comment.id)
+    if (!range) return
+    // Scroll without touching the ProseMirror selection — a selection
+    // transaction would pop the selection toolbar / click-to-comment
+    // affordance over the jumped-to text.
+    range.startContainer.parentElement?.scrollIntoView({
+      block: 'center',
+      behavior: 'smooth',
+    })
+    // Pulse: strong tint stepping down to resting — highlight pseudo-elements
+    // can't transition, so the fade is two steps (same as the merge pulse).
+    flashTimers.current.forEach(clearTimeout)
+    setHighlight('comment-anchor-flash', [range])
+    flashTimers.current = [
+      setTimeout(() => {
+        clearHighlight('comment-anchor-flash')
+        setHighlight('comment-anchor-flash-soft', [range])
+      }, 400),
+      setTimeout(() => clearHighlight('comment-anchor-flash-soft'), 1000),
+    ]
+  }, [])
+
+  return { anchoredIds, hoverAnchor, jumpToComment }
+}

--- a/app/frontend/pages/documents/use_comment_anchors.ts
+++ b/app/frontend/pages/documents/use_comment_anchors.ts
@@ -41,6 +41,7 @@ export function useCommentAnchors({
   tintAll,
 }: Options): CommentAnchors {
   const rangesRef = useRef(new Map<number, Range>())
+  const hoveredIdRef = useRef<number | null>(null)
   const [anchoredIds, setAnchoredIds] = useState<Set<number> | null>(null)
 
   useEffect(() => {
@@ -63,6 +64,12 @@ export function useCommentAnchors({
     rangesRef.current = ranges
 
     setHighlight('comment-anchor', tintAll ? [...ranges.values()] : [])
+    // Re-derive the hover spotlight from the fresh ranges: edits move the
+    // anchor under a hovered card, and resolving a hovered card unmounts it
+    // without ever firing mouseleave.
+    const hovered = hoveredIdRef.current === null ? null : ranges.get(hoveredIdRef.current)
+    if (hovered) setHighlight('comment-anchor-hot', [hovered])
+    else clearHighlight('comment-anchor-hot')
     setAnchoredIds((prev) => {
       const next = new Set(ranges.keys())
       if (prev && prev.size === next.size && [...next].every((id) => prev.has(id))) {
@@ -83,11 +90,14 @@ export function useCommentAnchors({
   }, [])
 
   const hoverAnchor = useCallback((comment: CommentPayload | null) => {
+    hoveredIdRef.current = comment === null ? null : comment.id
     const range = comment === null ? null : rangesRef.current.get(comment.id)
     if (range) setHighlight('comment-anchor-hot', [range])
     else clearHighlight('comment-anchor-hot')
   }, [])
 
+  // Mutated in place (never reassigned) so the unmount cleanup's captured
+  // reference always sees the live timers.
   const flashTimers = useRef<ReturnType<typeof setTimeout>[]>([])
   useEffect(() => {
     const timers = flashTimers.current
@@ -107,14 +117,15 @@ export function useCommentAnchors({
     // Pulse: strong tint stepping down to resting — highlight pseudo-elements
     // can't transition, so the fade is two steps (same as the merge pulse).
     flashTimers.current.forEach(clearTimeout)
+    flashTimers.current.length = 0
     setHighlight('comment-anchor-flash', [range])
-    flashTimers.current = [
+    flashTimers.current.push(
       setTimeout(() => {
         clearHighlight('comment-anchor-flash')
         setHighlight('comment-anchor-flash-soft', [range])
       }, 400),
       setTimeout(() => clearHighlight('comment-anchor-flash-soft'), 1000),
-    ]
+    )
   }, [])
 
   return { anchoredIds, hoverAnchor, jumpToComment }

--- a/app/frontend/pages/documents/use_comment_anchors.ts
+++ b/app/frontend/pages/documents/use_comment_anchors.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { editorViewCtx } from '@milkdown/kit/core'
 import type { EditorView } from '@milkdown/kit/prose/view'
+import { findCommentAnchorRange } from '../../editor/comment_anchors'
 import type { EditorHandle } from '../../editor/milkdown_editor'
-import { findTextRange } from '../../editor/suggestions'
 import { clearHighlight, domRange, setHighlight } from '../../lib/highlights'
 import type { CommentPayload } from '../../types/payloads'
 
@@ -28,11 +28,11 @@ export interface CommentAnchors {
 }
 
 /**
- * Connects rail comment cards to the text they discuss. Anchors are the
- * same string-match resolution the composer highlight uses (first
- * within-block occurrence); ranges are re-resolved per doc version so
- * highlights track edits around them, mirroring MarginSuggestions'
- * anchor tinting.
+ * Connects rail comment cards to the text they discuss. Anchors resolve
+ * through the same matcher as the composer highlight (first within-block
+ * occurrence, plus a multi-block span fallback for cross-paragraph
+ * selections); ranges are re-resolved per doc version so highlights track
+ * edits around them, mirroring MarginSuggestions' anchor tinting.
  */
 export function useCommentAnchors({
   comments,
@@ -44,7 +44,9 @@ export function useCommentAnchors({
   const hoveredIdRef = useRef<number | null>(null)
   const [anchoredIds, setAnchoredIds] = useState<Set<number> | null>(null)
 
-  useEffect(() => {
+  // Layout effect: an optimistic post must measure before paint, or its
+  // card renders one frame in the unlinked state and flickers to linked.
+  useLayoutEffect(() => {
     if (!handle) return
 
     let view: EditorView
@@ -57,7 +59,7 @@ export function useCommentAnchors({
     const ranges = new Map<number, Range>()
     for (const comment of comments) {
       if (comment.resolved || !comment.anchor_text) continue
-      const range = findTextRange(view.state.doc, comment.anchor_text)
+      const range = findCommentAnchorRange(view.state.doc, comment.anchor_text)
       const dom = range ? domRange(view, range.from, range.to) : null
       if (dom) ranges.set(comment.id, dom)
     }
@@ -109,8 +111,13 @@ export function useCommentAnchors({
     if (!range) return
     // Scroll without touching the ProseMirror selection — a selection
     // transaction would pop the selection toolbar / click-to-comment
-    // affordance over the jumped-to text.
-    range.startContainer.parentElement?.scrollIntoView({
+    // affordance over the jumped-to text. For an anchor starting at a block
+    // boundary, domAtPos returns the block element itself (not its text
+    // node) — its parentElement would be the editor root and "center" would
+    // scroll to the middle of the whole document.
+    const start = range.startContainer
+    const startEl = start instanceof Element ? start : start.parentElement
+    startEl?.scrollIntoView({
       block: 'center',
       behavior: 'smooth',
     })

--- a/app/frontend/pages/documents/use_comments.ts
+++ b/app/frontend/pages/documents/use_comments.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react'
 import { router } from '@inertiajs/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
-import { findTextRange } from '../../editor/suggestions'
+import { findCommentAnchorRange } from '../../editor/comment_anchors'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import type { CommentPayload } from '../../types/payloads'
 
@@ -53,7 +53,7 @@ export function useComments({
     if (!composerOpen || composerAnchor === null) return
     const view = viewRef.current
     if (!view) return
-    const range = findTextRange(view.state.doc, composerAnchor)
+    const range = findCommentAnchorRange(view.state.doc, composerAnchor)
     const dom = range ? domRange(view, range.from, range.to) : null
     setHighlight('comment-anchor-draft', dom ? [dom] : [])
     return () => clearHighlight('comment-anchor-draft')

--- a/app/frontend/pages/documents/use_comments.ts
+++ b/app/frontend/pages/documents/use_comments.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react'
 import { router } from '@inertiajs/react'
 import type { EditorView } from '@milkdown/kit/prose/view'
-import { TextSelection } from '@milkdown/kit/prose/state'
 import { findTextRange } from '../../editor/suggestions'
 import { domRange, setHighlight, clearHighlight } from '../../lib/highlights'
 import type { CommentPayload } from '../../types/payloads'
@@ -30,7 +29,6 @@ export interface Comments {
   submitComment: (body: string, anchorText: string | null) => void
   submitAnchoredComment: (body: string) => void
   resolveComment: (comment: CommentPayload) => void
-  jumpToAnchor: (anchorText: string) => void
 }
 
 /** Comment submission/resolution and the anchored composer lifecycle. */
@@ -57,8 +55,8 @@ export function useComments({
     if (!view) return
     const range = findTextRange(view.state.doc, composerAnchor)
     const dom = range ? domRange(view, range.from, range.to) : null
-    setHighlight('comment-anchor', dom ? [dom] : [])
-    return () => clearHighlight('comment-anchor')
+    setHighlight('comment-anchor-draft', dom ? [dom] : [])
+    return () => clearHighlight('comment-anchor-draft')
     // docTick keeps the highlight tracking edits around the anchor.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [composerOpen, composerAnchor, docTick])
@@ -129,22 +127,6 @@ export function useComments({
     [submitComment, composerAnchor, viewRef],
   )
 
-  const jumpToAnchor = useCallback(
-    (anchorText: string) => {
-      const view = viewRef.current
-      if (!view) return
-      const range = findTextRange(view.state.doc, anchorText)
-      if (!range) return
-      const tr = view.state.tr.setSelection(
-        TextSelection.create(view.state.doc, range.from, range.to),
-      )
-      tr.scrollIntoView()
-      view.dispatch(tr)
-      view.focus()
-    },
-    [viewRef],
-  )
-
   return {
     composerAnchor,
     composerOpen,
@@ -154,6 +136,5 @@ export function useComments({
     submitComment,
     submitAnchoredComment,
     resolveComment,
-    jumpToAnchor,
   }
 }

--- a/app/frontend/pages/documents/use_floating_chrome.ts
+++ b/app/frontend/pages/documents/use_floating_chrome.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type RefObject } from 'react'
 import type { EditorView } from '@milkdown/kit/prose/view'
+import { findCommentAnchorRange } from '../../editor/comment_anchors'
 import { aiSpanAt, type AiSpan, type ProvenanceSpan } from '../../editor/provenance'
-import { findTextRange } from '../../editor/suggestions'
 import {
   useAnchoredPopover,
   type AnchoredPosition,
@@ -174,7 +174,7 @@ export function useFloatingChrome({
     getRange: () => {
       const view = viewRef.current
       if (!view || composerAnchor === null) return null
-      return findTextRange(view.state.doc, composerAnchor)
+      return findCommentAnchorRange(view.state.doc, composerAnchor)
     },
     preferBelow: true,
     persistent: true,

--- a/app/frontend/styles/comments.css
+++ b/app/frontend/styles/comments.css
@@ -20,6 +20,18 @@
   opacity: 0.6;
 }
 
+/* Cards whose anchor text resolves in the copy: the whole card jumps to it,
+ * with hover tinting the anchor (mirrors the margin suggestion cards). */
+.comment-card--linked {
+  cursor: pointer;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.comment-card--linked:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 10px rgb(0 0 0 / 0.06);
+}
+
 .comment-meta {
   display: flex;
   align-items: center;
@@ -41,14 +53,18 @@
   line-height: 1.4;
 }
 
-.comment-quote--link {
-  cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease;
+/* The quoted text was edited out of the document — the quote stays for
+ * context but no longer navigates anywhere. */
+.comment-quote--stale {
+  color: var(--ink-faint);
+  border-left-color: var(--line);
 }
 
-.comment-quote--link:hover {
-  border-color: var(--accent);
-  color: var(--ink);
+/* Anchor-state caption: "On the whole document" / "no longer in the document". */
+.comment-scope {
+  font-size: 0.68rem;
+  color: var(--ink-faint);
+  font-style: italic;
 }
 
 .comment-body {
@@ -141,11 +157,51 @@
   margin: 0;
 }
 
+/* Comment anchors in the copy, via the CSS Custom Highlight API — the
+ * accent (terracotta on proof, blue on whitey) keeps comment anchors
+ * distinct from the purple suggestion/provenance tints. */
+
 /* The anchored text stays tinted while its composer is open. */
+::highlight(comment-anchor-draft) {
+  background-color: rgb(182 92 61 / 0.2);
+}
+
+/* Every open comment's anchor, tinted while in Comment mode. */
 ::highlight(comment-anchor) {
-  background-color: rgb(157 78 221 / 0.18);
+  background-color: rgb(182 92 61 / 0.12);
+}
+
+/* Hovering a linked rail card spotlights its anchor. */
+::highlight(comment-anchor-hot) {
+  background-color: rgb(182 92 61 / 0.3);
+}
+
+/* Jump pulse: strong tint stepping down to resting (two steps — highlight
+ * pseudo-elements can't transition). */
+::highlight(comment-anchor-flash) {
+  background-color: rgb(182 92 61 / 0.38);
+}
+
+::highlight(comment-anchor-flash-soft) {
+  background-color: rgb(182 92 61 / 0.16);
+}
+
+[data-theme='whitey'] ::highlight(comment-anchor-draft) {
+  background-color: rgb(65 131 196 / 0.2);
 }
 
 [data-theme='whitey'] ::highlight(comment-anchor) {
-  background-color: rgb(65 131 196 / 0.18);
+  background-color: rgb(65 131 196 / 0.12);
+}
+
+[data-theme='whitey'] ::highlight(comment-anchor-hot) {
+  background-color: rgb(65 131 196 / 0.3);
+}
+
+[data-theme='whitey'] ::highlight(comment-anchor-flash) {
+  background-color: rgb(65 131 196 / 0.38);
+}
+
+[data-theme='whitey'] ::highlight(comment-anchor-flash-soft) {
+  background-color: rgb(65 131 196 / 0.16);
 }

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -1979,6 +1979,94 @@ try {
   await winA.close()
   await winB.close()
 
+  // --- Comment anchors: block-boundary jump on a long document ---
+  // A whole-paragraph anchor (what click-to-comment produces) resolves to a
+  // range starting at a block boundary; the jump must scroll to that block,
+  // not the middle of the document.
+  const jumpAnchorPara = 'Anchor paragraph for the jump check.'
+  const jumpFiller = Array.from(
+    { length: 40 },
+    (_, i) => `Filler paragraph ${i + 1} keeps the anchor far above the fold.`,
+  )
+  const jumpDoc = await (
+    await fetch(`${BASE}/api/docs`, {
+      method: 'POST',
+      headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Comment jump check',
+        content: `# Comment jump check\n\n${jumpAnchorPara}\n\n${jumpFiller.join('\n\n')}`,
+      }),
+    })
+  ).json()
+  await fetch(`${BASE}/api/docs/${jumpDoc.slug}/comments`, {
+    method: 'POST',
+    headers: { 'X-Agent-Name': 'check', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: 'Jump target comment.', anchor_text: jumpAnchorPara }),
+  })
+  const jumpWin = await makePage('a')
+  await jumpWin.goto(`${BASE}/d/${jumpDoc.slug}/comment`)
+  await waitForLive(jumpWin)
+  const jumpCard = jumpWin.locator('.comment-card--linked', { hasText: 'Jump target comment.' })
+  await jumpCard.waitFor({ timeout: 10000 })
+  await jumpWin.mouse.move(400, 400)
+  await jumpWin.mouse.wheel(0, 100000)
+  // Agent pseudo-cursor widgets ("✦ check") inject their labels into
+  // paragraph textContent — strip them before matching, as elsewhere.
+  await jumpWin.waitForFunction(
+    (text) => {
+      const para = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) => {
+        const clone = el.cloneNode(true)
+        clone.querySelectorAll('.ProseMirror-yjs-cursor, .agent-cursor').forEach((n) => n.remove())
+        return clone.textContent === text
+      })
+      return Boolean(para) && para.getBoundingClientRect().bottom < 0
+    },
+    jumpAnchorPara,
+    { timeout: 5000 },
+  )
+  await jumpCard.locator('.comment-body').click()
+  const jumpLanded = await jumpWin
+    .waitForFunction(
+      (text) => {
+        const para = Array.from(document.querySelectorAll('.milkdown .ProseMirror p')).find((el) => {
+          const clone = el.cloneNode(true)
+          clone.querySelectorAll('.ProseMirror-yjs-cursor, .agent-cursor').forEach((n) => n.remove())
+          return clone.textContent === text
+        })
+        if (!para) return false
+        const rect = para.getBoundingClientRect()
+        return rect.top >= 0 && rect.bottom <= window.innerHeight
+      },
+      jumpAnchorPara,
+      { timeout: 5000 },
+    )
+    .then(() => true)
+    .catch(() => false)
+  if (jumpLanded) ok('card click scrolled a block-boundary anchor into view on a long document')
+  else fail('card click did not bring the anchor paragraph into view')
+
+  // Multi-paragraph selection comments resolve through the multi-block span
+  // fallback: the card links and jumps instead of reading as stale.
+  const jumpParaBox = (text) =>
+    jumpWin.locator('.milkdown .ProseMirror p', { hasText: text }).first().boundingBox()
+  const spanStart = await jumpParaBox('Filler paragraph 3 keeps')
+  const spanEnd = await jumpParaBox('Filler paragraph 4 keeps')
+  await jumpWin.mouse.move(spanStart.x + 2, spanStart.y + spanStart.height / 2)
+  await jumpWin.mouse.down()
+  await jumpWin.mouse.move(spanEnd.x + spanEnd.width * 0.6, spanEnd.y + spanEnd.height / 2, {
+    steps: 8,
+  })
+  await jumpWin.mouse.up()
+  await jumpWin.locator('.selection-toolbar button', { hasText: 'Comment' }).click()
+  const spanComment = `Cross-paragraph comment ${Date.now()}`
+  await jumpWin.getByPlaceholder('Say something about this…').fill(spanComment)
+  await jumpWin.locator('.comment-composer--anchored .btn-accept').click()
+  await jumpWin
+    .locator('.comment-card--linked', { hasText: spanComment })
+    .waitFor({ timeout: 10000 })
+  ok('multi-paragraph selection comment resolved and linked (not mislabeled stale)')
+  await jumpWin.close()
+
   // --- Demo doc: localStorage tampering cannot unlock suggest mode ---
   const demoPage = await browser.newPage()
   await demoPage.goto(`${BASE}/d/${SLUG}`)

--- a/script/browser_check.mjs
+++ b/script/browser_check.mjs
@@ -1922,6 +1922,60 @@ try {
   await winA.locator('.comment-card', { hasText: clickComment }).waitFor({ timeout: 10000 })
   ok('click-to-comment posted and synced to the other window')
 
+  // --- Comment anchors: rail cards visibly connect to their text ---
+  // The card just posted anchors the first paragraph; Comment mode keeps
+  // every open anchor tinted in the copy.
+  const anchorTintOk = await winB
+    .waitForFunction(() => CSS.highlights?.has('comment-anchor'), undefined, { timeout: 5000 })
+    .then(() => true)
+    .catch(() => false)
+  if (anchorTintOk) ok('comment mode tints open comment anchors in the copy')
+  else fail('comment mode did not register the comment-anchor highlight')
+
+  const linkedCard = winB.locator('.comment-card--linked', { hasText: clickComment })
+  await linkedCard.waitFor({ timeout: 5000 })
+  ok('anchored rail card is linked (whole card clickable)')
+  await linkedCard.locator('.comment-body').click()
+  const flashOk = await winB
+    .waitForFunction(
+      () =>
+        CSS.highlights?.has('comment-anchor-flash') ||
+        CSS.highlights?.has('comment-anchor-flash-soft'),
+      undefined,
+      { timeout: 2000 },
+    )
+    .then(() => true)
+    .catch(() => false)
+  if (flashOk) ok('clicking the card pulsed its anchor in the document')
+  else fail('card click did not pulse the comment anchor')
+
+  // Anchor-status captions: an unanchored comment reads as whole-document,
+  // and an anchor quoting text absent from the doc reads as stale.
+  const trackApi = `${BASE}/api/docs/${trackDoc.slug}`
+  await fetch(`${trackApi}/comments`, {
+    method: 'POST',
+    headers: agentHeaders,
+    body: JSON.stringify({ body: 'General note without an anchor.' }),
+  })
+  await fetch(`${trackApi}/comments`, {
+    method: 'POST',
+    headers: agentHeaders,
+    body: JSON.stringify({
+      body: 'Note anchored to vanished text.',
+      anchor_text: 'This exact sentence never existed in the track document.',
+    }),
+  })
+  await winB
+    .locator('.comment-card', { hasText: 'General note without an anchor.' })
+    .locator('.comment-scope', { hasText: 'On the whole document' })
+    .waitFor({ timeout: 10000 })
+  ok('unanchored comment card reads as on the whole document')
+  await winB
+    .locator('.comment-card', { hasText: 'Note anchored to vanished text.' })
+    .locator('.comment-scope', { hasText: 'no longer in the document' })
+    .waitFor({ timeout: 10000 })
+  ok('stale-anchor comment card flags its missing text')
+
   await winA.close()
   await winB.close()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Riffrec feedback on Comment mode ([recording bundle](https://thinkroom.kieranklaassen.com/d/r3UnjYQCKX/comment)): "It's very hard to see where these comments apply. I want to see a line or I want to see it close to where it is. … When I click on here I want to probably see where it is connected to, or maybe these are not connected to anywhere — but probably you should have a comment on text."

Today the rail comment list has no visual link to the document: commented text carries no tint, only the small quote block inside a card is clickable (the recording shows repeated dead clicks on card bodies), and there is no way to tell an unanchored comment from a badly-linked one.

## What

- **Comment mode tints every open comment's anchor** in the copy via the CSS Custom Highlight API — the same pattern `MarginSuggestions` uses for suggestion anchors. Comment anchors wear the accent hue (terracotta on proof, blue on whitey) so they read distinctly from purple suggestion/provenance tints.
- **Hovering a linked card spotlights its anchor**; **clicking anywhere on the card** scrolls the anchor into view (smooth, centered) and pulses it. The jump doesn't dispatch a ProseMirror selection, so it can't pop the selection toolbar / click-to-comment affordance over the jumped-to text.
- **Cards state their anchor status** once the editor has measured: linked (clickable), "Quoted text is no longer in the document" (stale anchor), or "On the whole document" (never anchored). Unmeasured renders plain — no false "text is gone" flashes.
- New `useCommentAnchors` hook owns range resolution (re-resolved per `docTick` so highlights track local and remote edits), hover, and jump; the old quote-only `jumpToAnchor` in `useComments` is retired. The composer highlight is renamed `comment-anchor-draft`.
- **Cross-paragraph selection anchors now resolve** through a shared `findCommentAnchorRange` (`app/frontend/editor/comment_anchors.ts`): first within-block occurrence as before, plus an exactly-validated multi-block span fallback for anchors stored as `textBetween(from, to, '\n')`. The rail tint/hover/jump, the composer draft highlight, and the composer placement all use it. Unresolved multiline anchors degrade to a plain quote rather than claiming the text is gone.

### Review-pass fixes (reproduced before fixing)

- Jump scroll targeted the editor root for whole-paragraph anchors (`domAtPos` at a block boundary returns the block element, whose `parentElement` is the ProseMirror root) — clicking a click-to-comment card on a long document centered the middle of the document instead of the anchor. Now scrolls the boundary element itself.
- Hover spotlight stuck permanently when the panel unmounted or hid under the cursor (mode switch, ⌘\ rail hide, desktop→mobile flip) — cleared on panel unmount and on rail hide.
- Anchors measure in a layout effect so an optimistic post can't flash one unlinked frame.

## Testing

- `npm run check` (tsc + eslint + cli tests), `bin/rubocop`, `bin/rails test` (590 runs) — all green.
- `script/browser_check.mjs` extended and fully green: anchor tint registered in Comment mode, whole-card link, click pulse, "On the whole document" and stale captions, block-boundary jump landing on a 40-paragraph document, and a drag-selected multi-paragraph comment resolving as linked.
- Manual GUI verification in Comment mode (Chrome), including the review-pass fixes re-verified end-to-end.

![Comment mode showing anchor tints and card states](https://cursor.com/artifacts/c/art-c868f410-9d4b-431f-8e75-409edfa8fa6f)

![Hovering a multi-paragraph comment card spotlights both anchored paragraphs](https://cursor.com/artifacts/c/art-4e595be1-df53-45fe-9ce1-284b098fc3ce)

<a href="https://cursor.com/agents/bc-f5547dc7-8f45-4c94-8658-031122f6ce0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomment_anchor_hover_jump_pulse_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-bda344fd-a15d-4577-b626-89ac7b5e2066" alt="comment_anchor_hover_jump_pulse_walkthrough.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5547dc7-8f45-4c94-8658-031122f6ce0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5547dc7-8f45-4c94-8658-031122f6ce0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

