### PR TITLE
fix(webmcp): mark update_document results as untrusted content

### DIFF
--- a/app/services/agent_guide.rb
+++ b/app/services/agent_guide.rb
@@ -726,7 +726,8 @@ class AgentGuide
           required: %w[agent_name content],
           additionalProperties: false
         },
-        annotations: { read_only_hint: false, untrusted_content_hint: false },
+        # previous_content in the result is other humans' and agents' writing.
+        annotations: { read_only_hint: false, untrusted_content_hint: true },
         kind: "editor",
         action: "replace_content",
         include_viewer_context: true

--- a/test/services/agent_guide_webmcp_test.rb
+++ b/test/services/agent_guide_webmcp_test.rb
@@ -6,7 +6,7 @@ class AgentGuideWebmcpTest < ActiveSupport::TestCase
   UNTRUSTED_TOOLS = %w[
     thinkroom_read_document thinkroom_poll_events thinkroom_resolve_comment
     thinkroom_comment thinkroom_propose_suggestion thinkroom_create_document
-    thinkroom_announce_presence
+    thinkroom_announce_presence thinkroom_update_document
   ].freeze
   TRUSTED_TOOLS = %w[thinkroom_guide thinkroom_ack_events].freeze
   READ_ONLY_TOOL_SET = %w[
@@ -108,7 +108,7 @@ class AgentGuideWebmcpTest < ActiveSupport::TestCase
     assert_equal Document::MAX_CONTENT_BYTES, content[:maxLength]
     assert_includes content[:description], "Markdown"
     assert_includes content[:description], "UTF-8"
-    assert_equal({ read_only_hint: false, untrusted_content_hint: false }, tool[:annotations])
+    assert_equal({ read_only_hint: false, untrusted_content_hint: true }, tool[:annotations])
     assert_equal true, tool[:include_viewer_context]
     assert_includes tool[:description], "Markdown"
     assert_includes tool[:description], "previous_content"
@@ -325,8 +325,11 @@ class AgentGuideWebmcpTest < ActiveSupport::TestCase
 
   private
 
+  # The editor tool only exists on the writable manifest, so fall back to it.
   def find_tool(name)
-    @tools.find { |tool| tool[:name] == name } || flunk("no tool named #{name}")
+    @tools.find { |tool| tool[:name] == name } ||
+      AgentGuide.webmcp_tools(@document, BASE_URL, can_write: true)[:tools].find { |tool| tool[:name] == name } ||
+      flunk("no tool named #{name}")
   end
 
   def collect_strings(value, acc = [])


### PR DESCRIPTION
## Summary

`thinkroom_update_document` returns `previous_content` — the prior document source, which is other humans' and agents' writing — so its manifest entry now sets `untrusted_content_hint: true`, matching every other tool whose result echoes document text. Without it an agent could treat injected page text inside `previous_content` as trusted tool output.

Follow-up to #202 (Bugbot finding on `f773bab`).

## Test plan

- `bin/rails test test/services/agent_guide_webmcp_test.rb test/integration/webmcp_props_test.rb` — the threat-model assertion now covers the editor tool via the writable manifest.
- `bin/rubocop` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest metadata and test-only helper changes; no runtime write or auth behavior changes.
> 
> **Overview**
> **`thinkroom_update_document`** now advertises **`untrusted_content_hint: true`** in its WebMCP manifest, because the tool result includes **`previous_content`** (prior document source from humans and other agents). That aligns the in-page editor tool with other tools whose outputs echo document text, so clients should not treat echoed page content as trusted tool output.
> 
> Tests add **`thinkroom_update_document`** to the threat-model **`UNTRUSTED_TOOLS`** list, assert the new annotation on the writable manifest, and extend **`find_tool`** to resolve tools that only appear when **`can_write: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76245975e4d0c1a6c8699685a20ddf09bdcbf7f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->